### PR TITLE
[Do not merge] Check no. of cores available on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ install:
     - export PATH=$GOPATH/bin:$PATH
 
 script:
+    - grep -c ^processor /proc/cpuinfo
     - ./verify/verify-boilerplate.sh
     - ./verify/verify-gofmt.sh
     - ./verify/verify-golint.sh


### PR DESCRIPTION
Ref #49 
Seems like `go build $(go list ./... | grep -v "/vendor/")` is taking too long to execute (> 10m) and hence timing out.
Let's check if we have enough cores available on jenkins for parallel execution.

cc @gmarek @wojtek-t 