### PR TITLE
Add travis wait to 'go build' command for avoiding timeout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,5 +24,5 @@ script:
     - ./verify/verify-golint.sh
     - ./verify/verify-flags-underscore.py
     - go get -d ./...
-    - go build $(go list ./... | grep -v "/vendor/")
+    - travis_wait go build $(go list ./... | grep -v "/vendor/")
     - ./verify/test.sh


### PR DESCRIPTION
Ref #49 #50 

Following instruction here: https://docs.travis-ci.com/user/common-build-problems/#Build-times-out-because-no-output-was-received.
This should make travis print something to stdout once every minute to ensure longer run.

cc @gmarek @wojtek-t 