### PR TITLE
RCs added, resize working, labels exposed

### DIFF
--- a/clusterloader/config/logger.yaml
+++ b/clusterloader/config/logger.yaml
@@ -15,6 +15,6 @@ ClusterLoader:
       pods:
         stepping:
           stepsize: 10
-          pause: 60 
+          pause: 60s
         ratelimit:
-          delay: 100
+          delay: 100ms

--- a/clusterloader/config/rctest.yaml
+++ b/clusterloader/config/rctest.yaml
@@ -1,0 +1,37 @@
+ClusterLoader:
+  delete: true
+  projects:
+    - num: 1
+      basename: clusterproject
+      tuning: default
+      RCs:
+        - num: 5
+          image: gcr.io/google_containers/pause-amd64:3.0
+          basename: pausepods
+          label: purpose=test
+    - num: 2
+      basename: zip
+      tuning: default
+      RCs:
+        - num: 5
+          image: gcr.io/google_containers/pause-amd64:3.0
+          basename: pausepods
+    - num: 2
+      basename: zip
+      tuning: default
+      RCs:
+        - num: 1
+          image: gcr.io/google_containers/pause-amd64:3.0
+          basename: grumble
+          label: app=grumble
+  tuningsets:
+    - name: default
+      pods:
+        stepping:
+          stepsize: 10
+          pause: 30s
+        ratelimit:
+          delay: 100ms
+      project:
+        ratelimit:
+          delay: 10s

--- a/clusterloader/config/test.yaml
+++ b/clusterloader/config/test.yaml
@@ -1,4 +1,3 @@
-provider: local
 ClusterLoader:
   delete: true
   projects:
@@ -15,6 +14,6 @@ ClusterLoader:
       pods:
         stepping:
           stepsize: 10
-          pause: 30 
+          pause: 30s
         ratelimit:
-          delay: 100
+          delay: 100ms

--- a/clusterloader/framework/context.go
+++ b/clusterloader/framework/context.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -18,58 +18,63 @@ package framework
 
 import (
 	"os"
-	"time"
 
 	"github.com/spf13/viper"
 )
 
-// ContextType is the root config struct
-type ContextType struct {
+// Context is the root config struct
+type Context struct {
 	ClusterLoader struct {
-		Projects   []ClusterLoaderType
-		TuningSets []TuningSetType
+		Projects   []ClusterLoader
+		TuningSets []TuningSet
 	}
 }
 
-// ClusterLoaderType struct only used for Cluster Loader test config
-type ClusterLoaderType struct {
+// TuningSets is custom slice type so we can define methods on it
+type TuningSets []TuningSet
+
+// ClusterLoader struct only used for Cluster Loader test config
+type ClusterLoader struct {
 	Number    int `mapstructure:"num"`
 	Basename  string
 	Tuning    string
-	Pods      []ClusterLoaderObjectType
-	Templates []ClusterLoaderObjectType
+	Pods      []ClusterLoaderObject
+	RCs       []ClusterLoaderObject
+	Templates []ClusterLoaderObject
 }
 
-// ClusterLoaderObjectType is nested object type for cluster loader struct
-type ClusterLoaderObjectType struct {
+// ClusterLoaderObject is nested object type for cluster loader struct
+type ClusterLoaderObject struct {
 	Total    int
 	Number   int `mapstructure:"num"`
 	Image    string
 	Basename string
 	File     string
+	Label    string
 }
 
-// TuningSetType is nested type for controlling Cluster Loader deployment pattern
-type TuningSetType struct {
+// TuningSet is nested type for controlling Cluster Loader deployment pattern
+type TuningSet struct {
 	Name      string
-	Pods      TuningSetObjectType
-	Templates TuningSetObjectType
+	Project   TuningSetObject
+	Pods      TuningSetObject
+	Templates TuningSetObject
 }
 
-// TuningSetObjectType is shared struct for Pods & Templates
-type TuningSetObjectType struct {
+// TuningSetObject is shared struct for Pods & Templates
+type TuningSetObject struct {
 	Stepping struct {
 		StepSize int
-		Pause    time.Duration
-		Timeout  time.Duration
+		Pause    string
+		Timeout  string
 	}
 	RateLimit struct {
-		Delay time.Duration
+		Delay string
 	}
 }
 
-// ConfigContext variable of type ContextType
-var ConfigContext ContextType
+// ConfigContext variable of type Context
+var ConfigContext Context
 
 // ParseConfig will complete flag parsing as well as viper tasks
 func ParseConfig(config string) {

--- a/clusterloader/framework/pod_utils.go
+++ b/clusterloader/framework/pod_utils.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	"fmt"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/kubernetes/pkg/api/v1"
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+const maxRetries = 5
+
+// CreatePods creates pods in a user defined namspace with user configurable tuning sets
+func CreatePods(f *framework.Framework, name, namespace string, labels labels.Set, spec v1.PodSpec, maxCount int, tuning *TuningSet) error {
+	for i := 0; i < maxCount; i++ {
+		framework.Logf("%v/%v : Creating pod", i+1, maxCount)
+		podObj := newPod(name, namespace, i, labels, spec)
+		if _, err := createNewPodWithRetries(f, namespace, podObj); err != nil {
+			return err
+		}
+		if tuning == nil {
+			continue
+		}
+		// If a rate limit has been defined we wait for N ms between creation
+		if err := tuning.Pods.Delay(); err != nil {
+			return err
+		}
+		// If a stepping tuningset has been defined in the config, we wait for the step of pods to be created, and pause
+		if tuning.Pods.Stepping.StepSize != 0 && (i+1)%tuning.Pods.Stepping.StepSize == 0 {
+			verifyRunning := f.NewClusterVerification(
+				&v1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: namespace,
+					},
+				},
+				framework.PodStateVerification{
+					Selectors:   labels,
+					ValidPhases: []v1.PodPhase{v1.PodRunning},
+				},
+			)
+
+			duration, err := time.ParseDuration(tuning.Pods.Stepping.Timeout)
+			if err != nil {
+				framework.Logf("Timeout not set: %v", err)
+			}
+			pods, err := verifyRunning.WaitFor(i+1, duration)
+			if err != nil {
+				return err
+			} else if len(pods) < i+1 {
+				return fmt.Errorf("Only got %v out of %v", len(pods), i+1)
+			}
+
+			framework.Logf("We have created %d pods; sleep %v", i+1, duration)
+			if err := tuning.Pods.Pause(); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// createNewPodWithRetries uses polling to retry pod creation
+func createNewPodWithRetries(f *framework.Framework, namespace string, podObj *v1.Pod) (pod *v1.Pod, err error) {
+	for retryCount := 0; retryCount < maxRetries; retryCount++ {
+		pod, err = f.ClientSet.Core().Pods(namespace).Create(podObj)
+		if err == nil {
+			break
+		}
+	}
+	return
+}
+
+// newPod creates a new Pod config object
+func newPod(name, namespace string, num int, labels map[string]string, spec v1.PodSpec) *v1.Pod {
+	return &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf(name+"-pod-%v", num),
+			Namespace: namespace,
+			Labels:    labels,
+		},
+		Spec: spec,
+	}
+}

--- a/clusterloader/framework/rc_utils.go
+++ b/clusterloader/framework/rc_utils.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/kubernetes/pkg/api/v1"
+	"k8s.io/kubernetes/test/e2e/framework"
+	kutils "k8s.io/kubernetes/test/utils"
+)
+
+// CreateRC will create a new RC if it does not exist, or it will update an existing RC with a new replica count if it does exist
+func CreateRC(f *framework.Framework, name, namespace string, label labels.Set, spec v1.PodSpec, replicas int) error {
+	_, err := f.ClientSet.Core().ReplicationControllers(namespace).Get(name, metav1.GetOptions{})
+	// If RC is not found, Get() will return a NotFound error
+	if errors.IsNotFound(err) {
+		newRC := newRC(name, int32(replicas), label, spec)
+		if _, err := createNewRCWithRetries(f, name, namespace, newRC); err != nil {
+			return err
+		}
+	} else {
+		updateReplicas := func(update *v1.ReplicationController) {
+			x := int32(replicas)
+			update.Spec.Replicas = &x
+		}
+		if _, err := framework.UpdateReplicationControllerWithRetries(f.ClientSet, namespace, name, updateReplicas); err != nil {
+			return err
+		}
+	}
+
+	// Wait for pods running matching label using podstore
+	// does not take replica count into effect, nor owner reference
+	return kutils.WaitForPodsWithLabelRunning(f.ClientSet, namespace, labels.SelectorFromSet(label))
+}
+
+// createNewRCWithRetries uses polling to retry RC creation
+func createNewRCWithRetries(f *framework.Framework, name, namespace string, rcObj *v1.ReplicationController) (rc *v1.ReplicationController, err error) {
+	for retryCount := 0; retryCount < maxRetries; retryCount++ {
+		if rc, err = f.ClientSet.Core().ReplicationControllers(namespace).Create(rcObj); err == nil {
+			framework.Logf("Created replication controller %q", name)
+			break
+		}
+	}
+	return
+}
+
+// newRC creates a new ReplicationController config object
+func newRC(rsName string, replicas int32, rcPodLabels map[string]string, spec v1.PodSpec) *v1.ReplicationController {
+	return &v1.ReplicationController{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: rsName,
+		},
+		Spec: v1.ReplicationControllerSpec{
+			Replicas: func(i int32) *int32 { return &i }(replicas),
+			Template: &v1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: rcPodLabels,
+				},
+				Spec: spec,
+			},
+		},
+	}
+}

--- a/clusterloader/framework/tuning_utils.go
+++ b/clusterloader/framework/tuning_utils.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	"time"
+
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+// Delay acts on a TuningSetObject and will sleep for RateLimit.Delay
+func (tuning *TuningSetObject) Delay() error {
+	return sleep(tuning.RateLimit.Delay)
+}
+
+// Pause acts on a TuningSetObject and will sleep for Stepping.Pause
+func (tuning *TuningSetObject) Pause() error {
+	return sleep(tuning.Stepping.Pause)
+}
+
+func sleep(d string) error {
+	if d != "" {
+		duration, err := time.ParseDuration(d)
+		if err != nil {
+			return err
+		}
+		framework.Logf("Waiting for %v", duration)
+		time.Sleep(duration)
+	}
+	return nil
+}
+
+// Get matches the name of the tuning set defined in the project and returns a pointer to the set
+func (ts TuningSets) Get(name string) *TuningSet {
+	if name == "" {
+		return nil
+	}
+	// Iterate through defined tuningSets
+	for _, v := range ts {
+		// If we have a matching tuningSet keep it
+		if v.Name == name {
+			return &v
+		}
+	}
+	framework.Logf("No tuning found for %q", name)
+	return nil
+}


### PR DESCRIPTION
PR to add some of the functionality as per our design discussions a few weeks ago.

First of all, there is now a tuningset to support a delay between creation of each new defined project.
We also support creation of RCs and modification of RCs. To do this we had to be able to recognize existing namespaces, as well as existing RCs, so there's less blind creation going on now. The generic side effect is that we can now define different "projects" with the same name and then have different objects deployed in each.

The RC makes use of the image field which was not utilized for pod definitions. 
Labels have also been exposed to the config so the user can now set their own.