### PR TITLE
Replace dockerization logic for benchmark with a runner script instead

### DIFF
--- a/benchmark/Makefile
+++ b/benchmark/Makefile
@@ -16,11 +16,7 @@ BINARY := build/benchmark
 SOURCES := $(shell find pkg -name '*.go' | grep -v "_test.go")
 TESTS := $(shell find pkg -name '*_test.go')
 
-REGISTRY := gcr.io/k8s-testimages
-IMAGE := $(REGISTRY)/benchmark
-VERSION := 0.1.0
-
-all: image
+all: benchmark
 
 godep:
 	go get -u github.com/tools/godep
@@ -34,10 +30,4 @@ test: godep $(TESTS)
 clean:
 	rm -f $(BINARY)
 
-image: benchmark
-	docker build --pull -t $(IMAGE):$(VERSION) .
-
-push:
-	gcloud docker -- push $(IMAGE):$(VERSION)
-
-.PHONY: all godep benchmark test clean image push
+.PHONY: all godep benchmark test clean

--- a/benchmark/runner.sh
+++ b/benchmark/runner.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 # Copyright 2017 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,12 +13,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.5
-MAINTAINER "Shyam JVS <shyamjvs@google.com>"
+# Runner script for the benchmark tool that works when called from any path.
 
-RUN apk --no-cache add ca-certificates
+set -o errexit
+set -o nounset
+set -o pipefail
 
-ADD ["build/benchmark", "/workspace/"]
-WORKDIR "/workspace"
+BENCHMARK_ARGS=${BENCHMARK_ARGS:-} # Parameters to configure the benchmark tool.
+BENCHMARK_DIR="${GOPATH}/src/k8s.io/perf-tests/benchmark"
 
-ENTRYPOINT ["/workspace/benchmark", "--alsologtostderr"]
+# Compile the tool.
+cd ${BENCHMARK_DIR}
+make benchmark
+cd -
+
+# Run the tool with args passed to this runner.
+${BENCHMARK_DIR}/build/benchmark --alsologtostderr ${BENCHMARK_ARGS}


### PR DESCRIPTION
Seems like docker image for running the tool is not needed. All we need is a runner for dockerized compilation and then running the binary with the right args.
This seems to be the pattern for running simple binaries in CI jobs, where anyway the running of bootstrap.py is dockerized. (Eg: Job ci-cadvisor-node-kubelet (https://github.com/kubernetes/test-infra/blob/master/jobs/config.json#L10) simply calls the runner script in the cadvisor repo (https://github.com/google/cadvisor/blob/master/build/jenkins_e2e.sh))

cc @wojtek-t @gmarek 