### PR TITLE
Benchmark tool prints results in a classified and sorted way

### DIFF
--- a/benchmark/cmd/benchmark.go
+++ b/benchmark/cmd/benchmark.go
@@ -114,6 +114,24 @@ func compare(jobComparisonData *util.JobComparisonData) {
 	}
 }
 
+// Pretty print results of the comparison.
+func printResults(jobComparisonData *util.JobComparisonData) {
+	glog.Infof("Metric-wise results of comparison for 99th percentile:")
+	jobComparisonData.PrettyPrintWithFilter(func(k util.MetricKey, d util.MetricComparisonData) bool {
+		return k.Percentile != "Perc99"
+	})
+	glog.Infof("")
+	glog.Infof("Metric-wise results of comparison for 90th percentile:")
+	jobComparisonData.PrettyPrintWithFilter(func(k util.MetricKey, d util.MetricComparisonData) bool {
+		return k.Percentile != "Perc90"
+	})
+	glog.Infof("")
+	glog.Infof("Metric-wise results of comparison for 50th percentile:")
+	jobComparisonData.PrettyPrintWithFilter(func(k util.MetricKey, d util.MetricComparisonData) bool {
+		return k.Percentile != "Perc50"
+	})
+}
+
 func main() {
 	// Set the tool's flags.
 	registerFlags(pflag.CommandLine)
@@ -124,8 +142,5 @@ func main() {
 	leftJobRuns, rightJobRuns := selectRuns()
 	jobComparisonData := getMetrics(leftJobRuns, rightJobRuns)
 	compare(jobComparisonData)
-
-	// Pretty print results.
-	glog.Infof("Metric-wise results of comparison:")
-	jobComparisonData.PrettyPrint()
+	printResults(jobComparisonData)
 }

--- a/benchmark/pkg/comparer/schemes/avgtest.go
+++ b/benchmark/pkg/comparer/schemes/avgtest.go
@@ -34,15 +34,14 @@ func CompareJobsUsingAvgTest(jobComparisonData *util.JobComparisonData, allowedR
 		leftSampleCount := len(metricData.LeftJobSample)
 		rightSampleCount := len(metricData.RightJobSample)
 		metricData.Matched = false
-		var leftRightAvgRatio float64
 		if leftSampleCount == 0 || rightSampleCount == 0 {
-			leftRightAvgRatio = math.NaN()
+			metricData.AvgRatio = math.NaN()
 		} else {
-			leftRightAvgRatio = metricData.AvgL / metricData.AvgR
-			if allowedRatioLowerBound <= leftRightAvgRatio && leftRightAvgRatio <= 1/allowedRatioLowerBound {
+			metricData.AvgRatio = metricData.AvgL / metricData.AvgR
+			if allowedRatioLowerBound <= metricData.AvgRatio && metricData.AvgRatio <= 1/allowedRatioLowerBound {
 				metricData.Matched = true
 			}
 		}
-		metricData.Comments = fmt.Sprintf("AvgRatio=%.4f\t\tN1=%v\tN2=%v", leftRightAvgRatio, leftSampleCount, rightSampleCount)
+		metricData.Comments = fmt.Sprintf("AvgRatio=%.4f\t\tN1=%v\tN2=%v", metricData.AvgRatio, leftSampleCount, rightSampleCount)
 	}
 }


### PR DESCRIPTION
The results printed by the tool would now be split by latency percentiles (50, 90, 99), and sorted by the avg ratio within each of those individual tables.

cc @wojtek-t 