### PR TITLE
Benchmark marks metrics with too low avg values as matched & prints some more useful info

### DIFF
--- a/benchmark/pkg/comparer/comparer.go
+++ b/benchmark/pkg/comparer/comparer.go
@@ -30,15 +30,15 @@ const (
 )
 
 // CompareJobsUsingScheme is a wrapper function for various comparison schemes.
-func CompareJobsUsingScheme(jobComparisonData *util.JobComparisonData, scheme string, matchThreshold float64) error {
+func CompareJobsUsingScheme(jobComparisonData *util.JobComparisonData, scheme string, matchThreshold, minMetricAvgForCompare float64) error {
 	switch scheme {
 	case AvgTest:
 		// matchThreshold is interpreted as the bound for ratio of left and right sample avgs for this test.
-		schemes.CompareJobsUsingAvgTest(jobComparisonData, matchThreshold)
+		schemes.CompareJobsUsingAvgTest(jobComparisonData, matchThreshold, minMetricAvgForCompare)
 		return nil
 	case KSTest:
 		// matchThreshold is interpreted as the allowed significance value for this test.
-		schemes.CompareJobsUsingKSTest(jobComparisonData, matchThreshold)
+		schemes.CompareJobsUsingKSTest(jobComparisonData, matchThreshold, minMetricAvgForCompare)
 		return nil
 	default:
 		return fmt.Errorf("Unknown comparison scheme '%v'", scheme)

--- a/benchmark/pkg/comparer/schemes/avgtest.go
+++ b/benchmark/pkg/comparer/schemes/avgtest.go
@@ -28,7 +28,7 @@ import (
 // results in the metric's object after checking ratio of the averages
 // of its left and right samples is within the allowed ratio lower bound
 // and upper bound (which is the inverse of lower bound).
-func CompareJobsUsingAvgTest(jobComparisonData *util.JobComparisonData, allowedRatioLowerBound float64) {
+func CompareJobsUsingAvgTest(jobComparisonData *util.JobComparisonData, allowedRatioLowerBound, minMetricAvgForCompare float64) {
 	jobComparisonData.ComputeStatsForMetricSamples()
 	for _, metricData := range jobComparisonData.Data {
 		leftSampleCount := len(metricData.LeftJobSample)
@@ -40,6 +40,9 @@ func CompareJobsUsingAvgTest(jobComparisonData *util.JobComparisonData, allowedR
 		} else {
 			metricData.AvgRatio = metricData.AvgL / metricData.AvgR
 			if allowedRatioLowerBound <= metricData.AvgRatio && metricData.AvgRatio <= 1/allowedRatioLowerBound {
+				metricData.Matched = true
+			}
+			if metricData.AvgL < minMetricAvgForCompare && metricData.AvgR < minMetricAvgForCompare {
 				metricData.Matched = true
 			}
 		}

--- a/benchmark/pkg/comparer/schemes/avgtest.go
+++ b/benchmark/pkg/comparer/schemes/avgtest.go
@@ -36,12 +36,13 @@ func CompareJobsUsingAvgTest(jobComparisonData *util.JobComparisonData, allowedR
 		metricData.Matched = false
 		if leftSampleCount == 0 || rightSampleCount == 0 {
 			metricData.AvgRatio = math.NaN()
+			metricData.Matched = true
 		} else {
 			metricData.AvgRatio = metricData.AvgL / metricData.AvgR
 			if allowedRatioLowerBound <= metricData.AvgRatio && metricData.AvgRatio <= 1/allowedRatioLowerBound {
 				metricData.Matched = true
 			}
 		}
-		metricData.Comments = fmt.Sprintf("AvgRatio=%.4f\t\tN1=%v\tN2=%v", metricData.AvgRatio, leftSampleCount, rightSampleCount)
+		metricData.Comments = fmt.Sprintf("AvgL/R=%.2f\tAvgL(ms)=%.2f\tAvgR(ms)=%.2f\tN1=%v\tN2=%v", metricData.AvgRatio, metricData.AvgL, metricData.AvgR, leftSampleCount, rightSampleCount)
 	}
 }

--- a/benchmark/pkg/comparer/schemes/avgtest_test.go
+++ b/benchmark/pkg/comparer/schemes/avgtest_test.go
@@ -45,23 +45,23 @@ func TestCompareJobsUsingAvgTest(t *testing.T) {
 			metricKey3: {
 				LeftJobSample:  []float64{1.00, 10.00, 100.00},
 				RightJobSample: []float64{},
-				Matched:        true, // Should change to false later.
+				Matched:        false, // Should change to true later.
 			},
 		},
 	}
 
 	CompareJobsUsingAvgTest(jobComparisonData, lowAvgRatioThreshold)
-	if !jobComparisonData.Data[metricKey1].Matched || !jobComparisonData.Data[metricKey2].Matched || jobComparisonData.Data[metricKey3].Matched {
+	if !jobComparisonData.Data[metricKey1].Matched || !jobComparisonData.Data[metricKey2].Matched || !jobComparisonData.Data[metricKey3].Matched {
 		t.Errorf("Wrong comparison result for Avg-based test at an allowed ratio of %v", lowAvgRatioThreshold)
 	}
 
 	CompareJobsUsingAvgTest(jobComparisonData, mediumAvgRatioThreshold)
-	if !jobComparisonData.Data[metricKey1].Matched || jobComparisonData.Data[metricKey2].Matched || jobComparisonData.Data[metricKey3].Matched {
+	if !jobComparisonData.Data[metricKey1].Matched || jobComparisonData.Data[metricKey2].Matched || !jobComparisonData.Data[metricKey3].Matched {
 		t.Errorf("Wrong comparison result for Avg-based test at an allowed ratio of %v", mediumAvgRatioThreshold)
 	}
 
 	CompareJobsUsingAvgTest(jobComparisonData, highAvgRatioThreshold)
-	if jobComparisonData.Data[metricKey1].Matched || jobComparisonData.Data[metricKey2].Matched || jobComparisonData.Data[metricKey3].Matched {
+	if jobComparisonData.Data[metricKey1].Matched || jobComparisonData.Data[metricKey2].Matched || !jobComparisonData.Data[metricKey3].Matched {
 		t.Errorf("Wrong comparison result for Avg-based test at an allowed ratio of %v", highAvgRatioThreshold)
 	}
 }

--- a/benchmark/pkg/comparer/schemes/avgtest_test.go
+++ b/benchmark/pkg/comparer/schemes/avgtest_test.go
@@ -50,18 +50,23 @@ func TestCompareJobsUsingAvgTest(t *testing.T) {
 		},
 	}
 
-	CompareJobsUsingAvgTest(jobComparisonData, lowAvgRatioThreshold)
+	CompareJobsUsingAvgTest(jobComparisonData, lowAvgRatioThreshold, 0)
 	if !jobComparisonData.Data[metricKey1].Matched || !jobComparisonData.Data[metricKey2].Matched || !jobComparisonData.Data[metricKey3].Matched {
 		t.Errorf("Wrong comparison result for Avg-based test at an allowed ratio of %v", lowAvgRatioThreshold)
 	}
 
-	CompareJobsUsingAvgTest(jobComparisonData, mediumAvgRatioThreshold)
+	CompareJobsUsingAvgTest(jobComparisonData, mediumAvgRatioThreshold, 0)
 	if !jobComparisonData.Data[metricKey1].Matched || jobComparisonData.Data[metricKey2].Matched || !jobComparisonData.Data[metricKey3].Matched {
 		t.Errorf("Wrong comparison result for Avg-based test at an allowed ratio of %v", mediumAvgRatioThreshold)
 	}
 
-	CompareJobsUsingAvgTest(jobComparisonData, highAvgRatioThreshold)
+	CompareJobsUsingAvgTest(jobComparisonData, highAvgRatioThreshold, 0)
 	if jobComparisonData.Data[metricKey1].Matched || jobComparisonData.Data[metricKey2].Matched || !jobComparisonData.Data[metricKey3].Matched {
 		t.Errorf("Wrong comparison result for Avg-based test at an allowed ratio of %v", highAvgRatioThreshold)
+	}
+
+	CompareJobsUsingAvgTest(jobComparisonData, highAvgRatioThreshold, 1.5)
+	if !jobComparisonData.Data[metricKey1].Matched || !jobComparisonData.Data[metricKey2].Matched || !jobComparisonData.Data[metricKey3].Matched {
+		t.Errorf("Wrong comparison result for Avg-based test at an allowed ratio of %v with min-metric-avg-for-compare=1.5", highAvgRatioThreshold)
 	}
 }

--- a/benchmark/pkg/comparer/schemes/kstest.go
+++ b/benchmark/pkg/comparer/schemes/kstest.go
@@ -28,7 +28,8 @@ import (
 // CompareJobsUsingKSTest takes a JobComparisonData object, compares left and
 // right job samples of each metric inside it and fills in the comparison
 // results in the metric's object after running a KS test on the two samples.
-func CompareJobsUsingKSTest(jobComparisonData *util.JobComparisonData, significanceLevel float64) {
+func CompareJobsUsingKSTest(jobComparisonData *util.JobComparisonData, significanceLevel, minMetricAvgForCompare float64) {
+	jobComparisonData.ComputeStatsForMetricSamples()
 	for _, metricData := range jobComparisonData.Data {
 		leftSampleCount := len(metricData.LeftJobSample)
 		rightSampleCount := len(metricData.RightJobSample)
@@ -40,6 +41,9 @@ func CompareJobsUsingKSTest(jobComparisonData *util.JobComparisonData, significa
 		} else {
 			pValue = onlinestats.KS(metricData.LeftJobSample, metricData.RightJobSample)
 			if pValue >= significanceLevel {
+				metricData.Matched = true
+			}
+			if metricData.AvgL < minMetricAvgForCompare && metricData.AvgR < minMetricAvgForCompare {
 				metricData.Matched = true
 			}
 		}

--- a/benchmark/pkg/comparer/schemes/kstest.go
+++ b/benchmark/pkg/comparer/schemes/kstest.go
@@ -36,6 +36,7 @@ func CompareJobsUsingKSTest(jobComparisonData *util.JobComparisonData, significa
 		var pValue float64
 		if leftSampleCount == 0 || rightSampleCount == 0 {
 			pValue = math.NaN()
+			metricData.Matched = true
 		} else {
 			pValue = onlinestats.KS(metricData.LeftJobSample, metricData.RightJobSample)
 			if pValue >= significanceLevel {

--- a/benchmark/pkg/comparer/schemes/kstest_test.go
+++ b/benchmark/pkg/comparer/schemes/kstest_test.go
@@ -48,26 +48,26 @@ func TestCompareJobsUsingKSTest(t *testing.T) {
 				// Should never match as one side of the data is missing.
 				LeftJobSample:  []float64{1.00, 10.00, 100.00},
 				RightJobSample: []float64{},
-				Matched:        true, // Should change to false later.
+				Matched:        false, // Should change to true later.
 			},
 		},
 	}
 
 	// Check that both first and second metric match at a very low significance level.
 	CompareJobsUsingKSTest(jobComparisonData, lowSignificanceLevel)
-	if !jobComparisonData.Data[metricKey1].Matched || !jobComparisonData.Data[metricKey2].Matched || jobComparisonData.Data[metricKey3].Matched {
+	if !jobComparisonData.Data[metricKey1].Matched || !jobComparisonData.Data[metricKey2].Matched || !jobComparisonData.Data[metricKey3].Matched {
 		t.Errorf("Wrong comparison result for KS test at a significance level of %v", lowSignificanceLevel)
 	}
 
 	// Check that the second metric mismatches at a high significance level, while the first still matches.
 	CompareJobsUsingKSTest(jobComparisonData, highSignificanceLevel)
-	if !jobComparisonData.Data[metricKey1].Matched || jobComparisonData.Data[metricKey2].Matched || jobComparisonData.Data[metricKey3].Matched {
+	if !jobComparisonData.Data[metricKey1].Matched || jobComparisonData.Data[metricKey2].Matched || !jobComparisonData.Data[metricKey3].Matched {
 		t.Errorf("Wrong comparison result for KS test at a significance level of %v", highSignificanceLevel)
 	}
 
 	// Checking validity of the statistical test, it should fail always if significance level is > 1.0 (as p-value is always <= 1.0).
 	CompareJobsUsingKSTest(jobComparisonData, extremeSignificanceLevel)
-	if jobComparisonData.Data[metricKey1].Matched || jobComparisonData.Data[metricKey2].Matched || jobComparisonData.Data[metricKey3].Matched {
+	if jobComparisonData.Data[metricKey1].Matched || jobComparisonData.Data[metricKey2].Matched || !jobComparisonData.Data[metricKey3].Matched {
 		t.Errorf("Wrong comparison result for KS test at a significance level of %v", extremeSignificanceLevel)
 	}
 }

--- a/benchmark/pkg/comparer/schemes/kstest_test.go
+++ b/benchmark/pkg/comparer/schemes/kstest_test.go
@@ -54,20 +54,26 @@ func TestCompareJobsUsingKSTest(t *testing.T) {
 	}
 
 	// Check that both first and second metric match at a very low significance level.
-	CompareJobsUsingKSTest(jobComparisonData, lowSignificanceLevel)
+	CompareJobsUsingKSTest(jobComparisonData, lowSignificanceLevel, 0)
 	if !jobComparisonData.Data[metricKey1].Matched || !jobComparisonData.Data[metricKey2].Matched || !jobComparisonData.Data[metricKey3].Matched {
 		t.Errorf("Wrong comparison result for KS test at a significance level of %v", lowSignificanceLevel)
 	}
 
 	// Check that the second metric mismatches at a high significance level, while the first still matches.
-	CompareJobsUsingKSTest(jobComparisonData, highSignificanceLevel)
+	CompareJobsUsingKSTest(jobComparisonData, highSignificanceLevel, 0)
 	if !jobComparisonData.Data[metricKey1].Matched || jobComparisonData.Data[metricKey2].Matched || !jobComparisonData.Data[metricKey3].Matched {
 		t.Errorf("Wrong comparison result for KS test at a significance level of %v", highSignificanceLevel)
 	}
 
 	// Checking validity of the statistical test, it should fail always if significance level is > 1.0 (as p-value is always <= 1.0).
-	CompareJobsUsingKSTest(jobComparisonData, extremeSignificanceLevel)
+	CompareJobsUsingKSTest(jobComparisonData, extremeSignificanceLevel, 0)
 	if jobComparisonData.Data[metricKey1].Matched || jobComparisonData.Data[metricKey2].Matched || !jobComparisonData.Data[metricKey3].Matched {
 		t.Errorf("Wrong comparison result for KS test at a significance level of %v", extremeSignificanceLevel)
+	}
+
+	// Checking validity of the test, it should fail as significance level is > 1.0, but it passes due to high enough value of min-metric-avg-for-compare.
+	CompareJobsUsingKSTest(jobComparisonData, extremeSignificanceLevel, 1.5)
+	if !jobComparisonData.Data[metricKey1].Matched || !jobComparisonData.Data[metricKey2].Matched || !jobComparisonData.Data[metricKey3].Matched {
+		t.Errorf("Wrong comparison result for KS test at a significance level of %v with min-metric-avg-for-compare=1.5", extremeSignificanceLevel)
 	}
 }

--- a/benchmark/pkg/util/util.go
+++ b/benchmark/pkg/util/util.go
@@ -109,13 +109,13 @@ func (j *JobComparisonData) PrettyPrintWithFilter(filter MetricFilterFunc) {
 	metricsList := getMetricsSortedByAvgRatio(j)
 	var buf bytes.Buffer
 	w := tabwriter.NewWriter(&buf, 0, 0, 2, ' ', 0)
-	fmt.Fprintf(w, "E2E TEST\tVERB\tRESOURCE\tSUBRESOURCE\tPERCENTILE\tMATCHED?\tCOMMENTS\n")
+	fmt.Fprintf(w, "E2E TEST\tVERB\tRESOURCE\tSUBRESOURCE\tPERCENTILE\tCOMMENTS\n")
 	for _, metricPair := range metricsList {
 		key, data := metricPair.metricKey, metricPair.metricData
 		if filter(key, *data) {
 			continue
 		}
-		fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\t%v\t%v\n", key.TestName, key.Verb, key.Resource, key.Subresource, key.Percentile, data.Matched, data.Comments)
+		fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\t%v\n", key.TestName, key.Verb, key.Resource, key.Subresource, key.Percentile, data.Comments)
 	}
 	w.Flush()
 	glog.Infof("\n%v", buf.String())

--- a/verify/verify-flags/known-flags.txt
+++ b/verify/verify-flags/known-flags.txt
@@ -7,6 +7,7 @@ listen-url
 log-source-mode
 match-threshold
 min-allowed-api-request-count
+min-metric-avg-for-compare
 n-hours-count
 n-runs-count
 purge-after-seconds


### PR DESCRIPTION
And also NaN avg ratios are marked as matched.

/cc @gmarek