### PR TITLE
Create slo-monitor:0.9.3 based on alpine:3.6

### DIFF
--- a/slo-monitor/Dockerfile
+++ b/slo-monitor/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.5
+FROM alpine:3.6
 MAINTAINER Marek Grabowski <gmarek@google.com>
 ADD build/slo-monitor slo-monitor
 

--- a/slo-monitor/Makefile
+++ b/slo-monitor/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 PACKAGE = k8s.io/perf-tests/slo-monitor
-TAG = 0.9.2
+TAG = 0.9.3
 REPOSITORY = google-containers
 
 all: build
@@ -25,7 +25,7 @@ build: src/monitors/pod_monitor.go src/monitors/util.go src/monitors/store.go sr
 	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 godep go build -a -o build/slo-monitor src/main/slo-monitor.go
 
 push:
-	sudo docker build . -t gcr.io/$(REPOSITORY)/slo-monitor:$(TAG)
+	sudo docker build --pull . -t gcr.io/$(REPOSITORY)/slo-monitor:$(TAG)
 	gcloud docker -- push gcr.io/$(REPOSITORY)/slo-monitor:$(TAG)
 
 test: src


### PR DESCRIPTION
I believe this fixes CVE-2016-9841 and CVE-2016-9843 present in the existing slo-monitor images (0.9.1 and 0.9.2).

Images have not yet been pushed anywhere.

@gmarek 