### PR TITLE
Increase benchmark metric consideration threshold to 50ms

### DIFF
--- a/benchmark/cmd/benchmark.go
+++ b/benchmark/cmd/benchmark.go
@@ -52,7 +52,7 @@ func registerFlags(fs *pflag.FlagSet) {
 	fs.IntVar(&minAllowedAPIRequestCount, "min-allowed-api-request-count", 10, "The minimum requests count for an API call (within a particular test of a particular run) to be included for comparison")
 	fs.StringVar(&comparisonScheme, "comparison-scheme", comparer.AvgTest, fmt.Sprintf("Statistical test to be used as the algorithm for comparison. Allowed options: %v, %v", comparer.AvgTest, comparer.KSTest))
 	fs.Float64Var(&matchThreshold, "match-threshold", 0.8, "The threshold for metric comparison, interpretation depends on test used (significance level for KSTest, bound for ratio of avgs in AvgTest)")
-	fs.Float64Var(&minMetricAvgForCompare, "min-metric-avg-for-compare", 20.0, "The minimum value for a metric's avg to consider it for comparison. If in both left & right job the avg is less than this, it's directly marked as matched.")
+	fs.Float64Var(&minMetricAvgForCompare, "min-metric-avg-for-compare", 50.0, "The minimum value for a metric's avg to consider it for comparison. If in both left & right job the avg is less than this, it's directly marked as matched.")
 }
 
 // Select the runs of the left and right jobs to be used for comparison using the given run-selection scheme.


### PR DESCRIPTION
We're catching too much noise with 20ms.
IMO 50ms should be good enough to spot 'real' differences.