### PR TITLE
Fix misspell warnings in Go Report Card

### DIFF
--- a/slo-monitor/src/monitors/util.go
+++ b/slo-monitor/src/monitors/util.go
@@ -41,7 +41,7 @@ func podRunningReady(p *v1.Pod) (bool, error) {
 }
 
 // PodRunningReadyOrSucceeded checks whether pod p's phase is running and it has a ready
-// condition of status true or wheather the Pod already succeded.
+// condition of status true or wheather the Pod already succeeded.
 func PodRunningReadyOrSucceeded(p *v1.Pod) (bool, error) {
 	// Check if the phase is succeeded.
 	if p.Status.Phase == v1.PodSucceeded {

--- a/slo-monitor/src/monitors/watcher.go
+++ b/slo-monitor/src/monitors/watcher.go
@@ -29,7 +29,7 @@ const (
 	resyncPeriod = time.Duration(0)
 )
 
-// NewWatcherWithHandler creates a simple watcher that will call `h` for all comming objects
+// NewWatcherWithHandler creates a simple watcher that will call `h` for all coming objects
 func NewWatcherWithHandler(lw cache.ListerWatcher, objType runtime.Object, setHandler, deleteHandler func(obj interface{}) error) cache.Controller {
 	fifo := NewNoStoreQueue()
 


### PR DESCRIPTION
I was looking at the [Go Report Card](https://goreportcard.com/report/github.com/kubernetes/perf-tests) for the project and noticed it caught two misspellings. This PR just fixes those spelling errors so the Report Card will be 100% free of misspellings… nothing fancy.