### PR TITLE
PR: Network test cannot resolve host ftp.netperf.org

### DIFF
--- a/network/benchmarks/netperf/Dockerfile
+++ b/network/benchmarks/netperf/Dockerfile
@@ -31,7 +31,7 @@ RUN apt-get update \
 RUN mkdir -p /tmp
 
 # Download and build netperf from sources
-RUN curl -LO ftp://ftp.netperf.org/netperf/netperf-2.7.0.tar.gz && tar -xzf netperf-2.7.0.tar.gz
+RUN curl -LO https://github.com/HewlettPackard/netperf/archive/netperf-2.7.0.tar.gz && tar -xzf netperf-2.7.0.tar.gz && mv netperf-netperf-2.7.0/ netperf-2.7.0
 RUN cd netperf-2.7.0 && ./configure --prefix=/usr/local --bindir /usr/local/bin && make && make install
 
 COPY nptests /usr/bin/


### PR DESCRIPTION
Fixes #73 

Updated Dockerfile to reflect new location and added the rename command because they new archive untar's to netperf-netperf-2.7.0 in order to maintain further logic.