### PR TITLE
Use namely/perfest as Docker image

### DIFF
--- a/network/benchmarks/netperf/launch.go
+++ b/network/benchmarks/netperf/launch.go
@@ -45,7 +45,7 @@ const (
 	testNamespace    = "netperf"
 	csvDataMarker    = "GENERATING CSV OUTPUT"
 	csvEndDataMarker = "END CSV DATA"
-	netperfImage     = "girishkalele/netperf-latest"
+	netperfImage     = "namely/netperf:latest"
 
 	runUUID          = "latest"
 	orchestratorPort = 5202

--- a/network/benchmarks/netperf/nptest/Dockerfile
+++ b/network/benchmarks/netperf/nptest/Dockerfile
@@ -1,0 +1,21 @@
+FROM golang:1.9 AS builder
+
+WORKDIR /opt/apps/nptests
+ADD ./nptest.go nptest.go
+RUN go build -o nptests ./nptest.go
+
+FROM debian:jessie
+
+RUN apt-get update \
+    && apt-get install -y iperf3 curl wget net-tools gcc make \
+    && rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /tmp
+WORKDIR /tmp
+# Download and build netperf from sources
+RUN curl -LO https://github.com/HewlettPackard/netperf/archive/netperf-2.7.0.tar.gz
+RUN tar -xzf netperf-2.7.0.tar.gz
+RUN cd netperf-netperf-2.7.0 && ./configure --prefix=/usr/local --bindir /usr/local/bin && make && make install
+
+COPY --from=builder /opt/apps/nptests/nptests /usr/bin/
+
+ENTRYPOINT ["nptests"]


### PR DESCRIPTION
I've updated the image that this project uses to include the latest changes and published it to my companies Docker hub. It now uses the min mtu set to 96 and increments it by 40 each time. This change was made a while ago but no docker image was published for it.

I also removed a few of the tests because they rely on services that this project does not create. Only the `w2` service is actually created by this tool.