### PR TITLE
Fixed bug in handlePulledImageEvent

### DIFF
--- a/slo-monitor/src/monitors/pod_monitor.go
+++ b/slo-monitor/src/monitors/pod_monitor.go
@@ -211,8 +211,9 @@ func (pm *PodStartupLatencyDataMonitor) handlePodDelete(p *v1.Pod) {
 	defer pm.Unlock()
 
 	key := getPodKey(p)
-	data, ok := pm.PodStartupData[key]
-	if !ok {
+	ok := false
+	data := PodStartupMilestones{}
+	if data, ok = pm.PodStartupData[key]; !ok {
 		data = PodStartupMilestones{}
 		data.startedPulling = time.Unix(0, 0)
 	}
@@ -245,7 +246,7 @@ func (pm *PodStartupLatencyDataMonitor) handlePulledImageEvent(key string, e *v1
 
 	ok := false
 	data := PodStartupMilestones{}
-	if data, ok = pm.PodStartupData[key]; ok {
+	if data, ok = pm.PodStartupData[key]; !ok {
 		data.startedPulling = time.Unix(0, 0)
 		data.needPulled = -1
 	}


### PR DESCRIPTION
Fixed bug in handlePulledImageEvent function. It leads to negative startup time for pods, that pull images from docker registry. As a result they are not accounted.