### PR TITLE
Fixing dnsperf build

### DIFF
--- a/dns/image/Dockerfile.build
+++ b/dns/image/Dockerfile.build
@@ -1,4 +1,4 @@
-FROM alpine
+FROM alpine:3.7
 
 RUN apk add --update \
 	bind \
@@ -8,5 +8,7 @@ RUN apk add --update \
 	libcap-dev \
 	make \
 	musl-dev \
+	libressl2.6-libcrypto \
+	libcrypto1.0 \
 	openssl-dev \
     libxml2-dev

--- a/dns/image/Dockerfile.build
+++ b/dns/image/Dockerfile.build
@@ -1,7 +1,6 @@
 FROM alpine
 
-RUN apk update && \
-    apk add \
+RUN apk add --update \
 	bind \
 	bind-dev \
 	bind-libs \
@@ -9,4 +8,5 @@ RUN apk update && \
 	libcap-dev \
 	make \
 	musl-dev \
-	openssl-dev
+	openssl-dev \
+    libxml2-dev

--- a/dns/image/Dockerfile.image
+++ b/dns/image/Dockerfile.image
@@ -1,8 +1,8 @@
-FROM alpine
+FROM alpine:3.7
 
 RUN \
 	apk update && \
-	apk add bind-libs bind-tools libcap
+	apk add bind-libs bind-tools libcap libcrypto1.0
 
 COPY build/src/dnsperf /dnsperf
 COPY build/src/resperf /resperf


### PR DESCRIPTION
There was a missing library, the `libxml2-dev` on the build and `libcrypto1.0` on the final image. I have also changed a little bit the apk command.

How to replicate the issue ?
```bash
$ lsb_release -a
No LSB modules are available.
Distributor ID:	Ubuntu
Description:	Ubuntu 17.04
Release:	17.04
Codename:	zesty

$ git clone git@github.com:kubernetes/perf-tests.git
$ cd dns/image/
$ make
[some lines omitted]
docker run --rm -v `pwd`/build/src:/src kube-dns-perf-client-build \
	/bin/sh -c "cd /src && ./configure && make -j"
checking for gcc... gcc
checking for C compiler default output file name... a.out
checking whether the C compiler works... yes
checking whether we are cross compiling... no
checking for suffix of executables... 
checking for suffix of object files... o
checking whether we are using the GNU C compiler... yes
checking whether gcc accepts -g... yes
checking for gcc option to accept ISO C89... none needed
checking for a BSD-compatible install... /usr/bin/install -c
checking for ranlib... ranlib
checking for inline... inline
checking for socket in -lsocket... no
checking for inet_ntoa in -lnsl... no
checking for isc-config.sh... /usr/bin/isc-config.sh
checking for socklen_t... yes
checking for sa_len... no
checking build system type... x86_64-unknown-linux-gnu
checking host system type... x86_64-unknown-linux-gnu
checking for the pthreads library -lpthreads... no
checking whether pthreads work without any flags... yes
checking for joinable pthread attribute... PTHREAD_CREATE_JOINABLE
checking if more special flags are required for pthreads... no
configure: creating ./config.status
config.status: creating Makefile
gcc -g -O2 -I/usr/include -D_REENTRANT -D_GNU_SOURCE -DPACKAGE_NAME=\"\" -DPACKAGE_TARNAME=\"\" -DPACKAGE_VERSION=\"\" -DPACKAGE_STRING=\"\" -DPACKAGE_BUGREPORT=\"\" -DHAVE_PTHREAD=1  -c dnsperf.c
gcc -g -O2 -I/usr/include -D_REENTRANT -D_GNU_SOURCE -DPACKAGE_NAME=\"\" -DPACKAGE_TARNAME=\"\" -DPACKAGE_VERSION=\"\" -DPACKAGE_STRING=\"\" -DPACKAGE_BUGREPORT=\"\" -DHAVE_PTHREAD=1  -c datafile.c
gcc -g -O2 -I/usr/include -D_REENTRANT -D_GNU_SOURCE -DPACKAGE_NAME=\"\" -DPACKAGE_TARNAME=\"\" -DPACKAGE_VERSION=\"\" -DPACKAGE_STRING=\"\" -DPACKAGE_BUGREPORT=\"\" -DHAVE_PTHREAD=1  -c dns.c
gcc -g -O2 -I/usr/include -D_REENTRANT -D_GNU_SOURCE -DPACKAGE_NAME=\"\" -DPACKAGE_TARNAME=\"\" -DPACKAGE_VERSION=\"\" -DPACKAGE_STRING=\"\" -DPACKAGE_BUGREPORT=\"\" -DHAVE_PTHREAD=1  -c log.c
gcc -g -O2 -I/usr/include -D_REENTRANT -D_GNU_SOURCE -DPACKAGE_NAME=\"\" -DPACKAGE_TARNAME=\"\" -DPACKAGE_VERSION=\"\" -DPACKAGE_STRING=\"\" -DPACKAGE_BUGREPORT=\"\" -DHAVE_PTHREAD=1  -c net.c
gcc -g -O2 -I/usr/include -D_REENTRANT -D_GNU_SOURCE -DPACKAGE_NAME=\"\" -DPACKAGE_TARNAME=\"\" -DPACKAGE_VERSION=\"\" -DPACKAGE_STRING=\"\" -DPACKAGE_BUGREPORT=\"\" -DHAVE_PTHREAD=1  -c opt.c
gcc -g -O2 -I/usr/include -D_REENTRANT -D_GNU_SOURCE -DPACKAGE_NAME=\"\" -DPACKAGE_TARNAME=\"\" -DPACKAGE_VERSION=\"\" -DPACKAGE_STRING=\"\" -DPACKAGE_BUGREPORT=\"\" -DHAVE_PTHREAD=1  -c os.c
gcc -g -O2 -I/usr/include -D_REENTRANT -D_GNU_SOURCE -DPACKAGE_NAME=\"\" -DPACKAGE_TARNAME=\"\" -DPACKAGE_VERSION=\"\" -DPACKAGE_STRING=\"\" -DPACKAGE_BUGREPORT=\"\" -DHAVE_PTHREAD=1  -c resperf.c
In file included from datafile.c:32:0:
util.h:60:0: warning: "LOCK" redefined
 #define LOCK(mutex) do {      \
 
In file included from /usr/include/isc/magic.h:14:0,
                 from /usr/include/isc/buffer.h:100,
                 from datafile.c:26:
/usr/include/isc/util.h:90:0: note: this is the location of the previous definition
 #define LOCK(lp) do { \
 
In file included from datafile.c:32:0:
util.h:67:0: warning: "UNLOCK" redefined
 #define UNLOCK(mutex) do {      \
 
In file included from /usr/include/isc/magic.h:14:0,
                 from /usr/include/isc/buffer.h:100,
                 from datafile.c:26:
/usr/include/isc/util.h:101:0: note: this is the location of the previous definition
 #define UNLOCK(lp) do { \
 
In file included from datafile.c:32:0:
util.h:81:0: warning: "SIGNAL" redefined
 #define SIGNAL(cond) do {      \
 
In file included from /usr/include/isc/magic.h:14:0,
                 from /usr/include/isc/buffer.h:100,
                 from datafile.c:26:
/usr/include/isc/util.h:120:0: note: this is the location of the previous definition
 #define SIGNAL(cvp) do { \
 
In file included from datafile.c:32:0:
util.h:88:0: warning: "BROADCAST" redefined
 #define BROADCAST(cond) do {      \
 
In file included from /usr/include/isc/magic.h:14:0,
                 from /usr/include/isc/buffer.h:100,
                 from datafile.c:26:
/usr/include/isc/util.h:113:0: note: this is the location of the previous definition
 #define BROADCAST(cvp) do { \
 
In file included from datafile.c:32:0:
util.h:95:0: warning: "WAIT" redefined
 #define WAIT(cond, mutex) do {      \
 
In file included from /usr/include/isc/magic.h:14:0,
                 from /usr/include/isc/buffer.h:100,
                 from datafile.c:26:
/usr/include/isc/util.h:127:0: note: this is the location of the previous definition
 #define WAIT(cvp, lp) do { \
 
In file included from resperf.c:66:0:
util.h:60:0: warning: "LOCK" redefined
 #define LOCK(mutex) do {      \
 
In file included from /usr/include/isc/magic.h:14:0,
                 from /usr/include/isc/buffer.h:100,
                 from resperf.c:49:
/usr/include/isc/util.h:90:0: note: this is the location of the previous definition
 #define LOCK(lp) do { \
 
In file included from resperf.c:66:0:
util.h:67:0: warning: "UNLOCK" redefined
 #define UNLOCK(mutex) do {      \
 
In file included from /usr/include/isc/magic.h:14:0,
                 from /usr/include/isc/buffer.h:100,
                 from resperf.c:49:
/usr/include/isc/util.h:101:0: note: this is the location of the previous definition
 #define UNLOCK(lp) do { \
 
In file included from resperf.c:66:0:
util.h:81:0: warning: "SIGNAL" redefined
 #define SIGNAL(cond) do {      \
 
In file included from /usr/include/isc/magic.h:14:0,
                 from /usr/include/isc/buffer.h:100,
                 from resperf.c:49:
/usr/include/isc/util.h:120:0: note: this is the location of the previous definition
 #define SIGNAL(cvp) do { \
 
In file included from resperf.c:66:0:
util.h:88:0: warning: "BROADCAST" redefined
 #define BROADCAST(cond) do {      \
 
In file included from /usr/include/isc/magic.h:14:0,
                 from /usr/include/isc/buffer.h:100,
                 from resperf.c:49:
/usr/include/isc/util.h:113:0: note: this is the location of the previous definition
 #define BROADCAST(cvp) do { \
 
In file included from resperf.c:66:0:
util.h:95:0: warning: "WAIT" redefined
 #define WAIT(cond, mutex) do {      \
 
In file included from /usr/include/isc/magic.h:14:0,
                 from /usr/include/isc/buffer.h:100,
                 from resperf.c:49:
/usr/include/isc/util.h:127:0: note: this is the location of the previous definition
 #define WAIT(cvp, lp) do { \
 
In file included from dnsperf.c:75:0:
util.h:60:0: warning: "LOCK" redefined
 #define LOCK(mutex) do {      \
 
In file included from /usr/include/isc/magic.h:14:0,
                 from /usr/include/isc/buffer.h:100,
                 from dnsperf.c:55:
/usr/include/isc/util.h:90:0: note: this is the location of the previous definition
 #define LOCK(lp) do { \
 
In file included from dnsperf.c:75:0:
util.h:67:0: warning: "UNLOCK" redefined
 #define UNLOCK(mutex) do {      \
 
In file included from /usr/include/isc/magic.h:14:0,
                 from /usr/include/isc/buffer.h:100,
                 from dnsperf.c:55:
/usr/include/isc/util.h:101:0: note: this is the location of the previous definition
 #define UNLOCK(lp) do { \
 
In file included from dnsperf.c:75:0:
util.h:81:0: warning: "SIGNAL" redefined
 #define SIGNAL(cond) do {      \
 
In file included from /usr/include/isc/magic.h:14:0,
                 from /usr/include/isc/buffer.h:100,
                 from dnsperf.c:55:
/usr/include/isc/util.h:120:0: note: this is the location of the previous definition
 #define SIGNAL(cvp) do { \
 
In file included from dnsperf.c:75:0:
util.h:88:0: warning: "BROADCAST" redefined
 #define BROADCAST(cond) do {      \
 
In file included from /usr/include/isc/magic.h:14:0,
                 from /usr/include/isc/buffer.h:100,
                 from dnsperf.c:55:
/usr/include/isc/util.h:113:0: note: this is the location of the previous definition
 #define BROADCAST(cvp) do { \
 
In file included from dnsperf.c:75:0:
util.h:95:0: warning: "WAIT" redefined
 #define WAIT(cond, mutex) do {      \
 
In file included from /usr/include/isc/magic.h:14:0,
                 from /usr/include/isc/buffer.h:100,
                 from dnsperf.c:55:
/usr/include/isc/util.h:127:0: note: this is the location of the previous definition
 #define WAIT(cvp, lp) do { \
 
dns.c: In function 'name_fromstring':
dns.c:187:2: warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
  isc_buffer_init(&buffer, str, len);
  ^~~~~~~~~~~~~~~
dnsperf.c: In function 'print_statistics':
dnsperf.c:352:28: warning: format '%lu' expects argument of type 'long unsigned int', but argument 3 has type 'isc_uint64_t {aka long long unsigned int}' [-Wformat=]
    printf("#histogram %u %lu\n", i, stats->rtt_histogram[i]);
                            ^
ar rv libperf.a datafile.o dns.o log.o net.o opt.o os.o
a - datafile.o
ar: creating libperf.a
a - dns.o
a - log.o
a - net.o
a - opt.o
a - os.o
ranlib libperf.a
gcc  resperf.o  libperf.a  -L/usr/lib -lbind9 -ldns -lcrypto -lisccfg -lisc -ldl -lcap -lpthread -lxml2 -L/lib -lz -lm  -lm -o resperf
/usr/lib/gcc/x86_64-alpine-linux-musl/6.4.0/../../../../x86_64-alpine-linux-musl/bin/ld: cannot find -lxml2
collect2: error: ld returned 1 exit status
make: *** [Makefile:32: resperf] Error 1
make: *** Waiting for unfinished jobs....
Makefile:37: recipe for target 'build/src/dnsperf' failed
make: *** [build/src/dnsperf] Error 2
```