### PR TITLE
Adapt netperf Makefile to support MacOS

### DIFF
--- a/network/benchmarks/netperf/Makefile
+++ b/network/benchmarks/netperf/Makefile
@@ -26,7 +26,7 @@ push: docker
 	gcloud docker push $(DOCKERREPO)
 
 nptests: nptest/nptest.go
-	cd nptest; make nptests
+	cd nptest; GOOS=linux GOARCH=amd64 make nptests
 
 clean:
 	@rm -f Dockerbuild/*


### PR DESCRIPTION
nptest needs to be build for Linux (and potentially cross-compiled).

Fixes #105