### PR TITLE
Perfdash empty entries

### DIFF
--- a/perfdash/Makefile
+++ b/perfdash/Makefile
@@ -1,7 +1,7 @@
 all: push
 
 # See pod.yaml for the version currently running-- bump this ahead before rebuilding!
-TAG = 0.18
+TAG = 0.19
 
 REPO = gcr.io/k8s-testimages
 

--- a/perfdash/deployment.yaml
+++ b/perfdash/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: default
   labels:
     app: perfdash
-    version: "0.18"
+    version: "0.19"
 spec:
   selector:
     matchLabels:
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: perfdash
-        image: gcr.io/k8s-testimages/perfdash:0.18
+        image: gcr.io/k8s-testimages/perfdash:0.19
         command:
           - /perfdash
           -   --www=true


### PR DESCRIPTION
Adding empty objects  as a placeholders to data series. Due to this change, perfdash will match values to corresponding builds correctly.