### PR TITLE
Add OWNERS to nptests

### DIFF
--- a/network/benchmarks/netperf/OWNERS
+++ b/network/benchmarks/netperf/OWNERS
@@ -1,0 +1,7 @@
+approvers:
+- gmarek
+- shyamjvs
+- bowei
+- mkoderer
+- gonzolino
+- dkusidlo


### PR DESCRIPTION
As discussed with gmarek we add an OWNERS file for nptests to make
it possible to merge stuff more quickly.