### PR TITLE
Perfdash: requesting builds data on demand

### DIFF
--- a/perfdash/Makefile
+++ b/perfdash/Makefile
@@ -1,7 +1,7 @@
 all: push
 
 # See pod.yaml for the version currently running-- bump this ahead before rebuilding!
-TAG = 0.24
+TAG = 0.25
 
 REPO = gcr.io/k8s-testimages
 

--- a/perfdash/deployment.yaml
+++ b/perfdash/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: default
   labels:
     app: perfdash
-    version: "0.24"
+    version: "0.25"
 spec:
   selector:
     matchLabels:
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: perfdash
-        image: gcr.io/k8s-testimages/perfdash:0.24
+        image: gcr.io/k8s-testimages/perfdash:0.25
         command:
           - /perfdash
           -   --www=true

--- a/perfdash/downloader.go
+++ b/perfdash/downloader.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"sort"
 
 	"k8s.io/kubernetes/test/e2e/perftype"
 )
@@ -29,22 +30,22 @@ type Downloader interface {
 	getData() (TestToBuildData, error)
 }
 
-// BuildData contains job name and a map from build number to perf data
+// BuildData contains job name and a map from build number to perf data.
 type BuildData struct {
 	Builds  map[string][]perftype.DataItem `json:"builds"`
 	Job     string                         `json:"job"`
 	Version string                         `json:"version"`
 }
 
-// TestToBuildData is a map from test name to BuildData pointer
+// TestToBuildData is a map from test name to BuildData pointer.
 // TODO(random-liu): Use a more complex data structure if we need to support more test in the future.
 type TestToBuildData map[string]*BuildData
 
-// JobToTestData is a map from job name to TestToBuildData
+// JobToTestData is a map from job name to TestToBuildData.
 type JobToTestData map[string]TestToBuildData
 
-func (b *JobToTestData) ServeHTTP(res http.ResponseWriter, req *http.Request) {
-	data, err := json.Marshal(b)
+func serveHTTPObject(res http.ResponseWriter, req *http.Request, obj interface{}) {
+	data, err := json.Marshal(obj)
 	if err != nil {
 		res.Header().Set("Content-type", "text/html")
 		res.WriteHeader(http.StatusInternalServerError)
@@ -54,4 +55,73 @@ func (b *JobToTestData) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 	res.Header().Set("Content-type", "application/json")
 	res.WriteHeader(http.StatusOK)
 	res.Write(data)
+}
+
+func getURLParam(req *http.Request, name string) (string, bool) {
+	params, ok := req.URL.Query()[name]
+	if !ok || len(params) < 1 {
+		return "", false
+	}
+	return params[0], true
+}
+
+// ServeJobNames serves all available job names.
+func (j *JobToTestData) ServeJobNames(res http.ResponseWriter, req *http.Request) {
+	jobNames := make([]string, 0)
+	if j != nil {
+		for k := range *j {
+			jobNames = append(jobNames, k)
+		}
+	}
+	sort.Strings(jobNames)
+	serveHTTPObject(res, req, &jobNames)
+}
+
+// ServeTestNames serves all available test name for given job.
+func (j *JobToTestData) ServeTestNames(res http.ResponseWriter, req *http.Request) {
+	jobname, ok := getURLParam(req, "jobname")
+	if !ok {
+		fmt.Printf("Url Param 'jobname' is missing\n")
+		return
+	}
+
+	tests, ok := (*j)[jobname]
+	if !ok {
+		fmt.Printf("unknown jobname - %v\n", jobname)
+		return
+	}
+
+	testNames := make([]string, 0)
+	for k := range tests {
+		testNames = append(testNames, k)
+	}
+	sort.Strings(testNames)
+	serveHTTPObject(res, req, &testNames)
+}
+
+// ServeBuildsData serves builds data for given job name and test name.
+func (j *JobToTestData) ServeBuildsData(res http.ResponseWriter, req *http.Request) {
+	jobname, ok := getURLParam(req, "jobname")
+	if !ok {
+		fmt.Printf("Url Param 'jobname' is missing\n")
+		return
+	}
+	testname, ok := getURLParam(req, "testname")
+	if !ok {
+		fmt.Printf("Url Param 'testname' is missing\n")
+		return
+	}
+
+	tests, ok := (*j)[jobname]
+	if !ok {
+		fmt.Printf("unknown jobname - %v\n", jobname)
+		return
+	}
+	builds, ok := tests[testname]
+	if !ok {
+		fmt.Printf("unknown testname - %v\n", testname)
+		return
+	}
+
+	serveHTTPObject(res, req, builds)
 }

--- a/perfdash/perfdash.go
+++ b/perfdash/perfdash.go
@@ -88,7 +88,9 @@ func run() error {
 	}()
 
 	fmt.Println("Starting server")
-	http.Handle("/api", &result)
 	http.Handle("/", http.FileServer(http.Dir(*wwwDir)))
+	http.HandleFunc("/jobnames", result.ServeJobNames)
+	http.HandleFunc("/testnames", result.ServeTestNames)
+	http.HandleFunc("/buildsdata", result.ServeBuildsData)
 	return http.ListenAndServe(*addr, nil)
 }


### PR DESCRIPTION
Instead of getting all available data for every possible <job x test>, only requested data (for one selected <job x test>) will be retrieved.
ref #137 