### PR TITLE
Fixing verify_golint.sh for go1.10+ versions

### DIFF
--- a/verify/verify-golint.sh
+++ b/verify/verify-golint.sh
@@ -20,13 +20,6 @@ set -o pipefail
 
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 
-GO_VERSION=($(go version))
-# golint only works for golang 1.5+
-if [[ -n $(echo "${GO_VERSION[2]}" | grep -E 'go1.1|go1.2|go1.3|go1.4') ]]; then
-  echo "GOLINT requires go 1.5+. Skipping"
-  exit
-fi
-
 cd "${KUBE_ROOT}"
 
 GOLINT=${GOLINT:-"golint"}


### PR DESCRIPTION
Removing go version check - everyone uses 1.5+ version as default.