### PR TITLE
Update OWNERS for perf-dash

### DIFF
--- a/perfdash/OWNERS
+++ b/perfdash/OWNERS
@@ -1,10 +1,8 @@
 approvers:
-- Random-Liu
-- gmarek
 - krzysied
 - shyamjvs
+- wojtek-t
 reviewers:
-- Random-Liu
-- gmarek
 - krzysied
 - shyamjvs
+- wojtek-t


### PR DESCRIPTION
To avoid mis-assignment of reviewers for PRs.

/cc @krzysied 