### PR TITLE
ClusterLoader - Updating measurement api

### DIFF
--- a/clusterloader2/api/types.go
+++ b/clusterloader2/api/types.go
@@ -102,6 +102,10 @@ type TuningSet struct {
 type Measurement struct {
 	// Method is a name of a method registered in the ClusterLoader factory.
 	Method string
+	// Identifier is a string that differentiates measurement instances of the same method.
+	Identifier string
+	// Params is a map of {name: value} pairs which will be passed to the measurement method - allowing for injection of arbitrary parameters to it.
+	Params map[string]interface{}
 }
 
 // QpsLoad defines a uniform load with a given QPS.


### PR DESCRIPTION
Adding new fields to Measurement API:
- Identifier - is a identifier within method scope.
Pair <Method, Identifier> makes measurement unique at global scope. The new field is needed due to possible having multiple measurements  instances that uses the same measurement method.
- Params - map of <name, value>. Optional additional method parameters. Allows measurements to be more generic.