### PR TITLE
Adding Flags to run ClusterLoader, Netperf and DNS

### DIFF
--- a/run-e2e.sh
+++ b/run-e2e.sh
@@ -13,18 +13,44 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# run the script to run e2e tests for cluster loader, netperf and dns. 
+# run the script to run e2e tests for cluster loader, netperf and dns.
 # This enables the same to be invoked from kubetest from test-infra.
 
 set -o nounset
 set -o pipefail
 
 PERFTEST_ROOT=$(dirname "${BASH_SOURCE}")
-#CLUSTERLOADER
-cd ${PERFTEST_ROOT}/clusterloader/e2e/ && go test -c -o e2e.test
-./e2e.test --ginkgo.v=true --ginkgo.focus="Cluster\sLoader" --kubeconfig="${HOME}/.kube/config" --viper-config=../config/test
-#NETPERF
-cd ${PERFTEST_ROOT}/network/benchmarks/netperf/ && go run ./launch.go  --kubeConfig="${HOME}/.kube/config" --hostnetworking --iterations 1
-#DNS
-cd ${PERFTEST_ROOT}/dns
- ./run --params params/kubedns/default.yaml --out-dir out --use-cluster-dns
+case "$1" in
+    #CLUSTERLOADER
+  --cluster-loader )
+    cd ${PERFTEST_ROOT}/clusterloader/e2e/ && go test -c -o e2e.test
+    ./e2e.test --ginkgo.v=true --ginkgo.focus="Cluster\sLoader" --kubeconfig="${HOME}/.kube/config" --viper-config=../config/test
+    exit
+    ;;
+  --network-performance )
+    #NETPERF
+    cd ${PERFTEST_ROOT}/network/benchmarks/netperf/ && go run ./launch.go  --kubeConfig="${HOME}/.kube/config" --hostnetworking --iterations 1
+    exit
+    ;;
+  --kube-dns )
+    #KUBE-DNS
+    cd ${PERFTEST_ROOT}/dns
+    mkdir out
+    ./run --params params/kubedns/default.yaml --out-dir out --use-cluster-dns
+    exit
+    ;;
+  --core-dns )
+    #CORE-DNS
+    cd ${PERFTEST_ROOT}/dns
+    mkdir out
+    ./run --dns-server coredns --params params/coredns/default.yaml --out-dir out --use-cluster-dns
+    exit
+    ;;
+  --help | -h )
+    echo  " --cluster-loader                Run Cluster Loader Test"
+    echo  " --network-performance           Run Network Performance Test"
+    echo  " --kube-dns                      Run Kube-DNS test"
+    echo  " --core-dns                      Run Core-DNS test"
+    exit
+    ;;
+esac


### PR DESCRIPTION
Added flags to invoke clusterloader, netperf and DNS separately from Kubetest (e2e framework).