### PR TITLE
ClusterLoader - Adding test name to config

### DIFF
--- a/clusterloader2/api/types.go
+++ b/clusterloader2/api/types.go
@@ -23,6 +23,8 @@ import (
 // Config is a structure that represents configuration
 // for a single test scenario.
 type Config struct {
+	// Name of the test case.
+	Name string `json: name`
 	// AutomanagedNamespaces is a number of automanaged namespaces.
 	AutomanagedNamespaces int32 `json: automanagedNamespaces`
 	// Steps is a sequence of test steps executed in serial.

--- a/clusterloader2/cmd/clusterloader.go
+++ b/clusterloader2/cmd/clusterloader.go
@@ -79,6 +79,7 @@ func main() {
 		glog.Fatalf("Config reading error: %v", err)
 	}
 
+	glog.Infof("Running %v test - %v", testConfig.Name, testConfigPath)
 	if errList := test.RunTest(f, &clusterConfig, testConfig); len(errList) > 0 {
 		glog.Fatalf("Test execution failed: %v", errors.NewAggregate(errList).Error())
 	}

--- a/clusterloader2/testing/density/config.yaml
+++ b/clusterloader2/testing/density/config.yaml
@@ -1,3 +1,4 @@
+name: Density
 automanagedNamespaces: 3
 tuningSets:
 - name: Uniform100qps


### PR DESCRIPTION
In future there will be added option to run multiple tests in single clusterloader execution. Cause files will be created (for example: measurement summaries) for every test, there is a need to include test name in file name to prevent name collisions.