### PR TITLE
ClusterLoader - Allowing multiple tests

### DIFF
--- a/clusterloader2/cmd/clusterloader.go
+++ b/clusterloader2/cmd/clusterloader.go
@@ -19,8 +19,10 @@ package main
 import (
 	"flag"
 	"fmt"
+	"os"
 
 	"github.com/golang/glog"
+	"github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/perf-tests/clusterloader2/pkg/config"
 	"k8s.io/perf-tests/clusterloader2/pkg/framework"
@@ -31,10 +33,11 @@ import (
 
 var (
 	clusterLoaderConfig config.ClusterLoaderConfig
+	testConfigPaths     []string
 )
 
 func initClusterFlags() {
-	flag.StringVar(&clusterLoaderConfig.ClusterConfig.KubeConfigPath, "kubeconfig", "", "Path to the kubeconfig file")
+	pflag.StringVar(&clusterLoaderConfig.ClusterConfig.KubeConfigPath, "kubeconfig", "", "Path to the kubeconfig file")
 }
 
 func validateClusterFlags() []error {
@@ -46,14 +49,16 @@ func validateClusterFlags() []error {
 }
 
 func initFlags() {
-	flag.StringVar(&clusterLoaderConfig.ReportDir, "report-dir", "", "Path to the directory where the reports should be saved. Default is empty, which cause reports being written to standard output.")
-	flag.StringVar(&clusterLoaderConfig.TestConfigPath, "testconfig", "", "Path to the test config file")
+	pflag.CommandLine = pflag.NewFlagSet(os.Args[0], pflag.ContinueOnError)
+	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
+	pflag.StringVar(&clusterLoaderConfig.ReportDir, "report-dir", "", "Path to the directory where the reports should be saved. Default is empty, which cause reports being written to standard output.")
+	pflag.StringArrayVar(&testConfigPaths, "testconfig", []string{}, "Paths to the test config files")
 	initClusterFlags()
 }
 
 func validateFlags() []error {
 	errList := make([]error, 0)
-	if clusterLoaderConfig.TestConfigPath == "" {
+	if len(testConfigPaths) < 1 {
 		errList = append(errList, fmt.Errorf("no test config path specified"))
 	}
 	errList = append(errList, validateClusterFlags()...)
@@ -63,7 +68,9 @@ func validateFlags() []error {
 func main() {
 	defer glog.Flush()
 	initFlags()
-	flag.Parse()
+	if err := pflag.CommandLine.Parse(os.Args[1:]); err != nil {
+		glog.Fatalf("Flag parse failed: %v", err)
+	}
 	if errList := validateFlags(); len(errList) > 0 {
 		glog.Fatalf("Parsing flags error: %v", errors.NewAggregate(errList).Error())
 	}
@@ -72,15 +79,16 @@ func main() {
 	if err != nil {
 		glog.Fatalf("Framework creation error: %v", err)
 	}
-	testConfig, err := config.ReadConfig(clusterLoaderConfig.TestConfigPath)
-	if err != nil {
-		glog.Fatalf("Config reading error: %v", err)
-	}
+	for _, clusterLoaderConfig.TestConfigPath = range testConfigPaths {
+		testConfig, err := config.ReadConfig(clusterLoaderConfig.TestConfigPath)
+		if err != nil {
+			glog.Fatalf("Config reading error: %v", err)
+		}
 
-	glog.Infof("Running %v test - %v", testConfig.Name, clusterLoaderConfig.TestConfigPath)
-	if errList := test.RunTest(f, &clusterLoaderConfig, testConfig); len(errList) > 0 {
-		glog.Fatalf("Test execution failed: %v", errors.NewAggregate(errList).Error())
+		glog.Infof("Running %v test - %v", testConfig.Name, clusterLoaderConfig.TestConfigPath)
+		if errList := test.RunTest(f, &clusterLoaderConfig, testConfig); len(errList) > 0 {
+			glog.Fatalf("Test execution failed: %v", errors.NewAggregate(errList).Error())
+		}
+		glog.Infof("Test %v ran successfully!", clusterLoaderConfig.TestConfigPath)
 	}
-
-	glog.Info("Test ran successfully!")
 }

--- a/clusterloader2/pkg/config/codec.go
+++ b/clusterloader2/pkg/config/codec.go
@@ -30,16 +30,16 @@ import (
 
 // ReadConfig creates test config from file specified by the given path.
 func ReadConfig(path string) (*api.Config, error) {
-	// This must be done after common flags are registered, since Viper is a flag option.
 	base := filepath.Base(path)
 	ext := filepath.Ext(base)
-	viper.SetConfigName(strings.TrimSuffix(base, ext))
-	viper.AddConfigPath(filepath.Dir(path))
-	if err := viper.ReadInConfig(); err != nil {
+	v := viper.New()
+	v.SetConfigName(strings.TrimSuffix(base, ext))
+	v.AddConfigPath(filepath.Dir(path))
+	if err := v.ReadInConfig(); err != nil {
 		return nil, fmt.Errorf("read config failed: %v", err)
 	}
 	var config api.Config
-	if err := viper.Unmarshal(&config); err != nil {
+	if err := v.Unmarshal(&config); err != nil {
 		return nil, fmt.Errorf("unmarshaling failed: %v", err)
 	}
 	return &config, nil


### PR DESCRIPTION
Allowing `--testconfig` flag to be used multiple times.
Test will wait until resources are cleaned up.