### PR TITLE
ClusterLoader - Api responsiveness fix

### DIFF
--- a/clusterloader2/pkg/measurement/common/api_responsiveness.go
+++ b/clusterloader2/pkg/measurement/common/api_responsiveness.go
@@ -48,23 +48,23 @@ const (
 
 	currentApiCallMetricsVersion = "v1"
 
-	metricName = "APICallLatency"
+	metricName = "APIResponsiveness"
 )
 
 func init() {
-	measurement.Register(metricName, createAPICallLatencyMeasurement)
+	measurement.Register(metricName, createAPIResponsivenessMeasurement)
 }
 
-func createAPICallLatencyMeasurement() measurement.Measurement {
-	return &apiCallLatencyMeasurement{}
+func createAPIResponsivenessMeasurement() measurement.Measurement {
+	return &apiResponsivenessMeasurement{}
 }
 
-type apiCallLatencyMeasurement struct{}
+type apiResponsivenessMeasurement struct{}
 
 // Execute supports two actions:
 // - reset - Resets latency data on api server side.
 // - gather - Gathers and prints current api server latency data.
-func (*apiCallLatencyMeasurement) Execute(config *measurement.MeasurementConfig) ([]measurement.Summary, error) {
+func (*apiResponsivenessMeasurement) Execute(config *measurement.MeasurementConfig) ([]measurement.Summary, error) {
 	var summaries []measurement.Summary
 	action, err := util.GetString(config.Params, "action")
 	if err != nil {
@@ -220,7 +220,7 @@ func (a *apiResponsiveness) SummaryName() string {
 
 // PrintSummary returns summary as a string.
 func (a *apiResponsiveness) PrintSummary() (string, error) {
-	return util.PrettyPrintJSON(a)
+	return util.PrettyPrintJSON(apiCallToPerfData(a))
 }
 
 func (a *apiResponsiveness) Len() int { return len(a.ApiCalls) }

--- a/clusterloader2/testing/density/config.yaml
+++ b/clusterloader2/testing/density/config.yaml
@@ -1,4 +1,4 @@
-name: Density
+name: density
 automanagedNamespaces: 3
 tuningSets:
 - name: Uniform100qps
@@ -17,8 +17,8 @@ steps:
     Method: Timer
     Params:
       action: start
-  - Identifier: APICallLatency
-    Method: APICallLatency
+  - Identifier: APIResponsiveness
+    Method: APIResponsiveness
     Params:
       action: reset
 # Create saturation pods
@@ -99,8 +99,8 @@ steps:
     - basename: latency-pod-rc
       objectTemplatePath: rc.yaml
 - measurements:
-  - Identifier: APICallLatency
-    Method: APICallLatency
+  - Identifier: APIResponsiveness
+    Method: APIResponsiveness
     Params:
       action: gather
       nodeCount: 3

--- a/clusterloader2/testing/load/config.yaml
+++ b/clusterloader2/testing/load/config.yaml
@@ -1,4 +1,4 @@
-name: Load
+name: load
 automanagedNamespaces: 3
 tuningSets:
 - name: Average0.33qps
@@ -17,8 +17,8 @@ steps:
     Method: Timer
     Params:
       action: start
-  - Identifier: APICallLatency
-    Method: APICallLatency
+  - Identifier: APIResponsiveness
+    Method: APIResponsiveness
     Params:
       action: reset
 # Create RCs
@@ -102,8 +102,8 @@ steps:
     - basename: rc
       objectTemplatePath: rc.yaml
 - measurements:
-  - Identifier: APICallLatency
-    Method: APICallLatency
+  - Identifier: APIResponsiveness
+    Method: APIResponsiveness
     Params:
       action: gather
       nodeCount: 3


### PR DESCRIPTION
Changing metric to have exactly the same name and the same layout as original one.
Needed due to backward compatibility. 