### PR TITLE
ClusterLoader - Adding templating to test configs

### DIFF
--- a/clusterloader2/cmd/clusterloader.go
+++ b/clusterloader2/cmd/clusterloader.go
@@ -38,12 +38,17 @@ var (
 
 func initClusterFlags() {
 	pflag.StringVar(&clusterLoaderConfig.ClusterConfig.KubeConfigPath, "kubeconfig", "", "Path to the kubeconfig file")
+	// TODO(krzysied): query actual number of nodes with client (if not set).
+	pflag.IntVar(&clusterLoaderConfig.ClusterConfig.Nodes, "nodes", 0, "number of nodes")
 }
 
 func validateClusterFlags() *util.ErrorList {
 	errList := util.NewErrorList()
 	if clusterLoaderConfig.ClusterConfig.KubeConfigPath == "" {
 		errList.Append(fmt.Errorf("no kubeconfig path specified"))
+	}
+	if clusterLoaderConfig.ClusterConfig.Nodes < 1 {
+		errList.Append(fmt.Errorf("number of nodes not specified"))
 	}
 	return errList
 }
@@ -80,13 +85,8 @@ func main() {
 		glog.Fatalf("Framework creation error: %v", err)
 	}
 	for _, clusterLoaderConfig.TestConfigPath = range testConfigPaths {
-		testConfig, err := config.ReadConfig(clusterLoaderConfig.TestConfigPath)
-		if err != nil {
-			glog.Fatalf("Config reading error: %v", err)
-		}
-
-		glog.Infof("Running %v test - %v", testConfig.Name, clusterLoaderConfig.TestConfigPath)
-		if errList := test.RunTest(f, &clusterLoaderConfig, testConfig); !errList.IsEmpty() {
+		glog.Infof("Running %v", clusterLoaderConfig.TestConfigPath)
+		if errList := test.RunTest(f, &clusterLoaderConfig); !errList.IsEmpty() {
 			glog.Fatalf("Test execution failed: %v", errList.String())
 		}
 		glog.Infof("Test %v ran successfully!", clusterLoaderConfig.TestConfigPath)

--- a/clusterloader2/pkg/config/cluster.go
+++ b/clusterloader2/pkg/config/cluster.go
@@ -26,4 +26,5 @@ type ClusterLoaderConfig struct {
 // ClusterConfig is a structure that represents cluster description.
 type ClusterConfig struct {
 	KubeConfigPath string `json: kubeConfigPath`
+	Nodes          int    `json: nodes`
 }


### PR DESCRIPTION
Test configs will support templating. Nodes placeholder and template functions will available for test configs.
`nodes` must be provided!