### PR TITLE
Perfdash - removing kubernetes version from client label

### DIFF
--- a/perfdash/Makefile
+++ b/perfdash/Makefile
@@ -1,7 +1,7 @@
 all: push
 
 # See pod.yaml for the version currently running-- bump this ahead before rebuilding!
-TAG = 1.9
+TAG = 1.10
 
 REPO = gcr.io/k8s-testimages
 

--- a/perfdash/deployment.yaml
+++ b/perfdash/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: default
   labels:
     app: perfdash
-    version: "1.9"
+    version: "1.10"
 spec:
   selector:
     matchLabels:
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: perfdash
-        image: gcr.io/k8s-testimages/perfdash:1.9
+        image: gcr.io/k8s-testimages/perfdash:1.10
         command:
           - /perfdash
           -   --www=true


### PR DESCRIPTION
Due to client label (DensityRequestCountByClient/LoadRequestCountByClient) containing kubernetes version, there is no option to compere across different runs.
This version should be removed.