### PR TITLE
Updating golint

### DIFF
--- a/verify/install-verify-tools.sh
+++ b/verify/install-verify-tools.sh
@@ -21,11 +21,7 @@ set -o pipefail
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 GO_VERSION=($(go version))
 
-# golint only works for golang 1.5+
-if [[ -z $(echo "${GO_VERSION[2]}" | grep -E 'go1.1|go1.2|go1.3|go1.4') ]]; then
-  go get -u github.com/golang/lint/golint
-fi
-
+go get -u golang.org/x/lint/golint
 go get -u github.com/tools/godep
 
 # ex: ts=2 sw=2 et filetype=sh


### PR DESCRIPTION
Changing github.com/golang/lint/golint to golang.org/x/lint/golint.
That's the proper way of installation according to https://github.com/golang/lint

Removing version check - we always use 1.5+ version.