### PR TITLE
Verify gofmt fix

### DIFF
--- a/verify/verify-gofmt.sh
+++ b/verify/verify-gofmt.sh
@@ -22,13 +22,6 @@ set -o pipefail
 
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 
-GO_VERSION=($(go version))
-
-if [[ -z $(echo "${GO_VERSION[2]}" | grep -E 'go1.2|go1.3|go1.4|go1.5|go1.6|go1.7|go1.9') ]]; then
-  echo "Unknown go version '${GO_VERSION}', skipping gofmt."
-  exit 1
-fi
-
 cd "${KUBE_ROOT}"
 
 find_files() {


### PR DESCRIPTION
Removing go version check from verify-gofmt.sh. Go version checks have been already removed from all other verify scripts.