### PR TITLE
ClusterLoader - Adding time limited tuning sets

### DIFF
--- a/clusterloader2/api/types.go
+++ b/clusterloader2/api/types.go
@@ -102,6 +102,10 @@ type TuningSet struct {
 	RandomizedLoad *RandomizedLoad `json: randomizedLoad`
 	// SteppedLoad is a definition for SteppedLoad tuning set.
 	SteppedLoad *SteppedLoad `json: steppedLoad`
+	// TimeLimitedLoad is a definition for TimeLimitedLoad tuning set.
+	TimeLimitedLoad *TimeLimitedLoad `json: timeLimitedLoad`
+	// RandomizedTimeLimitedLoad is a definition for RandomizedTimeLimitedLoad tuning set.
+	RandomizedTimeLimitedLoad *RandomizedTimeLimitedLoad `json: randomizedTimeLimitedLoad`
 }
 
 // Measurement is a structure that defines the measurement method call.
@@ -135,4 +139,16 @@ type SteppedLoad struct {
 	BurstSize int32 `json: burstSize`
 	// StepDelay specifies the interval between peeks.
 	StepDelay time.Duration `json: stepDelay`
+}
+
+// TimeLimitedLoad defines a load that spreads operations over given time.
+type TimeLimitedLoad struct {
+	// TimeLimit specifies the limit of the time that operation will be spread over.
+	TimeLimit time.Duration `json: timeLimit`
+}
+
+// RandomizedTimeLimitedLoad defines a load that randomly spreads operations over given time.
+type RandomizedTimeLimitedLoad struct {
+	// TimeLimit specifies the limit of the time that operation will be spread over.
+	TimeLimit time.Duration `json: timeLimit`
 }

--- a/clusterloader2/pkg/tuningset/randomized_time_limited.go
+++ b/clusterloader2/pkg/tuningset/randomized_time_limited.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tuningset
+
+import (
+	"math/rand"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/perf-tests/clusterloader2/api"
+)
+
+type randomizedTimeLimitedLoad struct {
+	params *api.RandomizedTimeLimitedLoad
+}
+
+func newRandomizedTimeLimitedLoad(params *api.RandomizedTimeLimitedLoad) TuningSet {
+	return &randomizedTimeLimitedLoad{
+		params: params,
+	}
+}
+
+func (r *randomizedTimeLimitedLoad) Execute(actions []func()) {
+	var wg wait.Group
+	for i := range actions {
+		index := i
+		wg.Start(func() {
+			// Sleeps for random duration in [0, TimeLimit].
+			time.Sleep(time.Duration(rand.Int63n(r.params.TimeLimit.Nanoseconds())))
+			actions[index]()
+		})
+	}
+	wg.Wait()
+}

--- a/clusterloader2/pkg/tuningset/simple_tuning_set_factory.go
+++ b/clusterloader2/pkg/tuningset/simple_tuning_set_factory.go
@@ -54,6 +54,10 @@ func (tf *simpleTuningSetFactory) CreateTuningSet(name string) (TuningSet, error
 		return newRandomizedLoad(tuningSet.RandomizedLoad), nil
 	case tuningSet.SteppedLoad != nil:
 		return newSteppedLoad(tuningSet.SteppedLoad), nil
+	case tuningSet.TimeLimitedLoad != nil:
+		return newTimeLimitedLoad(tuningSet.TimeLimitedLoad), nil
+	case tuningSet.RandomizedTimeLimitedLoad != nil:
+		return newRandomizedTimeLimitedLoad(tuningSet.RandomizedTimeLimitedLoad), nil
 	default:
 		return nil, fmt.Errorf("incorrect tuning set: %v", tuningSet)
 	}

--- a/clusterloader2/pkg/tuningset/time_limited.go
+++ b/clusterloader2/pkg/tuningset/time_limited.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tuningset
+
+import (
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/perf-tests/clusterloader2/api"
+)
+
+type timeLimitedLoad struct {
+	params *api.TimeLimitedLoad
+}
+
+func newTimeLimitedLoad(params *api.TimeLimitedLoad) TuningSet {
+	return &timeLimitedLoad{
+		params: params,
+	}
+}
+
+func (t *timeLimitedLoad) Execute(actions []func()) {
+	sleepDuration := time.Duration(t.params.TimeLimit.Nanoseconds() / int64(len(actions)))
+	var wg wait.Group
+	for i := range actions {
+		wg.Start(actions[i])
+		time.Sleep(sleepDuration)
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
Two new tuning sets added:
- TimeLimitedLoad
Spreads action evenly over given time.
- RandomizedTimeLimitedLoad
Runs each action at random point of time (within given time limit).