### PR TITLE
ClusterLoader - Reimplementing wait for controlled pods measurement

### DIFF
--- a/clusterloader2/pkg/measurement/common/wait_for_controlled_pods.go
+++ b/clusterloader2/pkg/measurement/common/wait_for_controlled_pods.go
@@ -24,7 +24,6 @@ package common
 import (
 	"fmt"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/golang/glog"
@@ -32,15 +31,19 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
 	"k8s.io/perf-tests/clusterloader2/pkg/measurement"
 	"k8s.io/perf-tests/clusterloader2/pkg/measurement/util/runtimeobjects"
 	"k8s.io/perf-tests/clusterloader2/pkg/util"
 )
 
 const (
-	defaultWaitForRCPodsTimeout      = 60 * time.Second
-	defaultWaitForRCPodsInterval     = 5 * time.Second
+	defaultSyncTimeout               = 60 * time.Second
+	defaultOperationTimeout          = 10 * time.Minute
+	checkControlledPodsInterval      = 5 * time.Second
 	waitForControlledPodsRunningName = "WaitForControlledPodsRunning"
+	waitForControlledPodsWorkers     = 10
 )
 
 func init() {
@@ -48,99 +51,365 @@ func init() {
 }
 
 func createWaitForControlledPodsRunningMeasurement() measurement.Measurement {
-	return &waitForControlledPodsRunningMeasurement{}
+	return &waitForControlledPodsRunningMeasurement{
+		queue:      workqueue.New(),
+		checkerMap: make(map[string]*objectChecker),
+	}
 }
 
-type waitForControlledPodsRunningMeasurement struct{}
+type waitForControlledPodsRunningMeasurement struct {
+	informer          cache.SharedInformer
+	kind              string
+	namespace         string
+	labelSelector     string
+	fieldSelector     string
+	operationTimeout  time.Duration
+	stopCh            chan struct{}
+	isRunning         bool
+	queue             workqueue.Interface
+	workerGroup       wait.Group
+	handlingGroup     wait.Group
+	lock              sync.Mutex
+	opResourceVersion uint64
+	checkerMap        map[string]*objectChecker
+}
 
-// Execute waits until all specified RCs have all pods running or until timeout happens.
-// RCs can be specified by field and/or label selectors.
+// Execute waits until all specified controlling objects have all pods running or until timeout happens.
+// Controlling objects can be specified by field and/or label selectors.
 // If namespace is not passed by parameter, all-namespace scope is assumed.
-func (*waitForControlledPodsRunningMeasurement) Execute(config *measurement.MeasurementConfig) ([]measurement.Summary, error) {
+// "Start" action starts observation of the controlling objects, while "gather" waits for until
+// specified number of controlling objects have all pods running.
+func (w *waitForControlledPodsRunningMeasurement) Execute(config *measurement.MeasurementConfig) ([]measurement.Summary, error) {
 	var summaries []measurement.Summary
-	kind, err := util.GetString(config.Params, "kind")
-	if err != nil {
-		return summaries, err
-	}
-	namespace, err := util.GetStringOrDefault(config.Params, "namespace", metav1.NamespaceAll)
-	if err != nil {
-		return summaries, err
-	}
-	labelSelector, err := util.GetStringOrDefault(config.Params, "labelSelector", "")
-	if err != nil {
-		return summaries, err
-	}
-	fieldSelector, err := util.GetStringOrDefault(config.Params, "fieldSelector", "")
-	if err != nil {
-		return summaries, err
-	}
-	timeout, err := util.GetDurationOrDefault(config.Params, "timeout", defaultWaitForRCPodsTimeout)
+	action, err := util.GetString(config.Params, "action")
 	if err != nil {
 		return summaries, err
 	}
 
-	runtimeObjectsList, err := runtimeobjects.ListRuntimeObjectsForKind(config.ClientSet, kind, namespace, labelSelector, fieldSelector)
-	if err != nil {
-		return summaries, err
-	}
-	var wg wait.Group
-	errList := util.NewErrorList()
-	var runningRuntimeObjects int32
-	for objectCounter := 0; objectCounter < len(runtimeObjectsList); objectCounter++ {
-		objectIndex := objectCounter
-		wg.Start(func() {
-			if err := waitForRuntimeObject(config.ClientSet, runtimeObjectsList[objectIndex], timeout); err != nil {
-				errList.Append(fmt.Errorf("waiting for %v error: %v", kind, err))
-				return
-			}
-
-			atomic.AddInt32(&runningRuntimeObjects, 1)
-			objName, err := runtimeobjects.GetNameFromRuntimeObject(runtimeObjectsList[objectIndex])
-			if err != nil {
-				errList.Append(fmt.Errorf("reading object name error: %v", err))
-				return
-			}
-			objNamespace, err := runtimeobjects.GetNamespaceFromRuntimeObject(runtimeObjectsList[objectIndex])
-			if err != nil {
-				errList.Append(fmt.Errorf("reading object namespace error: %v", err))
-				return
-			}
-			glog.Infof("%s: %s (%s) has all pods running", waitForControlledPodsRunningName, objName, objNamespace)
-		})
-	}
-	wg.Wait()
-
-	if int(runningRuntimeObjects) == len(runtimeObjectsList) {
-		glog.Infof("%s: %d / %d %ss are running with all pods", waitForControlledPodsRunningName, runningRuntimeObjects, len(runtimeObjectsList), kind)
+	switch action {
+	case "start":
+		w.kind, err = util.GetString(config.Params, "kind")
+		if err != nil {
+			return summaries, err
+		}
+		w.namespace, err = util.GetStringOrDefault(config.Params, "namespace", metav1.NamespaceAll)
+		if err != nil {
+			return summaries, err
+		}
+		w.labelSelector, err = util.GetStringOrDefault(config.Params, "labelSelector", "")
+		if err != nil {
+			return summaries, err
+		}
+		w.fieldSelector, err = util.GetStringOrDefault(config.Params, "fieldSelector", "")
+		if err != nil {
+			return summaries, err
+		}
+		w.operationTimeout, err = util.GetDurationOrDefault(config.Params, "operationTimeout", defaultOperationTimeout)
+		if err != nil {
+			return summaries, err
+		}
+		return summaries, w.start(config.ClientSet)
+	case "gather":
+		syncTimeout, err := util.GetDurationOrDefault(config.Params, "syncTimeout", defaultSyncTimeout)
+		if err != nil {
+			return summaries, err
+		}
+		return summaries, w.gather(config.ClientSet, syncTimeout)
+	case "stop":
+		w.stop()
 		return summaries, nil
+	default:
+		return summaries, fmt.Errorf("unknown action %v", action)
 	}
-	return summaries, fmt.Errorf("error while waiting for %ss to be running in namespace '%v' with labels '%v' and fields '%v' - only %d found running with all pods: %v",
-		kind, namespace, labelSelector, fieldSelector, runningRuntimeObjects, errList.String())
 }
 
-func waitForRuntimeObject(c clientset.Interface, obj runtime.Object, timeout time.Duration) error {
-	runtimeObjectNamespace, err := runtimeobjects.GetNamespaceFromRuntimeObject(obj)
+// String returns a string representation of the metric.
+func (*waitForControlledPodsRunningMeasurement) String() string {
+	return waitForControlledPodsRunningName
+}
+
+func (w *waitForControlledPodsRunningMeasurement) start(c clientset.Interface) error {
+	if w.informer != nil {
+		glog.Infof("%v: wait for controlled pods measurement already running", w)
+		return nil
+	}
+	glog.Infof("%v: starting wait for controlled pods measurement...", w)
+	optionsModifier := func(options *metav1.ListOptions) {
+		options.FieldSelector = w.fieldSelector
+		options.LabelSelector = w.labelSelector
+	}
+	listerWatcher := cache.NewFilteredListWatchFromClient(c.CoreV1().RESTClient(), w.kind+"s", w.namespace, optionsModifier)
+	w.isRunning = true
+	w.stopCh = make(chan struct{})
+	w.informer = cache.NewSharedInformer(listerWatcher, nil, 0)
+	w.informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			addF := func() {
+				w.handleObject(c, nil, obj)
+			}
+			w.queue.Add(&addF)
+		},
+		UpdateFunc: func(oldObj, newObj interface{}) {
+			updateF := func() {
+				w.handleObject(c, oldObj, newObj)
+			}
+			w.queue.Add(&updateF)
+		},
+		DeleteFunc: func(obj interface{}) {
+			deleteF := func() {
+				w.handleObject(c, obj, nil)
+			}
+			w.queue.Add(&deleteF)
+		},
+	})
+
+	for i := 0; i < waitForControlledPodsWorkers; i++ {
+		w.workerGroup.Start(w.worker)
+	}
+	go w.informer.Run(w.stopCh)
+	timeoutCh := make(chan struct{})
+	timeoutTimer := time.AfterFunc(informerSyncTimeout, func() {
+		close(timeoutCh)
+	})
+	defer timeoutTimer.Stop()
+	if !cache.WaitForCacheSync(timeoutCh, w.informer.HasSynced) {
+		return fmt.Errorf("timed out waiting for caches to sync")
+	}
+
+	return nil
+}
+
+func (w *waitForControlledPodsRunningMeasurement) worker() {
+	for {
+		f, stop := w.queue.Get()
+		if stop {
+			return
+		}
+		(*f.(*func()))()
+		w.queue.Done(f)
+	}
+}
+
+func (w *waitForControlledPodsRunningMeasurement) gather(c clientset.Interface, syncTimeout time.Duration) error {
+	glog.Infof("%v: waiting for controlled pods measurement...", w)
+	if w.informer == nil {
+		return fmt.Errorf("metric %s has not been started", w)
+	}
+	desiredCount, maxResourceVersion, err := w.getObjectCountAndMaxVersion(c)
 	if err != nil {
 		return err
+	}
+
+	cond := func() (bool, error) {
+		return w.opResourceVersion >= maxResourceVersion, nil
+	}
+	if err := wait.Poll(checkControlledPodsInterval, syncTimeout, cond); err != nil {
+		return fmt.Errorf("timed out while waiting for controlled pods")
+	}
+
+	w.handlingGroup.Wait()
+	w.lock.Lock()
+	defer w.lock.Unlock()
+	numberRunning := 0
+	for _, checker := range w.checkerMap {
+		if status := checker.getStatus(); status {
+			numberRunning++
+		}
+	}
+	if desiredCount != numberRunning {
+		glog.Errorf("%s: incorrect objects number: %d/%d %ss are running with all pods", w, numberRunning, desiredCount, w.kind)
+		return fmt.Errorf("incorrect objects number")
+	}
+
+	glog.Infof("%s: %d/%d %ss are running with all pods", w, numberRunning, desiredCount, w.kind)
+	return nil
+}
+
+func (w *waitForControlledPodsRunningMeasurement) stop() {
+	close(w.stopCh)
+	w.queue.ShutDown()
+	w.workerGroup.Wait()
+	w.lock.Lock()
+	defer w.lock.Unlock()
+	w.isRunning = false
+	for _, checker := range w.checkerMap {
+		checker.terminate()
+	}
+}
+
+func (w *waitForControlledPodsRunningMeasurement) handleObject(c clientset.Interface, oldObj, newObj interface{}) {
+	var oldRuntimeObj runtime.Object
+	var newRuntimeObj runtime.Object
+	var ok bool
+	oldRuntimeObj, ok = oldObj.(runtime.Object)
+	if oldObj != nil && !ok {
+		glog.Errorf("%s: uncastable old object: %v", w, oldObj)
+		return
+	}
+	newRuntimeObj, ok = newObj.(runtime.Object)
+	if newObj != nil && !ok {
+		glog.Errorf("%s: uncastable new object: %v", w, newObj)
+		return
+	}
+	defer func() {
+		// We want to update version after (potentially) creating goroutine.
+		if err := w.updateOpResourceVersion(oldRuntimeObj); err != nil {
+			glog.Errorf("%s: updating resource version error: %v", w, err)
+		}
+		if err := w.updateOpResourceVersion(newRuntimeObj); err != nil {
+			glog.Errorf("%s: updating resource version error: %v", w, err)
+		}
+	}()
+	isEqual, err := runtimeobjects.IsEqualRuntimeObjectsSpec(oldRuntimeObj, newRuntimeObj)
+	if err != nil {
+		glog.Errorf("%s: comparing specs error: %v", w, err)
+		return
+	}
+	if isEqual {
+		// Skip updates without changes in the spec.
+		return
+	}
+
+	w.lock.Lock()
+	defer w.lock.Unlock()
+	if !w.isRunning {
+		return
+	}
+
+	if err := w.deleteObjectLocked(c, oldRuntimeObj); err != nil {
+		glog.Errorf("%s: delete checker error: %v", w, err)
+	} else if newRuntimeObj == nil {
+		key, err := runtimeobjects.CreateMetaNamespaceKey(oldRuntimeObj)
+		if err != nil {
+			glog.Errorf("%s: meta key creation error: %v", w, err)
+			return
+		}
+		glog.Infof("%s: %v has been deleted", w, key)
+	}
+	if err := w.createObjectLocked(c, newRuntimeObj); err != nil {
+		glog.Errorf("%s: create checker error: %v", w, err)
+	}
+}
+
+func (w *waitForControlledPodsRunningMeasurement) createObjectLocked(c clientset.Interface, obj runtime.Object) error {
+	if obj == nil {
+		return nil
+	}
+	key, err := runtimeobjects.CreateMetaNamespaceKey(obj)
+	if err != nil {
+		return fmt.Errorf("meta key creation error: %v", err)
+	}
+	checker, err := w.waitForRuntimeObject(c, obj)
+	if err != nil {
+		return fmt.Errorf("waiting for %v error: %v", key, err)
+	}
+	time.AfterFunc(w.operationTimeout, func() {
+		checker.terminate()
+	})
+	w.checkerMap[key] = checker
+	return nil
+}
+
+func (w *waitForControlledPodsRunningMeasurement) deleteObjectLocked(c clientset.Interface, obj runtime.Object) error {
+	if obj == nil {
+		return nil
+	}
+	key, err := runtimeobjects.CreateMetaNamespaceKey(obj)
+	if err != nil {
+		return fmt.Errorf("meta key creation error: %v", err)
+	}
+	if checker, exists := w.checkerMap[key]; exists {
+		checker.terminate()
+		delete(w.checkerMap, key)
+	}
+	return nil
+}
+
+func (w *waitForControlledPodsRunningMeasurement) updateOpResourceVersion(runtimeObj runtime.Object) error {
+	if runtimeObj == nil {
+		return nil
+	}
+	version, err := runtimeobjects.GetResourceVersionFromRuntimeObject(runtimeObj)
+	if err != nil {
+		return fmt.Errorf("retriving resource version error: %v", err)
+	}
+	w.lock.Lock()
+	defer w.lock.Unlock()
+	if version > w.opResourceVersion {
+		w.opResourceVersion = version
+	}
+	return nil
+}
+
+// getObjectCountAndMaxVersion returns number of objects that satisfy measurements parameters
+// and maximal resource version of these objects.
+// These two values allow to properly handle all object operations:
+// - When create/delete operation are called we expect the exact number of objects.
+// - When objects is updated we expect to receive event referencing this specific version.
+//   Using maximum from objects resource versions assures that all updates will be processed.
+func (w *waitForControlledPodsRunningMeasurement) getObjectCountAndMaxVersion(c clientset.Interface) (int, uint64, error) {
+	var desiredCount int
+	var maxResourceVersion uint64
+	objects, err := runtimeobjects.ListRuntimeObjectsForKind(c, w.kind, w.namespace, w.labelSelector, w.fieldSelector)
+	if err != nil {
+		return desiredCount, maxResourceVersion, fmt.Errorf("listing objects error: %v", err)
+	}
+
+	for i := range objects {
+		runtimeObj, ok := objects[i].(runtime.Object)
+		if !ok {
+			glog.Errorf("%s: cannot cast to runtime.Object: %v", objects[i])
+			continue
+		}
+		version, err := runtimeobjects.GetResourceVersionFromRuntimeObject(runtimeObj)
+		if err != nil {
+			glog.Errorf("%s: retriving resource version error: %v", w, err)
+			continue
+		}
+		desiredCount++
+		if version > maxResourceVersion {
+			maxResourceVersion = version
+		}
+	}
+	return desiredCount, maxResourceVersion, nil
+}
+
+func (w *waitForControlledPodsRunningMeasurement) waitForRuntimeObject(clientSet clientset.Interface, obj runtime.Object) (*objectChecker, error) {
+	runtimeObjectNamespace, err := runtimeobjects.GetNamespaceFromRuntimeObject(obj)
+	if err != nil {
+		return nil, err
 	}
 	runtimeObjectSelector, err := runtimeobjects.GetSelectorFromRuntimeObject(obj)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	runtimeObjectReplicas, err := runtimeobjects.GetReplicasFromRuntimeObject(obj)
 	if err != nil {
-		return err
+		return nil, err
+	}
+	key, err := runtimeobjects.CreateMetaNamespaceKey(obj)
+	if err != nil {
+		return nil, fmt.Errorf("meta key creation error: %v", err)
 	}
 
-	stopCh := make(chan struct{})
-	time.AfterFunc(timeout, func() {
-		close(stopCh)
+	o := newObjectCheker()
+	o.lock.Lock()
+	defer o.lock.Unlock()
+	w.handlingGroup.Start(func() {
+		err = waitForPods(clientSet, runtimeObjectNamespace, runtimeObjectSelector.String(), "", int(runtimeObjectReplicas), o.stopCh, false)
+		o.lock.Lock()
+		defer o.lock.Unlock()
+		if err != nil {
+			if o.isRunning {
+				// Log error only if checker wasn't terminated.
+				glog.Errorf("%s: error for %v: %v", w, key, err)
+			}
+			return
+		}
+		glog.Infof("%s: %v has all pods (%d) running", w, key, runtimeObjectReplicas)
+		o.status = true
 	})
-	err = waitForPods(c, runtimeObjectNamespace, runtimeObjectSelector.String(), "", int(runtimeObjectReplicas), stopCh, false)
-	if err != nil {
-		return fmt.Errorf("waiting pods error: %v", err)
-	}
-	return nil
+	return o, nil
 }
 
 type objectChecker struct {

--- a/clusterloader2/testing/load/config.yaml
+++ b/clusterloader2/testing/load/config.yaml
@@ -38,6 +38,14 @@ steps:
     Params:
       action: reset
 # Create RCs
+- measurements:
+  - Identifier: WaitForRunningRCs
+    Method: WaitForControlledPodsRunning
+    Params:
+      action: start
+      kind: ReplicationController
+      labelSelector: kind = loadRC
+      operationTimeout: 10m
 - phases:
   - namespaceRange:
       min: 1
@@ -88,10 +96,7 @@ steps:
   - Identifier: WaitForRunningRCs
     Method: WaitForControlledPodsRunning
     Params:
-      kind: ReplicationController
-      labelSelector: kind = loadRC
-      # timeout = (totalPodsRounded /20)s + 3m
-      timeout: {{DivideInt $totalPodsRounded 20 | AddInt 180}}s
+      action: gather
 - name: Creating RCs
 # Scale RCs
 - phases:
@@ -99,7 +104,7 @@ steps:
       min: 1
       max: {{$namespaces}}
     replicasPerNamespace: {{$bigRCsPerNamespace}}
-    tuningSet: AvgSaturationQPS
+    tuningSet: AvgScalingQPS
     objectBundle:
     - basename: big-rc
       objectTemplatePath: rc.yaml
@@ -110,7 +115,7 @@ steps:
       min: 1
       max: {{$namespaces}}
     replicasPerNamespace: {{$mediumRCsPerNamespace}}
-    tuningSet: AvgSaturationQPS
+    tuningSet: AvgScalingQPS
     objectBundle:
     - basename: medium-rc
       objectTemplatePath: rc.yaml
@@ -121,7 +126,7 @@ steps:
       min: 1
       max: {{$namespaces}}
     replicasPerNamespace: {{$smallRCsPerNamespace}}
-    tuningSet: AvgSaturationQPS
+    tuningSet: AvgScalingQPS
     objectBundle:
     - basename: small-rc
       objectTemplatePath: rc.yaml
@@ -129,12 +134,10 @@ steps:
         ReplicasMin: {{MultiplyInt $SMALL_GROUP_SIZE 0.5}}
         ReplicasMax: {{MultiplyInt $SMALL_GROUP_SIZE 1.5}}
 - measurements:
-  - Identifier: WaitForScaledRCsRunning
+  - Identifier: WaitForRunningRCs
     Method: WaitForControlledPodsRunning
     Params:
-      kind: ReplicationController
-      labelSelector: kind = loadRC
-      timeout: 10m
+      action: gather
 - name: Scaling RCs
 # Delete RCs
 - phases:
@@ -169,6 +172,16 @@ steps:
     - basename: small-rc
       objectTemplatePath: rc.yaml
 - name: Deleting RCs
+- measurements:
+  - Identifier: WaitForRunningRCs
+    Method: WaitForControlledPodsRunning
+    Params:
+      action: gather
+- measurements:
+  - Identifier: WaitForRunningRCs
+    Method: WaitForControlledPodsRunning
+    Params:
+      action: stop
 - measurements:
   - Identifier: APIResponsiveness
     Method: APIResponsiveness


### PR DESCRIPTION
Reimplementing wait for controlled pods measurement. Now it support two actions:
- start - starts to observe the controlling objects.
- gather - waits for objects to have all pods running.
- stop - stops the observation.

Minor changes:
- parallel group that limits number of routines running in parallel added.
- `waitForPods` has stop channel. Timeouts should be handled by the caller.