### PR TITLE
ClusterLoader - Adding resources versions state

### DIFF
--- a/clusterloader2/pkg/state/namespaces_state.go
+++ b/clusterloader2/pkg/state/namespaces_state.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package state
+
+import (
+	"fmt"
+	"sync"
+
+	"k8s.io/perf-tests/clusterloader2/api"
+)
+
+// InstancesState represents state of object replicas.
+type InstancesState struct {
+	DesiredReplicaCount int32
+	CurrentReplicaCount int32
+	Object              api.Object
+}
+
+// InstancesIdentifier is a unique identifier for object replicas group
+type InstancesIdentifier struct {
+	Basename   string
+	ObjectKind string
+	ApiGroup   string
+}
+
+// namespaceState represents state of a single namespace.
+type namespaceState map[InstancesIdentifier]*InstancesState
+
+// namespacesState represents state of all used namespaces.
+type namespacesState struct {
+	lock            sync.RWMutex
+	namespaceStates map[string]namespaceState
+}
+
+// newNamespacesState creates new namsepaces state.
+func newNamespacesState() *namespacesState {
+	return &namespacesState{
+		namespaceStates: make(map[string]namespaceState),
+	}
+}
+
+// Get returns state of object instances -
+// number of existing replicas and its configuration.
+func (ns *namespacesState) Get(namespace string, identifier InstancesIdentifier) (*InstancesState, bool) {
+	ns.lock.RLock()
+	defer ns.lock.RUnlock()
+	namespaceState, exists := ns.namespaceStates[namespace]
+	if !exists {
+		return nil, false
+	}
+	instances, exists := namespaceState[identifier]
+	return instances, exists
+}
+
+// Set stores information about object instances state
+// to test state.
+func (ns *namespacesState) Set(namespace string, identifier InstancesIdentifier, instances *InstancesState) {
+	ns.lock.Lock()
+	defer ns.lock.Unlock()
+	_, exists := ns.namespaceStates[namespace]
+	if !exists {
+		ns.namespaceStates[namespace] = make(namespaceState)
+	}
+	ns.namespaceStates[namespace][identifier] = instances
+}
+
+// Delete removes information about given instances.
+// It there is no information for given object it is assumed that
+// there are no object replicas.
+func (ns *namespacesState) Delete(namespace string, identifier InstancesIdentifier) error {
+	ns.lock.Lock()
+	defer ns.lock.Unlock()
+	namespaceState, exists := ns.namespaceStates[namespace]
+	if !exists {
+		return fmt.Errorf("namespace %v not found", namespace)
+	}
+	_, exists = namespaceState[identifier]
+	if !exists {
+		return fmt.Errorf("no instances of %+v found in %v namespace", identifier, namespace)
+	}
+	delete(namespaceState, identifier)
+	return nil
+}

--- a/clusterloader2/pkg/state/resource_state.go
+++ b/clusterloader2/pkg/state/resource_state.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package state
+
+import (
+	"fmt"
+	"strconv"
+	"sync"
+)
+
+// ResourceTypeIdentifier is a unique identifier for a resource type.
+type ResourceTypeIdentifier struct {
+	ObjectKind string
+	ApiGroup   string
+}
+
+// resourcesVersionsState represents most recent resources versions for a given object types.
+// These versions are available only for resource types of objects that were create/updated
+// by the clusterloader.
+type resourcesVersionsState struct {
+	lock              sync.RWMutex
+	resourcesVersions map[ResourceTypeIdentifier]uint64
+}
+
+// newResourcesVersionState creates new resources versions state.
+func newResourcesVersionsState() *resourcesVersionsState {
+	return &resourcesVersionsState{
+		resourcesVersions: make(map[ResourceTypeIdentifier]uint64),
+	}
+}
+
+// Get returns state of current resource version.
+func (rs *resourcesVersionsState) Get(identifier ResourceTypeIdentifier) (string, bool) {
+	rs.lock.RLock()
+	defer rs.lock.RUnlock()
+	version, exists := rs.resourcesVersions[identifier]
+	if !exists {
+		return "0", false
+	}
+	return strconv.FormatUint(version, 10), true
+}
+
+// Set stores information about current resource version.
+func (rs *resourcesVersionsState) Set(identifier ResourceTypeIdentifier, resourceVersion string) error {
+	rs.lock.Lock()
+	defer rs.lock.Unlock()
+	version, err := strconv.ParseUint(resourceVersion, 10, 64)
+	if err != nil {
+		return fmt.Errorf("incorrect version format")
+	}
+	if current, exists := rs.resourcesVersions[identifier]; exists && current > version {
+		version = current
+	}
+	rs.resourcesVersions[identifier] = version
+	return nil
+}

--- a/clusterloader2/pkg/state/state.go
+++ b/clusterloader2/pkg/state/state.go
@@ -16,82 +16,27 @@ limitations under the License.
 
 package state
 
-import (
-	"fmt"
-	"sync"
-
-	"k8s.io/perf-tests/clusterloader2/api"
-)
-
-// InstancesState represents state of object replicas.
-type InstancesState struct {
-	DesiredReplicaCount int32
-	CurrentReplicaCount int32
-	Object              api.Object
+// State is a state of the cluster.
+// It is composed of namespaces state and resources versions state.
+type State struct {
+	namespacesState       *namespacesState
+	resourcesVersionState *resourcesVersionsState
 }
 
-// InstancesIdentifier is a unique identifier for object replicas group
-type InstancesIdentifier struct {
-	Basename   string
-	ObjectKind string
-	ApiGroup   string
-}
-
-// namespaceState represents state of a single namespace.
-type namespaceState map[InstancesIdentifier]*InstancesState
-
-// NamespacesState represents state of all used namespaces.
-type NamespacesState struct {
-	lock            sync.RWMutex
-	namespacesState map[string]namespaceState
-}
-
-// NewNamespacesState creates new namsepaces state.
-func NewNamespacesState() *NamespacesState {
-	return &NamespacesState{
-		namespacesState: make(map[string]namespaceState),
+// NewState creates new State instance.
+func NewState() *State {
+	return &State{
+		namespacesState:       newNamespacesState(),
+		resourcesVersionState: newResourcesVersionsState(),
 	}
 }
 
-// Get returns state of object instances -
-// number of existing replicas and its configuration.
-func (ns *NamespacesState) Get(namespace string, identifier InstancesIdentifier) (*InstancesState, bool) {
-	ns.lock.RLock()
-	defer ns.lock.RUnlock()
-	namespaceState, exists := ns.namespacesState[namespace]
-	if !exists {
-		return nil, false
-	}
-	instances, exists := namespaceState[identifier]
-	return instances, exists
+// GetNamespacesState returns namespaces state.
+func (s *State) GetNamespacesState() *namespacesState {
+	return s.namespacesState
 }
 
-// Set stores information about object instances state
-// to test state.
-func (ns *NamespacesState) Set(namespace string, identifier InstancesIdentifier, instances *InstancesState) {
-	ns.lock.Lock()
-	defer ns.lock.Unlock()
-	_, exists := ns.namespacesState[namespace]
-	if !exists {
-		ns.namespacesState[namespace] = make(namespaceState)
-	}
-	ns.namespacesState[namespace][identifier] = instances
-}
-
-// Delete removes information about given instances.
-// It there is no information for given object it is assumed that
-// there are no object replicas.
-func (ns *NamespacesState) Delete(namespace string, identifier InstancesIdentifier) error {
-	ns.lock.Lock()
-	defer ns.lock.Unlock()
-	namespaceState, exists := ns.namespacesState[namespace]
-	if !exists {
-		return fmt.Errorf("namespace %v not found", namespace)
-	}
-	_, exists = namespaceState[identifier]
-	if !exists {
-		return fmt.Errorf("no instances of %+v found in %v namespace", identifier, namespace)
-	}
-	delete(namespaceState, identifier)
-	return nil
+// GetResourcesVersionState returns resources versions state.
+func (s *State) GetResourcesVersionState() *resourcesVersionsState {
+	return s.resourcesVersionState
 }

--- a/clusterloader2/pkg/test/interface.go
+++ b/clusterloader2/pkg/test/interface.go
@@ -27,7 +27,7 @@ import (
 )
 
 // CreatContextFunc a type for function that creates Context based on given framework client and state.
-type CreatContextFunc func(c *config.ClusterLoaderConfig, f *framework.Framework, s *state.NamespacesState) Context
+type CreatContextFunc func(c *config.ClusterLoaderConfig, f *framework.Framework, s *state.State) Context
 
 // OperationType is a type of operation to be performed on an object.
 type OperationType int
@@ -47,7 +47,7 @@ const (
 type Context interface {
 	GetClusterLoaderConfig() *config.ClusterLoaderConfig
 	GetFramework() *framework.Framework
-	GetState() *state.NamespacesState
+	GetState() *state.State
 	GetTemplateProvider() *config.TemplateProvider
 	GetTuningSetFactory() tuningset.TuningSetFactory
 	GetMeasurementManager() *measurement.MeasurementManager

--- a/clusterloader2/pkg/test/simple_context.go
+++ b/clusterloader2/pkg/test/simple_context.go
@@ -29,13 +29,13 @@ import (
 type simpleContext struct {
 	clusterLoaderConfig *config.ClusterLoaderConfig
 	framework           *framework.Framework
-	state               *state.NamespacesState
+	state               *state.State
 	templateProvider    *config.TemplateProvider
 	tuningSetFactory    tuningset.TuningSetFactory
 	measurementManager  *measurement.MeasurementManager
 }
 
-func createSimpleContext(c *config.ClusterLoaderConfig, f *framework.Framework, s *state.NamespacesState) Context {
+func createSimpleContext(c *config.ClusterLoaderConfig, f *framework.Framework, s *state.State) Context {
 	return &simpleContext{
 		clusterLoaderConfig: c,
 		framework:           f,
@@ -57,7 +57,7 @@ func (sc *simpleContext) GetFramework() *framework.Framework {
 }
 
 // GetState returns current test state.
-func (sc *simpleContext) GetState() *state.NamespacesState {
+func (sc *simpleContext) GetState() *state.State {
 	return sc.state
 }
 

--- a/clusterloader2/pkg/test/simple_test_executor.go
+++ b/clusterloader2/pkg/test/simple_test_executor.go
@@ -145,7 +145,7 @@ func (ste *simpleTestExecutor) ExecutePhase(ctx Context, phase *api.Phase) *util
 				errList.Append(err)
 				return errList
 			}
-			instances, exists := ctx.GetState().Get(nsName, id)
+			instances, exists := ctx.GetState().GetNamespacesState().Get(nsName, id)
 			if !exists {
 				instances = &state.InstancesState{
 					DesiredReplicaCount: 0,
@@ -154,7 +154,7 @@ func (ste *simpleTestExecutor) ExecutePhase(ctx Context, phase *api.Phase) *util
 				}
 			}
 			instances.DesiredReplicaCount = phase.ReplicasPerNamespace
-			ctx.GetState().Set(nsName, id, instances)
+			ctx.GetState().GetNamespacesState().Set(nsName, id, instances)
 			instancesStates = append(instancesStates, instances)
 		}
 
@@ -219,7 +219,7 @@ func (ste *simpleTestExecutor) ExecutePhase(ctx Context, phase *api.Phase) *util
 			for j := range phase.ObjectBundle {
 				id, _ := getIdentifier(ctx, &phase.ObjectBundle[j])
 				instancesStates[j].CurrentReplicaCount = instancesStates[j].DesiredReplicaCount
-				ctx.GetState().Set(nsName, id, instancesStates[j])
+				ctx.GetState().GetNamespacesState().Set(nsName, id, instancesStates[j])
 			}
 		}()
 

--- a/clusterloader2/pkg/test/test.go
+++ b/clusterloader2/pkg/test/test.go
@@ -63,7 +63,7 @@ func RunTest(f *framework.Framework, clusterLoaderConfig *config.ClusterLoaderCo
 		}
 	}
 
-	ctx := CreateContext(clusterLoaderConfig, f, state.NewNamespacesState())
+	ctx := CreateContext(clusterLoaderConfig, f, state.NewState())
 	testConfigFilename := filepath.Base(clusterLoaderConfig.TestConfigPath)
 	mapping := map[string]interface{}{"Nodes": clusterLoaderConfig.ClusterConfig.Nodes}
 	testConfig, err := ctx.GetTemplateProvider().TemplateToConfig(testConfigFilename, mapping)


### PR DESCRIPTION
- Adding resources versions state
This is a map {apiVersion, Kind} -> {resourceVersion}
File `pkg/state/resource_state.go`.
- Adding state that contains both namespaces state (previous state) and resources versions state
Files: `pkg/state/state.go`, `pkg/state/namespaces_state.go`.
- Applying changes
Files: all not listed above.