### PR TITLE
Perfdash - Dropping old callbacks

### DIFF
--- a/perfdash/Makefile
+++ b/perfdash/Makefile
@@ -1,7 +1,7 @@
 all: push
 
 # See pod.yaml for the version currently running-- bump this ahead before rebuilding!
-TAG = 1.10
+TAG = 1.11
 
 REPO = gcr.io/k8s-testimages
 

--- a/perfdash/deployment.yaml
+++ b/perfdash/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: default
   labels:
     app: perfdash
-    version: "1.10"
+    version: "1.11"
 spec:
   selector:
     matchLabels:
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: perfdash
-        image: gcr.io/k8s-testimages/perfdash:1.10
+        image: gcr.io/k8s-testimages/perfdash:1.11
         command:
           - /perfdash
           -   --www=true

--- a/perfdash/www/script.js
+++ b/perfdash/www/script.js
@@ -22,6 +22,7 @@ var PerfDashApp = function(http, scope) {
     this.metricNames = [];
     this.onClick = this.onClickInternal_.bind(this);
     this.cap = 0;
+    this.currentCall = 0;
 };
 
 
@@ -90,8 +91,12 @@ PerfDashApp.prototype.metricCategoryNameChanged = function() {
 
 // Update the data to graph, using the selected metricName
 PerfDashApp.prototype.metricNameChanged = function() {
+    var callId = ++this.currentCall;
     this.http.get("buildsdata", {params: {jobname: this.jobName, metriccategoryname: this.metricCategoryName, metricname: this.metricName}})
             .success(function(data) {
+                    if (this.currentCall != callId) {
+                            return;
+                    }
                     this.data = data.builds;
                     this.job = data.job;
                     this.builds = this.getBuilds();


### PR DESCRIPTION
This is a handling for:
1. Requesting metric X
2. Requesting metric Y
3. Getting response Y. Drawing chart for Y.
4. Getting response X (due to X taking longer than Y). Drawing chart for X.

Point 4. is wrong. It should just omit the stale response.