### PR TITLE
Fix some typos

### DIFF
--- a/clusterloader/framework/util.go
+++ b/clusterloader/framework/util.go
@@ -92,7 +92,7 @@ func (cl *ClusterLoaderObject) ParseConfig() (*v1.Pod, error) {
 	return pod, nil
 }
 
-// MakePath returns fully qualfied file location as a string
+// MakePath returns fully qualified file location as a string
 func MakePath(file string) string {
 	// Handle an empty filename.
 	if file == "" {

--- a/clusterloader2/pkg/measurement/util/perftype.go
+++ b/clusterloader2/pkg/measurement/util/perftype.go
@@ -25,7 +25,7 @@ package util
 // DataItem is the data point.
 type DataItem struct {
 	// Data is a map from bucket to real data point (e.g. "Perc90" -> 23.5). Notice
-	// that all data items with the same label conbination should have the same buckets.
+	// that all data items with the same label combination should have the same buckets.
 	Data map[string]float64 `json:"data"`
 	// Unit is the data unit. Notice that all data items with the same label combination
 	// should have the same unit.

--- a/clusterloader2/pkg/state/namespaces_state.go
+++ b/clusterloader2/pkg/state/namespaces_state.go
@@ -46,7 +46,7 @@ type namespacesState struct {
 	namespaceStates map[string]namespaceState
 }
 
-// newNamespacesState creates new namsepaces state.
+// newNamespacesState creates new namespaces state.
 func newNamespacesState() *namespacesState {
 	return &namespacesState{
 		namespaceStates: make(map[string]namespaceState),

--- a/slo-monitor/src/monitors/pod_monitor.go
+++ b/slo-monitor/src/monitors/pod_monitor.go
@@ -310,7 +310,7 @@ func (pm *PodStartupLatencyDataMonitor) insertPodRunningTime(podKey string, crea
 	var data PodStartupMilestones
 	var ok bool
 	if data, ok = pm.PodStartupData[podKey]; !ok {
-		// Necessary to work anywere except UTC time zone...
+		// Necessary to work anywhere except UTC time zone...
 		data.startedPulling = time.Unix(0, 0)
 		data.finishedPulling = time.Unix(0, 0)
 	}


### PR DESCRIPTION
Fix some typos in the below files:

1. clusterloader/framework/util.go
2. clusterloader2/pkg/measurement/util/perftype.go
3. clusterloader2/pkg/state/namespaces_state.go
4. slo-monitor/src/monitors/pod_monitor.go