### PR TITLE
ClusterLoader - Adding metric violation error

### DIFF
--- a/clusterloader2/pkg/measurement/common/api_responsiveness.go
+++ b/clusterloader2/pkg/measurement/common/api_responsiveness.go
@@ -83,7 +83,7 @@ func (*apiResponsivenessMeasurement) Execute(config *measurement.MeasurementConf
 			return summaries, err
 		}
 		summary, err := apiserverMetricsGather(config.ClientSet, nodeCount)
-		if err == nil {
+		if err == nil || measurement.IsMetricViolationError(err) {
 			summaries = append(summaries, summary)
 		}
 		return summaries, err
@@ -139,6 +139,9 @@ func apiserverMetricsGather(c clientset.Interface, nodeCount int) (measurement.S
 			}
 			glog.Infof("%vTop latency metric: %+v", prefix, metrics.ApiCalls[i])
 		}
+	}
+	if badMetrics > 0 {
+		return metrics, measurement.NewMetricViolationError("top latency metric", "there should be no high-latency requests")
 	}
 	return metrics, nil
 }

--- a/clusterloader2/pkg/measurement/errors.go
+++ b/clusterloader2/pkg/measurement/errors.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package measurement
+
+type metricViolationError struct {
+	metric string
+	reason string
+}
+
+func (m *metricViolationError) Error() string {
+	return m.metric + ": " + m.reason
+}
+
+// NewMetricViolationError creates new metric violation error.
+func NewMetricViolationError(metric, reason string) error {
+	return &metricViolationError{
+		metric: metric,
+		reason: reason,
+	}
+}
+
+// IsMetricViolationError checks if given error is MetricViolation type.
+func IsMetricViolationError(err error) bool {
+	_, ok := err.(*metricViolationError)
+	return ok
+}


### PR DESCRIPTION
Failing tests when api responsiveness metric is not satisfy.