### PR TITLE
ClusterLoader - Fixing test metrics bundle

### DIFF
--- a/clusterloader2/pkg/measurement/common/bundle/test_metrics.go
+++ b/clusterloader2/pkg/measurement/common/bundle/test_metrics.go
@@ -149,8 +149,9 @@ func createConfig(config *measurement.MeasurementConfig, overrides map[string]in
 		params[k] = v
 	}
 	return &measurement.MeasurementConfig{
-		ClientSet: config.ClientSet,
-		Params:    params,
+		ClientSet:     config.ClientSet,
+		ClusterConfig: config.ClusterConfig,
+		Params:        params,
 	}
 }
 


### PR DESCRIPTION
Setting `ClusterConfig` in test metric bundle, which is required by the metrics.