### PR TITLE
ClusterLoader - Updating pod startup measurement logs

### DIFF
--- a/clusterloader2/pkg/measurement/util/latency_metric.go
+++ b/clusterloader2/pkg/measurement/util/latency_metric.go
@@ -17,6 +17,7 @@ limitations under the License.
 package util
 
 import (
+	"fmt"
 	"time"
 )
 
@@ -38,4 +39,18 @@ func (metric *LatencyMetric) SetQuantile(quantile float64, latency time.Duration
 	case 0.99:
 		metric.Perc99 = latency
 	}
+}
+
+// VerifyThreshod verifies latency metric against given percentile thresholds.
+func (metric *LatencyMetric) VerifyThreshod(threshold *LatencyMetric) error {
+	if metric.Perc50 > threshold.Perc50 {
+		return fmt.Errorf("too high latency 50th percentile: %v", metric.Perc50)
+	}
+	if metric.Perc90 > threshold.Perc90 {
+		return fmt.Errorf("too high latency 90th percentile: %v", metric.Perc90)
+	}
+	if metric.Perc99 > threshold.Perc99 {
+		return fmt.Errorf("too high latency 99th percentile: %v", metric.Perc99)
+	}
+	return nil
 }


### PR DESCRIPTION
Added:
- failing when podStartupLatencyThreshold(5s) is not satisfied.
- logging pod latencies.

ref #293 