### PR TITLE
ClusterLoader - Moving errors to pkg/errors

### DIFF
--- a/clusterloader2/cmd/clusterloader.go
+++ b/clusterloader2/cmd/clusterloader.go
@@ -24,6 +24,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/spf13/pflag"
 	"k8s.io/perf-tests/clusterloader2/pkg/config"
+	"k8s.io/perf-tests/clusterloader2/pkg/errors"
 	"k8s.io/perf-tests/clusterloader2/pkg/framework"
 	"k8s.io/perf-tests/clusterloader2/pkg/test"
 	"k8s.io/perf-tests/clusterloader2/pkg/util"
@@ -44,8 +45,8 @@ func initClusterFlags() {
 	pflag.StringVar(&clusterLoaderConfig.ClusterConfig.Provider, "provider", "", "Cluster provider")
 }
 
-func validateClusterFlags() *util.ErrorList {
-	errList := util.NewErrorList()
+func validateClusterFlags() *errors.ErrorList {
+	errList := errors.NewErrorList()
 	if clusterLoaderConfig.ClusterConfig.KubeConfigPath == "" {
 		errList.Append(fmt.Errorf("no kubeconfig path specified"))
 	}
@@ -61,8 +62,8 @@ func initFlags() {
 	initClusterFlags()
 }
 
-func validateFlags() *util.ErrorList {
-	errList := util.NewErrorList()
+func validateFlags() *errors.ErrorList {
+	errList := errors.NewErrorList()
 	if len(testConfigPaths) < 1 {
 		errList.Append(fmt.Errorf("no test config path specified"))
 	}

--- a/clusterloader2/pkg/errors/error_list.go
+++ b/clusterloader2/pkg/errors/error_list.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package util
+package errors
 
 import (
 	"bytes"

--- a/clusterloader2/pkg/errors/metric_violation_error.go
+++ b/clusterloader2/pkg/errors/metric_violation_error.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package measurement
+package errors
 
 type metricViolationError struct {
 	metric string

--- a/clusterloader2/pkg/framework/framework.go
+++ b/clusterloader2/pkg/framework/framework.go
@@ -25,9 +25,9 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/dynamic"
 	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/perf-tests/clusterloader2/pkg/errors"
 	"k8s.io/perf-tests/clusterloader2/pkg/framework/client"
 	"k8s.io/perf-tests/clusterloader2/pkg/framework/config"
-	"k8s.io/perf-tests/clusterloader2/pkg/util"
 
 	// ensure auth plugins are loaded
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
@@ -113,9 +113,9 @@ func (f *Framework) ListAutomanagedNamespaces() ([]string, error) {
 }
 
 // DeleteAutomanagedNamespaces deletes all automanged namespaces.
-func (f *Framework) DeleteAutomanagedNamespaces() *util.ErrorList {
+func (f *Framework) DeleteAutomanagedNamespaces() *errors.ErrorList {
 	var wg wait.Group
-	errList := util.NewErrorList()
+	errList := errors.NewErrorList()
 	for i := 1; i <= f.automanagedNamespaceCount; i++ {
 		name := fmt.Sprintf("%v-%d", f.automanagedNamespacePrefix, i)
 		wg.Start(func() {

--- a/clusterloader2/pkg/measurement/common/bundle/test_metrics.go
+++ b/clusterloader2/pkg/measurement/common/bundle/test_metrics.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"github.com/golang/glog"
+	"k8s.io/perf-tests/clusterloader2/pkg/errors"
 	"k8s.io/perf-tests/clusterloader2/pkg/measurement"
 	"k8s.io/perf-tests/clusterloader2/pkg/util"
 )
@@ -73,7 +74,7 @@ type testMetrics struct {
 // stop - which stops all metrics and collects all measurements.
 func (t *testMetrics) Execute(config *measurement.MeasurementConfig) ([]measurement.Summary, error) {
 	var summaries []measurement.Summary
-	errList := util.NewErrorList()
+	errList := errors.NewErrorList()
 	action, err := util.GetString(config.Params, "action")
 	if err != nil {
 		return summaries, err
@@ -162,7 +163,7 @@ func execute(m measurement.Measurement, config *measurement.MeasurementConfig) (
 	return m.Execute(config)
 }
 
-func appendResults(summaries *[]measurement.Summary, errList *util.ErrorList, summaryResults []measurement.Summary, errResult error) {
+func appendResults(summaries *[]measurement.Summary, errList *errors.ErrorList, summaryResults []measurement.Summary, errResult error) {
 	if errResult != nil {
 		errList.Append(errResult)
 		return

--- a/clusterloader2/pkg/measurement/common/slos/api_responsiveness.go
+++ b/clusterloader2/pkg/measurement/common/slos/api_responsiveness.go
@@ -26,6 +26,7 @@ import (
 	"github.com/prometheus/common/model"
 	"k8s.io/apimachinery/pkg/util/sets"
 	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/perf-tests/clusterloader2/pkg/errors"
 	"k8s.io/perf-tests/clusterloader2/pkg/measurement"
 	measurementutil "k8s.io/perf-tests/clusterloader2/pkg/measurement/util"
 	"k8s.io/perf-tests/clusterloader2/pkg/util"
@@ -83,7 +84,7 @@ func (*apiResponsivenessMeasurement) Execute(config *measurement.MeasurementConf
 			return summaries, err
 		}
 		summary, err := apiserverMetricsGather(config.ClientSet, nodeCount)
-		if err == nil || measurement.IsMetricViolationError(err) {
+		if err == nil || errors.IsMetricViolationError(err) {
 			summaries = append(summaries, summary)
 		}
 		return summaries, err
@@ -141,7 +142,7 @@ func apiserverMetricsGather(c clientset.Interface, nodeCount int) (measurement.S
 		}
 	}
 	if badMetrics > 0 {
-		return metrics, measurement.NewMetricViolationError("top latency metric", "there should be no high-latency requests")
+		return metrics, errors.NewMetricViolationError("top latency metric", "there should be no high-latency requests")
 	}
 	return metrics, nil
 }

--- a/clusterloader2/pkg/measurement/common/slos/pod_startup_latency.go
+++ b/clusterloader2/pkg/measurement/common/slos/pod_startup_latency.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/perf-tests/clusterloader2/pkg/errors"
 	"k8s.io/perf-tests/clusterloader2/pkg/measurement"
 	measurementutil "k8s.io/perf-tests/clusterloader2/pkg/measurement/util"
 	"k8s.io/perf-tests/clusterloader2/pkg/util"
@@ -231,7 +232,7 @@ func (p *podStartupLatencyMeasurement) gather(c clientset.Interface) ([]measurem
 	}
 
 	if slosErr := podStartupLatency.E2ELatency.VerifyThreshod(podStartupLatencyThreshold); slosErr != nil {
-		err = measurement.NewMetricViolationError("pod startup", slosErr.Error())
+		err = errors.NewMetricViolationError("pod startup", slosErr.Error())
 		glog.Error(err)
 	}
 	return []measurement.Summary{podStartupLatency}, err

--- a/clusterloader2/pkg/test/interface.go
+++ b/clusterloader2/pkg/test/interface.go
@@ -19,11 +19,11 @@ package test
 import (
 	"k8s.io/perf-tests/clusterloader2/api"
 	"k8s.io/perf-tests/clusterloader2/pkg/config"
+	"k8s.io/perf-tests/clusterloader2/pkg/errors"
 	"k8s.io/perf-tests/clusterloader2/pkg/framework"
 	"k8s.io/perf-tests/clusterloader2/pkg/measurement"
 	"k8s.io/perf-tests/clusterloader2/pkg/state"
 	"k8s.io/perf-tests/clusterloader2/pkg/tuningset"
-	"k8s.io/perf-tests/clusterloader2/pkg/util"
 )
 
 // CreatContextFunc a type for function that creates Context based on given framework client and state.
@@ -55,8 +55,8 @@ type Context interface {
 
 // TestExecutor is an interface for test executing object.
 type TestExecutor interface {
-	ExecuteTest(ctx Context, conf *api.Config) *util.ErrorList
-	ExecuteStep(ctx Context, step *api.Step) *util.ErrorList
-	ExecutePhase(ctx Context, phase *api.Phase) *util.ErrorList
-	ExecuteObject(ctx Context, object *api.Object, namespace string, replicaIndex int32, operation OperationType) *util.ErrorList
+	ExecuteTest(ctx Context, conf *api.Config) *errors.ErrorList
+	ExecuteStep(ctx Context, step *api.Step) *errors.ErrorList
+	ExecutePhase(ctx Context, phase *api.Phase) *errors.ErrorList
+	ExecuteObject(ctx Context, object *api.Object, namespace string, replicaIndex int32, operation OperationType) *errors.ErrorList
 }

--- a/clusterloader2/pkg/test/test.go
+++ b/clusterloader2/pkg/test/test.go
@@ -22,9 +22,9 @@ import (
 	"path/filepath"
 
 	"k8s.io/perf-tests/clusterloader2/pkg/config"
+	"k8s.io/perf-tests/clusterloader2/pkg/errors"
 	"k8s.io/perf-tests/clusterloader2/pkg/framework"
 	"k8s.io/perf-tests/clusterloader2/pkg/state"
-	"k8s.io/perf-tests/clusterloader2/pkg/util"
 )
 
 var (
@@ -38,27 +38,27 @@ var (
 )
 
 // RunTest runs test based on provided test configuration.
-func RunTest(f *framework.Framework, clusterLoaderConfig *config.ClusterLoaderConfig) *util.ErrorList {
+func RunTest(f *framework.Framework, clusterLoaderConfig *config.ClusterLoaderConfig) *errors.ErrorList {
 	if f == nil {
-		return util.NewErrorList(fmt.Errorf("framework must be provided"))
+		return errors.NewErrorList(fmt.Errorf("framework must be provided"))
 	}
 	if clusterLoaderConfig == nil {
-		return util.NewErrorList(fmt.Errorf("cluster loader config must be provided"))
+		return errors.NewErrorList(fmt.Errorf("cluster loader config must be provided"))
 	}
 	if CreateContext == nil {
-		return util.NewErrorList(fmt.Errorf("no CreateContext function installed"))
+		return errors.NewErrorList(fmt.Errorf("no CreateContext function installed"))
 	}
 	if Test == nil {
-		return util.NewErrorList(fmt.Errorf("no Test installed"))
+		return errors.NewErrorList(fmt.Errorf("no Test installed"))
 	}
 
 	if clusterLoaderConfig.ReportDir != "" {
 		if _, err := os.Stat(clusterLoaderConfig.ReportDir); err != nil {
 			if !os.IsNotExist(err) {
-				return util.NewErrorList(err)
+				return errors.NewErrorList(err)
 			}
 			if err = os.Mkdir(clusterLoaderConfig.ReportDir, 0755); err != nil {
-				return util.NewErrorList(fmt.Errorf("report directory creation error: %v", err))
+				return errors.NewErrorList(fmt.Errorf("report directory creation error: %v", err))
 			}
 		}
 	}
@@ -68,12 +68,12 @@ func RunTest(f *framework.Framework, clusterLoaderConfig *config.ClusterLoaderCo
 
 	mapping, err := config.GetOverridesMapping(clusterLoaderConfig.TestOverridesPath)
 	if err != nil {
-		return util.NewErrorList(fmt.Errorf("mapping creation error: %v", err))
+		return errors.NewErrorList(fmt.Errorf("mapping creation error: %v", err))
 	}
 	mapping["Nodes"] = clusterLoaderConfig.ClusterConfig.Nodes
 	testConfig, err := ctx.GetTemplateProvider().TemplateToConfig(testConfigFilename, mapping)
 	if err != nil {
-		return util.NewErrorList(fmt.Errorf("config reading error: %v", err))
+		return errors.NewErrorList(fmt.Errorf("config reading error: %v", err))
 	}
 	return Test.ExecuteTest(ctx, testConfig)
 }


### PR DESCRIPTION
Moving:
- `pkg/util/error_list.go` → `pkg/errors/error_list.go`
- `pkg/measurement/errors.go` → `pkg/errors/metric_violation_error.go`