### PR TITLE
Updating dns benchmark run script

### DIFF
--- a/dns/README.md
+++ b/dns/README.md
@@ -17,15 +17,23 @@ on Debian-based systems or with `pip install`.
 For CoreDNS:
 
 ``` sh
+$ ./run core-dns out
+```
+or
+``` sh
 $ mkdir out/                                        # output directory
-$ ./run --dns-server coredns --params params/coredns/default.yaml --out-dir out  # run the perf test
+$ python py/run_perf.py --dns-server coredns --params params/coredns/default.yaml --out-dir out  # run the perf test
 ```
 
 For kube-dns:
 
 ``` sh
+$ ./run kube-dns out
+```
+or
+``` sh
 $ mkdir out/                                        # output directory
-$ ./run --params params/kubedns/default.yaml --out-dir out  # run the perf test
+$ python py/run_perf.py --params params/kubedns/default.yaml --out-dir out  # run the perf test
 ```
 
 

--- a/dns/run
+++ b/dns/run
@@ -1,3 +1,35 @@
 #!/bin/sh
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-python py/run_perf.py "$@"
+# $1 - Test type.
+# $2 - Optional test output directory path. If not provided default "out" is used.
+# $3 - Optional json metrics directory path. If not provided metrics will not be created.
+
+outDir=${2:-"out"}
+mkdir -p ${outDir}
+
+case "$1" in
+  kube-dns )
+    python py/run_perf.py --params params/kubedns/default.yaml --out-dir ${outDir} --use-cluster-dns
+    ;;
+  core-dns )
+    python py/run_perf.py --dns-server coredns --params params/coredns/default.yaml --out-dir out --use-cluster-dns
+    ;;
+esac
+
+if [ "$#" -eq 3 ]; then
+  mkdir -p $3
+  go run ./jsonify/main.go --benchmarkDirPath=${outDir}/latest --jsonDirPath=$3 --benchmarkName=$1
+fi

--- a/run-e2e.sh
+++ b/run-e2e.sh
@@ -40,18 +40,9 @@ case "$1" in
     cd ${PERFTEST_ROOT}/network/benchmarks/netperf/ && go run ./launch.go  --kubeConfig="${HOME}/.kube/config" --hostnetworking --iterations 1
     exit
     ;;
-  kube-dns )
-    #KUBE-DNS
-    cd ${PERFTEST_ROOT}/dns
-    mkdir out
-    ./run --params params/kubedns/default.yaml --out-dir out --use-cluster-dns
-    exit
-    ;;
-  core-dns )
-    #CORE-DNS
-    cd ${PERFTEST_ROOT}/dns
-    mkdir out
-    ./run --dns-server coredns --params params/coredns/default.yaml --out-dir out --use-cluster-dns
+  kube-dns|core-dns )
+    cd dns
+    ./run $@
     exit
     ;;
   --help | -h )


### PR DESCRIPTION
- dns/run takes care of running benchmark. It runs tests, creates required directories and creates metrics.
- run-e2e.sh only calls dns/run