### PR TITLE
clusterloader2: Set etcd metrics cmd from CLI

### DIFF
--- a/clusterloader2/README.md
+++ b/clusterloader2/README.md
@@ -26,6 +26,7 @@ If not specified, summaries are printed to standard log.
  - provider - Cluster provider, options are: gce, gke, kubemark, aws, local, vsphere, skeleton
  - mastername - Name of the master node
  - masterip - DNS Name / IP of the master node
+ - etcd-metrics-cmd - Command to run that gets etcd prometheus metrics
 
 ## Tests
 

--- a/clusterloader2/cmd/clusterloader.go
+++ b/clusterloader2/cmd/clusterloader.go
@@ -54,6 +54,7 @@ func initClusterFlags() {
 	pflag.StringVar(&clusterLoaderConfig.ClusterConfig.Provider, "provider", "", "Cluster provider")
 	pflag.StringVar(&clusterLoaderConfig.ClusterConfig.MasterName, "mastername", "", "Name of the masternode")
 	pflag.StringVar(&clusterLoaderConfig.ClusterConfig.MasterIP, "masterip", "", "Hostname/IP of the masternode")
+	pflag.StringVar(&clusterLoaderConfig.ClusterConfig.EtcdMetricsCmd, "etcd-metrics-cmd", "curl http://localhost:2379", "Command to get etcd prometheus metrics")
 }
 
 func validateClusterFlags() *errors.ErrorList {

--- a/clusterloader2/pkg/config/cluster.go
+++ b/clusterloader2/pkg/config/cluster.go
@@ -30,6 +30,7 @@ type ClusterConfig struct {
 	Nodes          int    `json: nodes`
 	Provider       string `json: provider`
 	// TODO(krzysied): Add support for HA cluster with more than one master.
-	MasterIP   string `json: masterIP`
-	MasterName string `json: masterName`
+	MasterIP       string `json: masterIP`
+	MasterName     string `json: masterName`
+	EtcdMetricsCmd string `json: etcdMetricsCmd`
 }

--- a/clusterloader2/pkg/measurement/common/simple/etcd_metrics.go
+++ b/clusterloader2/pkg/measurement/common/simple/etcd_metrics.go
@@ -69,6 +69,10 @@ func (e *etcdMetricsMeasurement) Execute(config *measurement.MeasurementConfig) 
 	if err != nil {
 		return summaries, err
 	}
+	cmd, err := util.GetStringOrDefault(config.Params, "etcdMetricsCmd", config.ClusterConfig.EtcdMetricsCmd)
+	if err != nil {
+		return summaries, err
+	}
 
 	switch action {
 	case "start":
@@ -77,10 +81,10 @@ func (e *etcdMetricsMeasurement) Execute(config *measurement.MeasurementConfig) 
 		if err != nil {
 			return summaries, err
 		}
-		e.startCollecting(provider, host, waitTime)
+		e.startCollecting(provider, host, cmd, waitTime)
 		return summaries, nil
 	case "gather":
-		if err = e.stopAndSummarize(provider, host); err != nil {
+		if err = e.stopAndSummarize(provider, host, cmd); err != nil {
 			return summaries, err
 		}
 		summaries := append(summaries, e.metrics)
@@ -104,7 +108,7 @@ func (e *etcdMetricsMeasurement) String() string {
 	return etcdMetricsMetricName
 }
 
-func (e *etcdMetricsMeasurement) startCollecting(provider, host string, interval time.Duration) {
+func (e *etcdMetricsMeasurement) startCollecting(provider, host string, cmd string, interval time.Duration) {
 	e.isRunning = true
 	e.wg.Add(1)
 	go func() {
@@ -112,7 +116,7 @@ func (e *etcdMetricsMeasurement) startCollecting(provider, host string, interval
 		for {
 			select {
 			case <-time.After(interval):
-				dbSize, err := e.getEtcdDatabaseSize(provider, host)
+				dbSize, err := e.getEtcdDatabaseSize(provider, host, cmd)
 				if err != nil {
 					glog.Errorf("%s: failed to collect etcd database size", e)
 					continue
@@ -125,10 +129,10 @@ func (e *etcdMetricsMeasurement) startCollecting(provider, host string, interval
 	}()
 }
 
-func (e *etcdMetricsMeasurement) stopAndSummarize(provider, host string) error {
+func (e *etcdMetricsMeasurement) stopAndSummarize(provider, host string, cmd string) error {
 	defer e.Dispose()
 	// Do some one-off collection of metrics.
-	samples, err := e.getEtcdMetrics(provider, host)
+	samples, err := e.getEtcdMetrics(provider, host, cmd)
 	if err != nil {
 		return err
 	}
@@ -147,14 +151,13 @@ func (e *etcdMetricsMeasurement) stopAndSummarize(provider, host string) error {
 	return nil
 }
 
-func (e *etcdMetricsMeasurement) getEtcdMetrics(provider, host string) ([]*model.Sample, error) {
+func (e *etcdMetricsMeasurement) getEtcdMetrics(provider, host string, cmd string) ([]*model.Sample, error) {
 	// Etcd is only exposed on localhost level. We are using ssh method
 	if provider == "gke" {
 		glog.Infof("%s: not grabbing scheduler metrics through master SSH: unsupported for gke", e)
 		return nil, nil
 	}
 
-	cmd := "curl http://localhost:2379/metrics"
 	sshResult, err := measurementutil.SSH(cmd, host+":22", provider)
 	if err != nil || sshResult.Code != 0 {
 		return nil, fmt.Errorf("unexpected error (code: %d) in ssh connection to master: %#v", sshResult.Code, err)
@@ -164,8 +167,8 @@ func (e *etcdMetricsMeasurement) getEtcdMetrics(provider, host string) ([]*model
 	return measurementutil.ExtractMetricSamples(data)
 }
 
-func (e *etcdMetricsMeasurement) getEtcdDatabaseSize(provider, host string) (float64, error) {
-	samples, err := e.getEtcdMetrics(provider, host)
+func (e *etcdMetricsMeasurement) getEtcdDatabaseSize(provider, host string, cmd string) (float64, error) {
+	samples, err := e.getEtcdMetrics(provider, host, cmd)
 	if err != nil {
 		return 0, err
 	}

--- a/verify/verify-flags/known-flags.txt
+++ b/verify/verify-flags/known-flags.txt
@@ -1,5 +1,6 @@
 comparison-scheme
 enable-output-coloring
+etcd-metrics-cmd
 kubernetes-url
 left-build-number
 left-job-name


### PR DESCRIPTION
etcd might run on a different machine, with TLS or client certs or on a different port.
This allows to set the command via CLI.