### PR TITLE
ClusterLoader - Fixing test metrics bundle

### DIFF
--- a/clusterloader2/pkg/measurement/common/bundle/test_metrics.go
+++ b/clusterloader2/pkg/measurement/common/bundle/test_metrics.go
@@ -172,7 +172,6 @@ func execute(m measurement.Measurement, config *measurement.MeasurementConfig) (
 func appendResults(summaries *[]measurement.Summary, errList *errors.ErrorList, summaryResults []measurement.Summary, errResult error) {
 	if errResult != nil {
 		errList.Append(errResult)
-		return
 	}
 	*summaries = append(*summaries, summaryResults...)
 }


### PR DESCRIPTION
Summaries should be always appended.