### PR TITLE
Perfdash - Scheduling throughput metrics

### DIFF
--- a/perfdash/Makefile
+++ b/perfdash/Makefile
@@ -1,7 +1,7 @@
 all: push
 
 # See pod.yaml for the version currently running-- bump this ahead before rebuilding!
-TAG = 1.12
+TAG = 1.13
 
 REPO = gcr.io/k8s-testimages
 

--- a/perfdash/config.go
+++ b/perfdash/config.go
@@ -40,7 +40,7 @@ type TestDescription struct {
 }
 
 // TestDescriptions is a map job->component->description.
-type TestDescriptions map[string]map[string]TestDescription
+type TestDescriptions map[string]map[string][]TestDescription
 
 // Tests is a map from test label to test description.
 type Tests struct {
@@ -60,108 +60,108 @@ var (
 	// e2e test
 	performanceDescriptions = TestDescriptions{
 		"E2E": {
-			"DensityResources": {
+			"DensityResources": []TestDescription{{
 				Name:             "density",
 				OutputFilePrefix: "ResourceUsageSummary",
 				Parser:           parseResourceUsageData,
-			},
-			"DensityPodStartup": {
+			}},
+			"DensityPodStartup": []TestDescription{{
 				Name:             "density",
 				OutputFilePrefix: "PodStartupLatency",
 				Parser:           parseResponsivenessData,
-			},
-			"DensityTestPhaseTimer": {
+			}},
+			"DensityTestPhaseTimer": []TestDescription{{
 				Name:             "density",
 				OutputFilePrefix: "TestPhaseTimer",
 				Parser:           parseResponsivenessData,
-			},
-			"LoadResources": {
+			}},
+			"LoadResources": []TestDescription{{
 				Name:             "load",
 				OutputFilePrefix: "ResourceUsageSummary",
 				Parser:           parseResourceUsageData,
-			},
-			"LoadTestPhaseTimer": {
+			}},
+			"LoadTestPhaseTimer": []TestDescription{{
 				Name:             "load",
 				OutputFilePrefix: "TestPhaseTimer",
 				Parser:           parseResponsivenessData,
-			},
+			}},
 		},
 		"APIServer": {
-			"DensityResponsiveness": {
+			"DensityResponsiveness": []TestDescription{{
 				Name:             "density",
 				OutputFilePrefix: "APIResponsiveness",
 				Parser:           parseResponsivenessData,
-			},
-			"DensityRequestCount": {
+			}},
+			"DensityRequestCount": []TestDescription{{
 				Name:             "density",
 				OutputFilePrefix: "APIResponsiveness",
 				Parser:           parseRequestCountData,
-			},
-			"DensityRequestCountByClient": {
+			}},
+			"DensityRequestCountByClient": []TestDescription{{
 				Name:             "density",
 				OutputFilePrefix: "MetricsForE2E",
 				Parser:           parseApiserverRequestCount,
-			},
-			"LoadResponsiveness": {
+			}},
+			"LoadResponsiveness": []TestDescription{{
 				Name:             "load",
 				OutputFilePrefix: "APIResponsiveness",
 				Parser:           parseResponsivenessData,
-			},
-			"LoadRequestCount": {
+			}},
+			"LoadRequestCount": []TestDescription{{
 				Name:             "load",
 				OutputFilePrefix: "APIResponsiveness",
 				Parser:           parseRequestCountData,
-			},
-			"LoadRequestCountByClient": {
+			}},
+			"LoadRequestCountByClient": []TestDescription{{
 				Name:             "load",
 				OutputFilePrefix: "MetricsForE2E",
 				Parser:           parseApiserverRequestCount,
-			},
+			}},
 		},
 		"Scheduler": {
-			"SchedulingLatency": {
+			"SchedulingLatency": []TestDescription{{
 				Name:             "density",
 				OutputFilePrefix: "SchedulingMetrics",
 				Parser:           parseSchedulingLatency,
-			},
-			"SchedulingThroughput": {
+			}},
+			"SchedulingThroughput": []TestDescription{{
 				Name:             "density",
 				OutputFilePrefix: "SchedulingMetrics",
 				Parser:           pareseSchedulingThroughput,
-			},
+			}},
 		},
 		"Etcd": {
-			"BackendCommitDuration": {
+			"BackendCommitDuration": []TestDescription{{
 				Name:             "density",
 				OutputFilePrefix: "EtcdMetrics",
 				Parser:           parseHistogramMetric("backendCommitDuration"),
-			},
-			"SnapshotSaveTotalDuration": {
+			}},
+			"SnapshotSaveTotalDuration": []TestDescription{{
 				Name:             "density",
 				OutputFilePrefix: "EtcdMetrics",
 				Parser:           parseHistogramMetric("snapshotSaveTotalDuration"),
-			},
-			"PeerRoundTripTime": {
+			}},
+			"PeerRoundTripTime": []TestDescription{{
 				Name:             "density",
 				OutputFilePrefix: "EtcdMetrics",
 				Parser:           parseHistogramMetric("peerRoundTripTime"),
-			},
-			"WalFsyncDuration": {
+			}},
+			"WalFsyncDuration": []TestDescription{{
 				Name:             "density",
 				OutputFilePrefix: "EtcdMetrics",
 				Parser:           parseHistogramMetric("walFsyncDuration"),
-			},
+			}},
 		},
 	}
 
 	// benchmarkDescriptions contains metrics exported by test/integration/scheduler_perf
 	benchmarkDescriptions = TestDescriptions{
 		"Scheduler": {
-			"BenchmarkResults": {
+			"BenchmarkResults": []TestDescription{{
 				Name:             "benchmark",
 				OutputFilePrefix: "BenchmarkResults",
 				Parser:           parseResponsivenessData,
-			},
+			}},
 		},
 	}
 

--- a/perfdash/config.go
+++ b/perfdash/config.go
@@ -124,11 +124,18 @@ var (
 				OutputFilePrefix: "SchedulingMetrics",
 				Parser:           parseSchedulingLatency,
 			}},
-			"SchedulingThroughput": []TestDescription{{
-				Name:             "density",
-				OutputFilePrefix: "SchedulingMetrics",
-				Parser:           pareseSchedulingThroughput,
-			}},
+			"SchedulingThroughput": []TestDescription{
+				{
+					Name:             "density",
+					OutputFilePrefix: "SchedulingThroughput",
+					Parser:           parseSchedulingThroughputCL,
+				},
+				{
+					Name:             "density",
+					OutputFilePrefix: "SchedulingMetrics",
+					Parser:           parseSchedulingThroughput,
+				},
+			},
 		},
 		"Etcd": {
 			"BackendCommitDuration": []TestDescription{{

--- a/perfdash/deployment.yaml
+++ b/perfdash/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: default
   labels:
     app: perfdash
-    version: "1.12"
+    version: "1.13"
 spec:
   selector:
     matchLabels:
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: perfdash
-        image: gcr.io/k8s-testimages/perfdash:1.12
+        image: gcr.io/k8s-testimages/perfdash:1.13
         command:
           - /perfdash
           -   --www=true

--- a/perfdash/google-gcs-downloader.go
+++ b/perfdash/google-gcs-downloader.go
@@ -126,7 +126,7 @@ func (g *GoogleGCSDownloader) getJobData(wg *sync.WaitGroup, result JobToCategor
 						resultLock.Unlock()
 						testDescription.Parser(data, buildNumber, buildData)
 					}()
-                                        break
+					break
 				}
 			}
 		}

--- a/perfdash/google-gcs-downloader.go
+++ b/perfdash/google-gcs-downloader.go
@@ -96,35 +96,38 @@ func (g *GoogleGCSDownloader) getJobData(wg *sync.WaitGroup, result JobToCategor
 	for buildNumber := lastBuildNo; buildNumber > lastBuildNo-buildsToFetch && buildNumber > 0; buildNumber-- {
 		fmt.Printf("Fetching %s build %v...\n", job, buildNumber)
 		for categoryLabel, categoryMap := range tests.Descriptions {
-			for testLabel, testDescription := range categoryMap {
-				fileStem := fmt.Sprintf("artifacts/%v_%v", testDescription.OutputFilePrefix, testDescription.Name)
-				artifacts, err := g.GoogleGCSBucketUtils.ListFilesInBuild(job, buildNumber, fileStem)
-				if err != nil || len(artifacts) == 0 {
-					fmt.Printf("Error while looking for %s* in %s build %v: %v\n", fileStem, job, buildNumber, err)
-					continue
-				}
-				metricsFilename := artifacts[0][strings.LastIndex(artifacts[0], "/")+1:]
-				if len(artifacts) > 1 {
-					fmt.Printf("WARNING: found multiple %s files with data, reading only one: %s\n", fileStem, metricsFilename)
-				}
-				testDataResponse, err := g.GoogleGCSBucketUtils.GetFileFromJenkinsGoogleBucket(job, buildNumber, fmt.Sprintf("artifacts/%v", metricsFilename))
-				if err != nil {
-					panic(err)
-				}
-
-				func() {
-					testDataBody := testDataResponse.Body
-					defer testDataBody.Close()
-					data, err := ioutil.ReadAll(testDataBody)
-					if err != nil {
-						fmt.Fprintf(os.Stderr, "Error when reading response Body: %v\n", err)
-						return
+			for testLabel, testDescriptions := range categoryMap {
+				for _, testDescription := range testDescriptions {
+					fileStem := fmt.Sprintf("artifacts/%v_%v", testDescription.OutputFilePrefix, testDescription.Name)
+					artifacts, err := g.GoogleGCSBucketUtils.ListFilesInBuild(job, buildNumber, fileStem)
+					if err != nil || len(artifacts) == 0 {
+						fmt.Printf("Error while looking for %s* in %s build %v: %v\n", fileStem, job, buildNumber, err)
+						continue
 					}
-					resultLock.Lock()
-					buildData := result[tests.Prefix][categoryLabel][testLabel]
-					resultLock.Unlock()
-					testDescription.Parser(data, buildNumber, buildData)
-				}()
+					metricsFilename := artifacts[0][strings.LastIndex(artifacts[0], "/")+1:]
+					if len(artifacts) > 1 {
+						fmt.Printf("WARNING: found multiple %s files with data, reading only one: %s\n", fileStem, metricsFilename)
+					}
+					testDataResponse, err := g.GoogleGCSBucketUtils.GetFileFromJenkinsGoogleBucket(job, buildNumber, fmt.Sprintf("artifacts/%v", metricsFilename))
+					if err != nil {
+						panic(err)
+					}
+
+					func() {
+						testDataBody := testDataResponse.Body
+						defer testDataBody.Close()
+						data, err := ioutil.ReadAll(testDataBody)
+						if err != nil {
+							fmt.Fprintf(os.Stderr, "Error when reading response Body: %v\n", err)
+							return
+						}
+						resultLock.Lock()
+						buildData := result[tests.Prefix][categoryLabel][testLabel]
+						resultLock.Unlock()
+						testDescription.Parser(data, buildNumber, buildData)
+					}()
+                                        break
+				}
 			}
 		}
 	}

--- a/perfdash/parser.go
+++ b/perfdash/parser.go
@@ -224,7 +224,8 @@ func parseSchedulingLatency(data []byte, buildNumber int, testResult *BuildData)
 	testResult.Builds[build] = append(testResult.Builds[build], binding)
 }
 
-func pareseSchedulingThroughput(data []byte, buildNumber int, testResult *BuildData) {
+// TODO(krzysied): remove this parsing when old density test is removed.
+func parseSchedulingThroughput(data []byte, buildNumber int, testResult *BuildData) {
 	testResult.Version = "v1"
 	build := fmt.Sprintf("%d", buildNumber)
 	var obj schedulingMetrics
@@ -237,6 +238,29 @@ func pareseSchedulingThroughput(data []byte, buildNumber int, testResult *BuildD
 	perfData.Data["Perc90"] = obj.ThroughputPerc90
 	perfData.Data["Perc99"] = obj.ThroughputPerc99
 	perfData.Data["Average"] = obj.ThroughputAverage
+	testResult.Builds[build] = append(testResult.Builds[build], perfData)
+}
+
+type schedulingThroughputMetric struct {
+	Average float64 `json:"average"`
+	Perc50  float64 `json:"perc50"`
+	Perc90  float64 `json:"perc90"`
+	Perc99  float64 `json:"perc99"`
+}
+
+func parseSchedulingThroughputCL(data []byte, buildNumber int, testResult *BuildData) {
+	testResult.Version = "v1"
+	build := fmt.Sprintf("%d", buildNumber)
+	var obj schedulingThroughputMetric
+	if err := json.Unmarshal(data, &obj); err != nil {
+		fmt.Fprintf(os.Stderr, "error parsing JSON in build %d: %v %s\n", buildNumber, err, string(data))
+		return
+	}
+	perfData := perftype.DataItem{Unit: "1/s", Labels: map[string]string{}, Data: make(map[string]float64)}
+	perfData.Data["Perc50"] = obj.Perc50
+	perfData.Data["Perc90"] = obj.Perc90
+	perfData.Data["Perc99"] = obj.Perc99
+	perfData.Data["Average"] = obj.Average
 	testResult.Builds[build] = append(testResult.Builds[build], perfData)
 }
 


### PR DESCRIPTION
- Adding multiple parser support.
If first parser fails, second is used... Required to properly handle changes in metric.
- Adding cluster loader scheduling throughput metrics.