### PR TITLE
Dns benchmark - Adding numpy installation to run script

### DIFF
--- a/dns/run
+++ b/dns/run
@@ -20,6 +20,8 @@
 outDir=${2:-"out"}
 mkdir -p ${outDir}
 
+pip install numpy
+
 case "$1" in
   kube-dns )
     python py/run_perf.py --params params/kubedns/default.yaml --out-dir ${outDir} --use-cluster-dns


### PR DESCRIPTION
Adding numpy installation to run script, due to numpy being required by `py/run_perf.py`. This command installs numpy or does nothing is numpy s already available.