### PR TITLE
ClusterLoader - Overriding resource usage gathering for 2000 nodes test

### DIFF
--- a/clusterloader2/testing/density/2000_nodes/override.yaml
+++ b/clusterloader2/testing/density/2000_nodes/override.yaml
@@ -1,0 +1,1 @@
+NODE_MODE: masteranddns

--- a/clusterloader2/testing/density/config.yaml
+++ b/clusterloader2/testing/density/config.yaml
@@ -4,6 +4,7 @@
 
 #Constants
 {{$DENSITY_RESOURCE_CONSTRAINTS_FILE := DefaultParam .DENSITY_RESOURCE_CONSTRAINTS_FILE ""}}
+{{$NODE_MODE := DefaultParam .NODE_MODE "allnodes"}}
 {{$NODES_PER_NAMESPACE := DefaultParam .NODES_PER_NAMESPACE 100}}
 {{$PODS_PER_NODE := DefaultParam .PODS_PER_NODE 30}}
 {{$TEST_THROUGHPUT := DefaultParam .TEST_THROUGHPUT 20}}
@@ -41,6 +42,7 @@ steps:
     Method: TestMetrics
     Params:
       action: start
+      nodeMode: {{$NODE_MODE}}
       resourceConstraints: {{$DENSITY_RESOURCE_CONSTRAINTS_FILE}}
 # Create saturation pods
 - measurements:

--- a/clusterloader2/testing/load/config.yaml
+++ b/clusterloader2/testing/load/config.yaml
@@ -3,6 +3,7 @@
 # - Number of nodes should be divisible by NODES_PER_NAMESPACE (default 100).
 
 #Constants
+{{$NODE_MODE := DefaultParam .NODE_MODE "allnodes"}}
 {{$NODES_PER_NAMESPACE := DefaultParam .NODES_PER_NAMESPACE 100}}
 {{$PODS_PER_NODE := DefaultParam .PODS_PER_NODE 30}}
 {{$TEST_THROUGHPUT := DefaultParam .TEST_THROUGHPUT 10}}
@@ -44,6 +45,7 @@ steps:
     Method: TestMetrics
     Params:
       action: start
+      nodeMode: {{$NODE_MODE}}
 # Create RCs
 - measurements:
   - Identifier: WaitForRunningRCs


### PR DESCRIPTION
Resource usage will be gather from master and dns only.