### PR TITLE
Add not-ready/unreachable node tolerations ot density/load rcs.

### DIFF
--- a/clusterloader2/testing/density/rc.yaml
+++ b/clusterloader2/testing/density/rc.yaml
@@ -23,3 +23,14 @@ spec:
           requests:
             cpu: {{.CpuRequest}}
             memory: {{.MemoryRequest}}
+      # Add not-ready/unreachable tolerations for 15 minutes so that node
+      # failure doesn't trigger pod deletion.
+      tolerations:
+      - key: "node.kubernetes.io/not-ready"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 900
+      - key: "node.kubernetes.io/unreachable"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 900

--- a/clusterloader2/testing/load/rc.yaml
+++ b/clusterloader2/testing/load/rc.yaml
@@ -20,3 +20,14 @@ spec:
           requests:
             cpu: 10m
             memory: "10M"
+      # Add not-ready/unreachable tolerations for 15 minutes so that node
+      # failure doesn't trigger pod deletion.
+      tolerations:
+      - key: "node.kubernetes.io/not-ready"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 900
+      - key: "node.kubernetes.io/unreachable"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 900


### PR DESCRIPTION
This way, if node goes down (e.g. due to hostError), the test won't fail.