### PR TITLE
ClusterLoader - Fixing RC deletion handling

### DIFF
--- a/clusterloader2/pkg/measurement/common/simple/wait_for_pods.go
+++ b/clusterloader2/pkg/measurement/common/simple/wait_for_pods.go
@@ -139,7 +139,7 @@ func waitForPods(clientSet clientset.Interface, namespace, labelSelector, fieldS
 			if log {
 				glog.Infof("%s: %s: %s", callerName, selectorsString, podsStatus.String())
 			}
-			if podsStatus.Running == desiredPodCount {
+			if len(pods) == podsStatus.Running && podsStatus.Running == desiredPodCount {
 				return nil
 			}
 			oldPods = pods


### PR DESCRIPTION
- Waiting for pods.
Measurement will wait until desired pods are running and there are no others pods that match given labels and namespace (regardless their statuses).
- Waiting for controlled pod.
Handling of object deletion changed to waiting for pods with desired replicas equaling 0.