### PR TITLE
Migrate NodeKiller to clusterloader2.

### DIFF
--- a/clusterloader2/pkg/chaos/monkey.go
+++ b/clusterloader2/pkg/chaos/monkey.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package chaos
+
+import (
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/perf-tests/clusterloader2/api"
+)
+
+// Monkey simulates kubernetes component failures
+type Monkey struct {
+	client     clientset.Interface
+	provider   string
+	nodeKiller *NodeKiller
+}
+
+// NewMonkey constructs a new Monkey object.
+func NewMonkey(client clientset.Interface, provider string) *Monkey {
+	return &Monkey{client: client, provider: provider}
+}
+
+// Init initializes Monkey with given config.
+// When stopCh is closed, the Monkey will stop simulating failures.
+func (m *Monkey) Init(config api.ChaosMonkeyConfig, stopCh <-chan struct{}) error {
+	if config.NodeFailure != nil {
+		nodeKiller, err := NewNodeKiller(*config.NodeFailure, m.client, m.provider)
+		if err != nil {
+			return err
+		}
+		m.nodeKiller = nodeKiller
+		m.nodeKiller.Run(stopCh)
+	}
+
+	return nil
+}

--- a/clusterloader2/pkg/chaos/nodes.go
+++ b/clusterloader2/pkg/chaos/nodes.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package chaos
+
+import (
+	"fmt"
+	"math/rand"
+	"os/exec"
+	"sync"
+	"time"
+
+	"k8s.io/perf-tests/clusterloader2/api"
+	"k8s.io/perf-tests/clusterloader2/pkg/util"
+
+	"github.com/golang/glog"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	clientset "k8s.io/client-go/kubernetes"
+)
+
+// NodeKiller is a utility to simulate node failures.
+type NodeKiller struct {
+	config   api.NodeFailureConfig
+	client   clientset.Interface
+	provider string
+}
+
+// NewNodeKiller creates new NodeKiller.
+func NewNodeKiller(config api.NodeFailureConfig, client clientset.Interface, provider string) (*NodeKiller, error) {
+	if provider != "gce" && provider != "gke" {
+		return nil, fmt.Errorf("provider %q is not supported by NodeKiller")
+	}
+	return &NodeKiller{config, client, provider}, nil
+}
+
+// Run starts NodeKiller until stopCh is closed.
+func (k *NodeKiller) Run(stopCh <-chan struct{}) {
+	// wait.JitterUntil starts work immediately, so wait first.
+	time.Sleep(wait.Jitter(time.Duration(k.config.Interval), k.config.JitterFactor))
+	wait.JitterUntil(func() {
+		nodes, err := k.pickNodes()
+		if err != nil {
+			glog.Errorf("Unable to pick nodes to kill: %v", err)
+			return
+		}
+		k.kill(nodes)
+	}, time.Duration(k.config.Interval), k.config.JitterFactor, true, stopCh)
+}
+
+func (k *NodeKiller) pickNodes() ([]v1.Node, error) {
+	nodes, err := util.GetSchedulableUntainedNodes(k.client)
+	if err != nil {
+		return nil, err
+	}
+	rand.Shuffle(len(nodes), func(i, j int) {
+		nodes[i], nodes[j] = nodes[j], nodes[i]
+	})
+	numNodes := int(k.config.FailureRate * float64(len(nodes)))
+	if len(nodes) > numNodes {
+		return nodes[:numNodes], nil
+	}
+	return nodes, nil
+}
+
+func (k *NodeKiller) kill(nodes []v1.Node) {
+	wg := sync.WaitGroup{}
+	wg.Add(len(nodes))
+	for _, node := range nodes {
+		node := node
+		go func() {
+			defer wg.Done()
+
+			glog.Infof("Stopping docker and kubelet on %q to simulate failure", node.Name)
+			err := ssh("sudo systemctl stop docker kubelet", &node)
+			if err != nil {
+				glog.Errorf("ERROR while stopping node %q: %v", node.Name, err)
+				return
+			}
+
+			time.Sleep(time.Duration(k.config.SimulatedDowntime))
+
+			glog.Infof("Rebooting %q to repair the node", node.Name)
+			err = ssh("sudo reboot", &node)
+			if err != nil {
+				glog.Errorf("Error while rebooting node %q: %v", node.Name, err)
+				return
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+func ssh(command string, node *v1.Node) error {
+	zone, ok := node.Labels["failure-domain.beta.kubernetes.io/zone"]
+	if !ok {
+		return fmt.Errorf("unknown zone for %q node: no failure-domain.beta.kubernetes.io/zone label", node.Name)
+	}
+	cmd := exec.Command("gcloud", "compute", "ssh", "--zone", zone, "--command", command, node.Name)
+	output, err := cmd.CombinedOutput()
+	glog.Infof("ssh to %q finished with %q: %v", node.Name, string(output), err)
+	return err
+}

--- a/clusterloader2/pkg/test/interface.go
+++ b/clusterloader2/pkg/test/interface.go
@@ -18,6 +18,7 @@ package test
 
 import (
 	"k8s.io/perf-tests/clusterloader2/api"
+	"k8s.io/perf-tests/clusterloader2/pkg/chaos"
 	"k8s.io/perf-tests/clusterloader2/pkg/config"
 	"k8s.io/perf-tests/clusterloader2/pkg/errors"
 	"k8s.io/perf-tests/clusterloader2/pkg/framework"
@@ -51,6 +52,7 @@ type Context interface {
 	GetTemplateProvider() *config.TemplateProvider
 	GetTuningSetFactory() tuningset.TuningSetFactory
 	GetMeasurementManager() *measurement.MeasurementManager
+	GetChaosMonkey() *chaos.Monkey
 }
 
 // TestExecutor is an interface for test executing object.

--- a/clusterloader2/pkg/test/simple_context.go
+++ b/clusterloader2/pkg/test/simple_context.go
@@ -19,6 +19,7 @@ package test
 import (
 	"path/filepath"
 
+	"k8s.io/perf-tests/clusterloader2/pkg/chaos"
 	"k8s.io/perf-tests/clusterloader2/pkg/config"
 	"k8s.io/perf-tests/clusterloader2/pkg/framework"
 	"k8s.io/perf-tests/clusterloader2/pkg/measurement"
@@ -33,6 +34,7 @@ type simpleContext struct {
 	templateProvider    *config.TemplateProvider
 	tuningSetFactory    tuningset.TuningSetFactory
 	measurementManager  *measurement.MeasurementManager
+	chaosMonkey         *chaos.Monkey
 }
 
 func createSimpleContext(c *config.ClusterLoaderConfig, f *framework.Framework, s *state.State) Context {
@@ -44,6 +46,7 @@ func createSimpleContext(c *config.ClusterLoaderConfig, f *framework.Framework, 
 		templateProvider:    templateProvider,
 		tuningSetFactory:    tuningset.NewTuningSetFactory(),
 		measurementManager:  measurement.CreateMeasurementManager(f.GetClientSet(), &c.ClusterConfig, templateProvider),
+		chaosMonkey:         chaos.NewMonkey(f.GetClientSet(), c.ClusterConfig.Provider),
 	}
 }
 
@@ -72,7 +75,12 @@ func (sc *simpleContext) GetTuningSetFactory() tuningset.TuningSetFactory {
 	return sc.tuningSetFactory
 }
 
-// GetMeasurementManager returns measurment manager.
+// GetMeasurementManager returns measurement manager.
 func (sc *simpleContext) GetMeasurementManager() *measurement.MeasurementManager {
 	return sc.measurementManager
+}
+
+// GetChaosMonkey returns chaos monkey.
+func (sc *simpleContext) GetChaosMonkey() *chaos.Monkey {
+	return sc.chaosMonkey
 }

--- a/clusterloader2/pkg/test/simple_test_executor.go
+++ b/clusterloader2/pkg/test/simple_test_executor.go
@@ -48,6 +48,9 @@ func (ste *simpleTestExecutor) ExecuteTest(ctx Context, conf *api.Config) *error
 	glog.Infof("AutomanagedNamespacePrefix: %s", ctx.GetFramework().GetAutomanagedNamespacePrefix())
 	defer cleanupResources(ctx)
 	ctx.GetTuningSetFactory().Init(conf.TuningSets)
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	ctx.GetChaosMonkey().Init(conf.ChaosMonkey, stopCh)
 	automanagedNamespacesList, err := ctx.GetFramework().ListAutomanagedNamespaces()
 	if err != nil {
 		return errors.NewErrorList(fmt.Errorf("automanaged namespaces listing failed: %v", err))

--- a/clusterloader2/pkg/util/cluster.go
+++ b/clusterloader2/pkg/util/cluster.go
@@ -28,17 +28,23 @@ import (
 
 // GetSchedulableUntainedNodesNumber returns number of nodes in the cluster.
 func GetSchedulableUntainedNodesNumber(c clientset.Interface) (int, error) {
+	nodes, err := GetSchedulableUntainedNodes(c)
+	return len(nodes), err
+}
+
+// GetSchedulableUntainedNodes returns nodes in the cluster.
+func GetSchedulableUntainedNodes(c clientset.Interface) ([]corev1.Node, error) {
 	nodeList, err := client.ListNodes(c)
 	if err != nil {
-		return 0, err
+		return nil, err
 	}
-	numNodes := 0
+	var filtered []corev1.Node
 	for i := range nodeList {
 		if isNodeSchedulable(&nodeList[i]) && isNodeUntainted(&nodeList[i]) {
-			numNodes++
+			filtered = append(filtered, nodeList[i])
 		}
 	}
-	return numNodes, err
+	return filtered, err
 }
 
 // LogClusterNodes prints nodes information (name, internal ip, external ip) to log.


### PR DESCRIPTION
This is basically copy-paste of https://github.com/kubernetes/kubernetes/pull/71320.

In the next step, once we migrate -killer job to clusterloader2, I will remove NodeKiller from kubernetes/kubernetes repo to remove code duplication.

/assign @wojtek-t 
/assign @krzysied 