### PR TITLE
Add a way to optionally enable chaos monkey in tests.

### DIFF
--- a/clusterloader2/cmd/clusterloader.go
+++ b/clusterloader2/cmd/clusterloader.go
@@ -69,7 +69,7 @@ func initFlags() {
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 	pflag.StringVar(&clusterLoaderConfig.ReportDir, "report-dir", "", "Path to the directory where the reports should be saved. Default is empty, which cause reports being written to standard output.")
 	pflag.StringArrayVar(&testConfigPaths, "testconfig", []string{}, "Paths to the test config files")
-	pflag.StringVar(&clusterLoaderConfig.TestOverridesPath, "testoverrides", "", "Path to the config overrides file")
+	pflag.StringArrayVar(&clusterLoaderConfig.TestOverridesPath, "testoverrides", []string{}, "Paths to the config overrides file. The latter overrides take precedence over changes in former files.")
 	initClusterFlags()
 }
 

--- a/clusterloader2/pkg/config/cluster.go
+++ b/clusterloader2/pkg/config/cluster.go
@@ -21,7 +21,7 @@ type ClusterLoaderConfig struct {
 	ClusterConfig     ClusterConfig `json: clusterConfig`
 	ReportDir         string        `json: reportDir`
 	TestConfigPath    string        `json: testConfigPath`
-	TestOverridesPath string        `json: testOverrides`
+	TestOverridesPath []string      `json: testOverrides`
 }
 
 // ClusterConfig is a structure that represents cluster description.

--- a/clusterloader2/pkg/config/template_provider.go
+++ b/clusterloader2/pkg/config/template_provider.go
@@ -160,18 +160,21 @@ func (tp *TemplateProvider) TemplateInto(path string, mapping map[string]interfa
 	return decodeInto(b, obj)
 }
 
-// GetOverridesMapping returns mapping from file specified by the given path.
-func GetOverridesMapping(path string) (map[string]interface{}, error) {
-	var mapping map[string]interface{}
-	if path == "" {
-		mapping = make(map[string]interface{})
-	} else {
+// GetOverridesMapping returns mapping from file specified by the given paths.
+func GetOverridesMapping(paths []string) (map[string]interface{}, error) {
+	mapping := make(map[string]interface{})
+	for _, path := range paths {
 		bin, err := ioutil.ReadFile(path)
 		if err != nil {
 			return nil, fmt.Errorf("test overrides reading error: %v", err)
 		}
-		if err = decodeInto(bin, &mapping); err != nil {
+		tmpMapping := make(map[string]interface{})
+		if err = decodeInto(bin, &tmpMapping); err != nil {
 			return nil, fmt.Errorf("test overrides unmarshalling error: %v", err)
+		}
+		// Merge tmpMapping into mapping.
+		for k, v := range tmpMapping {
+			mapping[k] = v
 		}
 	}
 	return mapping, nil

--- a/clusterloader2/testing/chaosmonkey/override.yaml
+++ b/clusterloader2/testing/chaosmonkey/override.yaml
@@ -1,0 +1,1 @@
+ENABLE_CHAOSMONKEY: true

--- a/clusterloader2/testing/density/config.yaml
+++ b/clusterloader2/testing/density/config.yaml
@@ -16,7 +16,7 @@
 {{$LATENCY_POD_MEMORY := DefaultParam .LATENCY_POD_MEMORY 400}}
 {{$MIN_LATENCY_PODS := 500}}
 {{$MIN_SATURATION_PODS_TIMEOUT := 180}}
-
+{{$ENABLE_CHAOSMONKEY := DefaultParam .ENABLE_CHAOSMONKEY false}}
 #Variables
 {{$namespaces := DivideInt .Nodes $NODES_PER_NAMESPACE}}
 {{$podsPerNamespace := MultiplyInt $PODS_PER_NODE $NODES_PER_NAMESPACE}}
@@ -32,6 +32,14 @@ tuningSets:
 - name: Uniform5qps
   qpsLoad:
     qps: 5
+{{if $ENABLE_CHAOSMONKEY}}
+chaosMonkey:
+  nodeFailure:
+    failureRate: 0.01
+    interval: 1m
+    jitterFactor: 10.0
+    simulatedDowntime: 10m
+{{end}}
 steps:
 - measurements:
   - Identifier: APIResponsiveness

--- a/clusterloader2/testing/load/config.yaml
+++ b/clusterloader2/testing/load/config.yaml
@@ -10,6 +10,7 @@
 {{$BIG_GROUP_SIZE := 250}}
 {{$MEDIUM_GROUP_SIZE := 30}}
 {{$SMALL_GROUP_SIZE := 5}}
+{{$ENABLE_CHAOSMONKEY := DefaultParam .ENABLE_CHAOSMONKEY false}}
 
 #Variables
 {{$namespaces := DivideInt .Nodes $NODES_PER_NAMESPACE}}
@@ -35,6 +36,14 @@ tuningSets:
     # as each RC changes its size from X to a uniform random value in [X/2, 3X/2].
     # To match 10 [pods/s] requirement, we need to divide saturationTime by 4.
     timeLimit: {{DivideInt $saturationTime 4}}s
+{{if $ENABLE_CHAOSMONKEY}}
+chaosMonkey:
+  nodeFailure:
+    failureRate: 0.01
+    interval: 1m
+    jitterFactor: 10.0
+    simulatedDowntime: 10m
+{{end}}
 steps:
 - measurements:
   - Identifier: APIResponsiveness


### PR DESCRIPTION
Chaos monkey is disabled by default, but can be enabled by adding --testoverrides=testing/chaosmonkey/override.yaml.

/assign @wojtek-t 