### PR TITLE
Bug in chaos.Monkey: add missing go in m.nodeKiller.Run() call.

### DIFF
--- a/clusterloader2/pkg/chaos/monkey.go
+++ b/clusterloader2/pkg/chaos/monkey.go
@@ -42,7 +42,7 @@ func (m *Monkey) Init(config api.ChaosMonkeyConfig, stopCh <-chan struct{}) erro
 			return err
 		}
 		m.nodeKiller = nodeKiller
-		m.nodeKiller.Run(stopCh)
+		go m.nodeKiller.Run(stopCh)
 	}
 
 	return nil


### PR DESCRIPTION
Right now it blocks the main goroutine :|

/assign @wojtek-t 
/assign @krzysied 