### PR TITLE
Reduce amount of unuseful logs

### DIFF
--- a/clusterloader2/pkg/measurement/common/simple/wait_for_controlled_pods.go
+++ b/clusterloader2/pkg/measurement/common/simple/wait_for_controlled_pods.go
@@ -427,12 +427,10 @@ func (w *waitForControlledPodsRunningMeasurement) waitForRuntimeObject(clientSet
 			return
 		}
 		if isDeleted {
-			glog.Infof("%s: %v has been deleted", w, key)
 			o.status = terminated
 			return
 		}
 
-		glog.Infof("%s: %v has all pods (%d) running", w, key, runtimeObjectReplicas)
 		o.status = running
 	})
 	return o, nil


### PR DESCRIPTION
Those are redundant with what is already written from wait_for_pods.