### PR TITLE
Change operationTimeout to 15m in scalability tests

### DIFF
--- a/clusterloader2/pkg/measurement/interface.go
+++ b/clusterloader2/pkg/measurement/interface.go
@@ -32,6 +32,8 @@ type MeasurementConfig struct {
 	Params map[string]interface{}
 	// TemplateProvider provides templated objects.
 	TemplateProvider *config.TemplateProvider
+	// Identifier identifies this instance of measurement.
+	Identifier string
 	// TODO(krzysied): add CloudProvider.
 }
 

--- a/clusterloader2/pkg/measurement/manager.go
+++ b/clusterloader2/pkg/measurement/manager.go
@@ -57,6 +57,7 @@ func (mm *MeasurementManager) Execute(methodName string, identifier string, para
 		ClusterConfig:    mm.clusterConfig,
 		Params:           params,
 		TemplateProvider: mm.templateProvider,
+		Identifier:       identifier,
 	}
 	summaries, err := measurementInstance.Execute(config)
 	mm.summaries = append(mm.summaries, summaries...)

--- a/clusterloader2/pkg/measurement/util/latency_metric.go
+++ b/clusterloader2/pkg/measurement/util/latency_metric.go
@@ -41,8 +41,8 @@ func (metric *LatencyMetric) SetQuantile(quantile float64, latency time.Duration
 	}
 }
 
-// VerifyThreshod verifies latency metric against given percentile thresholds.
-func (metric *LatencyMetric) VerifyThreshod(threshold *LatencyMetric) error {
+// VerifyThreshold verifies latency metric against given percentile thresholds.
+func (metric *LatencyMetric) VerifyThreshold(threshold *LatencyMetric) error {
 	if metric.Perc50 > threshold.Perc50 {
 		return fmt.Errorf("too high latency 50th percentile: %v", metric.Perc50)
 	}

--- a/clusterloader2/testing/density/config.yaml
+++ b/clusterloader2/testing/density/config.yaml
@@ -24,7 +24,9 @@
 {{$latencyReplicas := DivideInt (MaxInt $MIN_LATENCY_PODS .Nodes) $namespaces}}
 {{$totalLatencyPods := MultiplyInt $namespaces $latencyReplicas}}
 {{$saturationRCTimeout := DivideFloat $totalPods $TEST_THROUGHPUT | AddInt $MIN_SATURATION_PODS_TIMEOUT}}
-
+# saturationRCHardTimeout must be at least 15m to make sure that 10m node
+# failure won't fail the test.
+{{$saturationRCHardTimeout := MaxInt $saturationRCTimeout 900}}
 
 name: density
 automanagedNamespaces: {{$namespaces}}
@@ -54,13 +56,20 @@ steps:
       resourceConstraints: {{$DENSITY_RESOURCE_CONSTRAINTS_FILE}}
 # Create saturation pods
 - measurements:
+  - Identifier: SaturationPodStartupLatency
+    Method: PodStartupLatency
+    Params:
+      action: start
+      labelSelector: group = saturation
+      threshold: {{$saturationRCTimeout}}s
+- measurements:
   - Identifier: WaitForRunningSaturationRCs
     Method: WaitForControlledPodsRunning
     Params:
       action: start
       kind: ReplicationController
       labelSelector: group = saturation
-      operationTimeout: {{$saturationRCTimeout}}s
+      operationTimeout: {{$saturationRCHardTimeout}}s
 - phases:
   - namespaceRange:
       min: 1
@@ -87,6 +96,11 @@ steps:
     Params:
       action: gather
 - measurements:
+  - Identifier: SaturationPodStartupLatency
+    Method: PodStartupLatency
+    Params:
+      action: gather
+- measurements:
   - Identifier: SchedulingThroughput
     Method: SchedulingThroughput
     Params:
@@ -106,7 +120,7 @@ steps:
       action: start
       kind: ReplicationController
       labelSelector: group = latency
-      operationTimeout: 10m
+      operationTimeout: 15m
 - phases:
   - namespaceRange:
       min: 1

--- a/clusterloader2/testing/load/config.yaml
+++ b/clusterloader2/testing/load/config.yaml
@@ -63,7 +63,7 @@ steps:
       action: start
       kind: ReplicationController
       labelSelector: group = load
-      operationTimeout: 10m
+      operationTimeout: 15m
 - phases:
   - namespaceRange:
       min: 1


### PR DESCRIPTION
As operationTimeout for WaitForRunningSaturationRCs was dynamically computed, I changed hard deadline to 15m and moved logic to compare perc99 in SaturationPodStartupLatency.

/assign @wojtek-t 
/assign @krzysied 