### PR TITLE
Dns benchmark files rename

### DIFF
--- a/dns/run
+++ b/dns/run
@@ -33,5 +33,5 @@ esac
 
 if [ "$#" -eq 3 ]; then
   mkdir -p $3
-  go run ./jsonify/main.go --benchmarkDirPath=${outDir}/latest --jsonDirPath=$3 --benchmarkName=$1
+  go run ./jsonify/main.go --benchmarkDirPath=${outDir}/latest --jsonDirPath=$3 --benchmarkName="dns"
 fi

--- a/perfdash/Makefile
+++ b/perfdash/Makefile
@@ -1,7 +1,7 @@
 all: push
 
 # See pod.yaml for the version currently running-- bump this ahead before rebuilding!
-TAG = 1.16
+TAG = 1.17
 
 REPO = gcr.io/k8s-testimages
 

--- a/perfdash/config.go
+++ b/perfdash/config.go
@@ -186,24 +186,24 @@ var (
 	}
 
 	dnsBenchmarkDescriptions = TestDescriptions{
-		"kube-dns": {
+		"dns": {
 			"Latency": []TestDescription{{
-				Name:             "kube-dns",
+				Name:             "dns",
 				OutputFilePrefix: "Latency",
 				Parser:           parseResponsivenessData,
 			}},
 			"LatencyPerc": []TestDescription{{
-				Name:             "kube-dns",
+				Name:             "dns",
 				OutputFilePrefix: "LatencyPerc",
 				Parser:           parseResponsivenessData,
 			}},
 			"Queries": []TestDescription{{
-				Name:             "kube-dns",
+				Name:             "dns",
 				OutputFilePrefix: "Queries",
 				Parser:           parseResponsivenessData,
 			}},
 			"Qps": []TestDescription{{
-				Name:             "kube-dns",
+				Name:             "dns",
 				OutputFilePrefix: "Qps",
 				Parser:           parseResponsivenessData,
 			}},

--- a/perfdash/deployment.yaml
+++ b/perfdash/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: default
   labels:
     app: perfdash
-    version: "1.16"
+    version: "1.17"
 spec:
   selector:
     matchLabels:
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: perfdash
-        image: gcr.io/k8s-testimages/perfdash:1.16
+        image: gcr.io/k8s-testimages/perfdash:1.17
         command:
           - /perfdash
           -   --www=true


### PR DESCRIPTION
Renaming benchmark files to be more generic.
Will allow easier job creation + perfdash setup.