### PR TITLE
Change apiserver's memory limit to 1200M.

### DIFF
--- a/clusterloader2/testing/density/100_nodes/constraints.yaml
+++ b/clusterloader2/testing/density/100_nodes/constraints.yaml
@@ -9,7 +9,7 @@ heapster:
   nemoryConstraint: 367001600 #350 * (1024 * 1024)
 kube-apiserver:
   cpuConstraint: 2.0
-  memoryConstraint: 1048576000 #1000 * (1024 * 1024)
+  memoryConstraint: 1258291200 #1200 * (1024 * 1024)
 kube-controller-manager:
   cpuConstraint: 0.9
   memoryConstraint: 262144000 #250 * (1024 * 1024)


### PR DESCRIPTION
Right now the test is using approx. ~980M so we are way too close to the limit (and we are hitting the limit in -killer job).