### PR TITLE
ClusterLoader - Changing to original load RC randimized range

### DIFF
--- a/clusterloader2/testing/load/config.yaml
+++ b/clusterloader2/testing/load/config.yaml
@@ -149,7 +149,7 @@ steps:
       objectTemplatePath: rc.yaml
       templateFillMap:
         ReplicasMin: {{MultiplyInt $BIG_GROUP_SIZE 0.5}}
-        ReplicasMax: {{MultiplyInt $BIG_GROUP_SIZE 1.5}}
+        ReplicasMax: {{SubtractInt (MultiplyInt $BIG_GROUP_SIZE 1.5) 1}}
         SvcName: big-service
   - namespaceRange:
       min: 1
@@ -161,7 +161,7 @@ steps:
       objectTemplatePath: rc.yaml
       templateFillMap:
         ReplicasMin: {{MultiplyInt $MEDIUM_GROUP_SIZE 0.5}}
-        ReplicasMax: {{MultiplyInt $MEDIUM_GROUP_SIZE 1.5}}
+        ReplicasMax: {{SubtractInt (MultiplyInt $MEDIUM_GROUP_SIZE 1.5) 1}}
         SvcName: medium-service
   - namespaceRange:
       min: 1
@@ -173,7 +173,7 @@ steps:
       objectTemplatePath: rc.yaml
       templateFillMap:
         ReplicasMin: {{MultiplyInt $SMALL_GROUP_SIZE 0.5}}
-        ReplicasMax: {{MultiplyInt $SMALL_GROUP_SIZE 1.5}}
+        ReplicasMax: {{SubtractInt (MultiplyInt $SMALL_GROUP_SIZE 1.5) 1}}
         SvcName: small-service
 - measurements:
   - Identifier: WaitForRunningRCs


### PR DESCRIPTION
Changing replicas random range to match original tests: https://github.com/kubernetes/kubernetes/blob/49891cc270019245a3d4796e84b33bf36d0bae08/test/e2e/scalability/load.go#L674

ref #371 

Should reduce pod post calls.