### PR TITLE
Use os.MkdirAll instead of os.MkDir when creating report dir

### DIFF
--- a/clusterloader2/cmd/clusterloader.go
+++ b/clusterloader2/cmd/clusterloader.go
@@ -120,7 +120,7 @@ func createReportDir() error {
 			if !os.IsNotExist(err) {
 				return err
 			}
-			if err = os.Mkdir(clusterLoaderConfig.ReportDir, 0755); err != nil {
+			if err = os.MkdirAll(clusterLoaderConfig.ReportDir, 0755); err != nil {
 				return fmt.Errorf("report directory creation error: %v", err)
 			}
 		}


### PR DESCRIPTION
MkDirAll is an equivalent of mkdir -p command, it creates all necessary parent directories if needed.
