### PR TITLE
ClusterLoader - Making every second RC use svc

### DIFF
--- a/clusterloader2/testing/load/rc.yaml
+++ b/clusterloader2/testing/load/rc.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{.Name}}
   labels:
     group: load
-    svc: {{.SvcName}}-{{DivideInt .Index 2}}
+    svc: {{.SvcName}}-{{.Index}}
 spec:
   replicas: {{RandIntRange .ReplicasMin .ReplicasMax}}
   selector:
@@ -13,7 +13,7 @@ spec:
     metadata:
       labels:
         name: {{.Name}}
-        svc: {{.SvcName}}-{{DivideInt .Index 2}}
+        svc: {{.SvcName}}-{{.Index}}
     spec:
       containers:
       - image: k8s.gcr.io/pause:3.1


### PR DESCRIPTION
This change will make only half of pods to use SVCs. Same as in original load test.

ref #371