### PR TITLE
Revert "ClusterLoader - Changing to original load RC randimized range"

### DIFF
--- a/clusterloader2/testing/load/config.yaml
+++ b/clusterloader2/testing/load/config.yaml
@@ -151,7 +151,7 @@ steps:
       objectTemplatePath: rc.yaml
       templateFillMap:
         ReplicasMin: {{MultiplyInt $BIG_GROUP_SIZE 0.5}}
-        ReplicasMax: {{SubtractInt (MultiplyInt $BIG_GROUP_SIZE 1.5) 1}}
+        ReplicasMax: {{MultiplyInt $BIG_GROUP_SIZE 1.5}}
         SvcName: big-service
   - namespaceRange:
       min: 1
@@ -163,7 +163,7 @@ steps:
       objectTemplatePath: rc.yaml
       templateFillMap:
         ReplicasMin: {{MultiplyInt $MEDIUM_GROUP_SIZE 0.5}}
-        ReplicasMax: {{SubtractInt (MultiplyInt $MEDIUM_GROUP_SIZE 1.5) 1}}
+        ReplicasMax: {{MultiplyInt $MEDIUM_GROUP_SIZE 1.5}}
         SvcName: medium-service
   - namespaceRange:
       min: 1
@@ -175,7 +175,7 @@ steps:
       objectTemplatePath: rc.yaml
       templateFillMap:
         ReplicasMin: {{MultiplyInt $SMALL_GROUP_SIZE 0.5}}
-        ReplicasMax: {{SubtractInt (MultiplyInt $SMALL_GROUP_SIZE 1.5) 1}}
+        ReplicasMax: {{MultiplyInt $SMALL_GROUP_SIZE 1.5}}
         SvcName: small-service
 - measurements:
   - Identifier: WaitForRunningRCs


### PR DESCRIPTION
The last run of ci-kubernetes-e2e-gce-scale-performance-cl was successful.
#372 shouldn't have a big impact on test execution -  this change is being reverted. 

Reverts kubernetes/perf-tests#372