### PR TITLE
add kubemark ssh key env variable

### DIFF
--- a/clusterloader2/pkg/measurement/util/ssh.go
+++ b/clusterloader2/pkg/measurement/util/ssh.go
@@ -73,42 +73,51 @@ func SSH(cmd, host, provider string) (SSHResult, error) {
 // getSigner returns an ssh.Signer for the provider ("gce", etc.) that can be
 // used to SSH to their nodes.
 func getSigner(provider string) (ssh.Signer, error) {
-	// Get the directory in which SSH keys are located.
-	keydir := filepath.Join(os.Getenv("HOME"), ".ssh")
+	// honor a consistent SSH key across all providers
+	if path := os.Getenv("KUBE_SSH_KEY_PATH"); len(path) > 0 {
+		return sshutil.MakePrivateKeySignerFromFile(path)
+	}
 
 	// Select the key itself to use. When implementing more providers here,
 	// please also add them to any SSH tests that are disabled because of signer
 	// support.
 	keyfile := ""
-	key := ""
 	switch provider {
-	case "gce", "gke", "kubemark":
-		keyfile = "google_compute_engine"
-	case "aws":
-		// If there is an env. variable override, use that.
-		awsKeyfile := os.Getenv("AWS_SSH_KEY")
-		if len(awsKeyfile) != 0 {
-			return sshutil.MakePrivateKeySignerFromFile(awsKeyfile)
+	case "gce", "gke":
+		keyfile = os.Getenv("GCE_SSH_KEY")
+		if keyfile == "" {
+			keyfile = "google_compute_engine"
 		}
-		// Otherwise revert to home dir
-		keyfile = "kube_aws_rsa"
+	case "kubemark":
+		keyfile = os.Getenv("KUBEMARK_SSH_KEY")
+		if keyfile == "" {
+			keyfile = "google_compute_engine"
+		}
+	case "aws", "eks":
+		keyfile := os.Getenv("AWS_SSH_KEY")
+		if keyfile == "" {
+			keyfile = "kube_aws_rsa"
+		}
 	case "local", "vsphere":
-		keyfile = os.Getenv("LOCAL_SSH_KEY") // maybe?
-		if len(keyfile) == 0 {
+		keyfile = os.Getenv("LOCAL_SSH_KEY")
+		if keyfile == "" {
 			keyfile = "id_rsa"
 		}
 	case "skeleton":
 		keyfile = os.Getenv("KUBE_SSH_KEY")
-		if len(keyfile) == 0 {
+		if keyfile == "" {
 			keyfile = "id_rsa"
 		}
 	default:
 		return nil, fmt.Errorf("GetSigner(...) not implemented for %s", provider)
 	}
 
-	if len(key) == 0 {
-		key = filepath.Join(keydir, keyfile)
+	// Respect absolute paths for keys given by user, fallback to assuming
+	// relative paths are in ~/.ssh
+	if !filepath.IsAbs(keyfile) {
+		keydir := filepath.Join(os.Getenv("HOME"), ".ssh")
+		keyfile = filepath.Join(keydir, keyfile)
 	}
 
-	return sshutil.MakePrivateKeySignerFromFile(key)
+	return sshutil.MakePrivateKeySignerFromFile(keyfile)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR is a cherry pick from kubernetes/kubernetes
https://github.com/kubernetes/kubernetes/blob/9fd23b217800a312a45dbaedb70f4ffa65ec661b/test/e2e/framework/ssh.go#L36

**Additional**, this PR adds an environment variable `KUBEMARK_SSH_KEY` for provider `kubemark` SSH.
