### PR TITLE
ClusterLoader - Pod startup log

### DIFF
--- a/clusterloader2/pkg/measurement/common/simple/scheduling_throughput.go
+++ b/clusterloader2/pkg/measurement/common/simple/scheduling_throughput.go
@@ -107,7 +107,7 @@ func (s *schedulingThroughputMeasurement) start(clientSet clientset.Interface, n
 
 	go func() {
 		defer ps.Stop()
-		selectorsString := createSelectorsString(namespace, labelSelector, fieldSelector)
+		selectorsString := measurementutil.CreateSelectorsString(namespace, labelSelector, fieldSelector)
 		lastScheduledCount := 0
 		for {
 			select {

--- a/clusterloader2/pkg/measurement/common/simple/wait_for_pods.go
+++ b/clusterloader2/pkg/measurement/common/simple/wait_for_pods.go
@@ -104,7 +104,7 @@ func waitForPods(clientSet clientset.Interface, namespace, labelSelector, fieldS
 	defer ps.Stop()
 
 	var podsStatus measurementutil.PodsStartupStatus
-	selectorsString := createSelectorsString(namespace, labelSelector, fieldSelector)
+	selectorsString := measurementutil.CreateSelectorsString(namespace, labelSelector, fieldSelector)
 	scaling := uninitialized
 	var oldPods []*corev1.Pod
 	for {
@@ -147,21 +147,4 @@ func waitForPods(clientSet clientset.Interface, namespace, labelSelector, fieldS
 			oldPods = pods
 		}
 	}
-}
-
-func createSelectorsString(namespace, labelSelector, fieldSelector string) string {
-	var selectorsStrings []string
-	if namespace != metav1.NamespaceAll {
-		selectorsStrings = append(selectorsStrings, fmt.Sprintf("namespace(%s)", namespace))
-	}
-	if labelSelector != "" {
-		selectorsStrings = append(selectorsStrings, fmt.Sprintf("labelSelector(%s)", labelSelector))
-	}
-	if fieldSelector != "" {
-		selectorsStrings = append(selectorsStrings, fmt.Sprintf("fieldSelector(%s)", fieldSelector))
-	}
-	if len(selectorsStrings) == 0 {
-		return "everything"
-	}
-	return fmt.Sprint(strings.Join(selectorsStrings, ", "))
 }

--- a/clusterloader2/pkg/measurement/util/selector.go
+++ b/clusterloader2/pkg/measurement/util/selector.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"fmt"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// CreateSelectorsString creates a string representation for given namespace, label selector and field selector.
+func CreateSelectorsString(namespace, labelSelector, fieldSelector string) string {
+	var selectorsStrings []string
+	if namespace != metav1.NamespaceAll {
+		selectorsStrings = append(selectorsStrings, fmt.Sprintf("namespace(%s)", namespace))
+	}
+	if labelSelector != "" {
+		selectorsStrings = append(selectorsStrings, fmt.Sprintf("labelSelector(%s)", labelSelector))
+	}
+	if fieldSelector != "" {
+		selectorsStrings = append(selectorsStrings, fmt.Sprintf("fieldSelector(%s)", fieldSelector))
+	}
+	if len(selectorsStrings) == 0 {
+		return "everything"
+	}
+	return fmt.Sprint(strings.Join(selectorsStrings, ", "))
+}


### PR DESCRIPTION
- Extracting `createSelectorsString` to `mesurement/util`.
- Adding selectors string and threshold logging to `PodStartupLatency` measurement. The logging format will be consistent with `SchedulingThroughput` and `WaitForControlledPodsRunning`.

ref https://github.com/kubernetes/kubernetes/issues/74088