### PR TITLE
Bump up kube-proxy cpu constraint

### DIFF
--- a/clusterloader2/testing/density/100_nodes/constraints.yaml
+++ b/clusterloader2/testing/density/100_nodes/constraints.yaml
@@ -1,3 +1,10 @@
+# NOTE: If you're here to update the constraints please err on the side of using higher limits
+# rather than lower limits. The point of these constraints is to detect changes in resource
+# consumption but not at the expense of test flakiness. Thus, the constrains should be significantly
+# higher than the actual consumption, e.g. we should get notified if a component starts using 5x
+# more resources, but not necessarily if it starts using 10% more resources as it may lead to
+# test flakiness.
+
 coredns:
   cpuConstraint: 0.05
   memoryConstraint: 31457280 #30 * (1024 * 1024)
@@ -14,7 +21,7 @@ kube-controller-manager:
   cpuConstraint: 1.1
   memoryConstraint: 314572800 #300 * (1024 * 1024)
 kube-proxy:
-  cpuConstraint: 0.05
+  cpuConstraint: 0.1
   memoryConstraint: 31457280 #30 * (1024 * 1024)
 kube-scheduler:
   cpuConstraint: 0.35


### PR DESCRIPTION
This is to prevent flakes like https://github.com/kubernetes/kubernetes/issues/73461#issuecomment-464619155:
```
[measurement call TestMetrics - TestMetrics error: [resource constraints: 1 constraints violated: [container kube-proxy-e2e-big-minion-group-m4xc/kube-proxy is using 0.051962892/0.05 CPU]]]
```