### PR TITLE
ClusterLoader - Add dynmaic client for WaitForControlledPodsRunning

### DIFF
--- a/clusterloader2/pkg/framework/framework.go
+++ b/clusterloader2/pkg/framework/framework.go
@@ -69,6 +69,11 @@ func (f *Framework) GetClientSets() *MultiClientSet {
 	return f.clientSets
 }
 
+// GetDynamicClients returns dynamic clients.
+func (f *Framework) GetDynamicClients() *MultiDynamicClient {
+	return f.dynamicClients
+}
+
 // CreateAutomanagedNamespaces creates automanged namespaces.
 func (f *Framework) CreateAutomanagedNamespaces(namespaceCount int) error {
 	if f.automanagedNamespaceCount != 0 {

--- a/clusterloader2/pkg/measurement/interface.go
+++ b/clusterloader2/pkg/measurement/interface.go
@@ -25,6 +25,8 @@ import (
 type MeasurementConfig struct {
 	// Clientsets are kubernetes clients.
 	ClientSets *framework.MultiClientSet
+	// DynamicClients are kuberentes dynamic clients.
+	DynamicClients *framework.MultiDynamicClient
 	// ClusterConfig represents configuration of the cluster.
 	ClusterConfig *config.ClusterConfig
 	// Params is a map of {name: value} pairs enabling for injection of arbitrary config

--- a/clusterloader2/pkg/measurement/manager.go
+++ b/clusterloader2/pkg/measurement/manager.go
@@ -26,6 +26,7 @@ import (
 // MeasurementManager manages all measurement executions.
 type MeasurementManager struct {
 	clientSets       *framework.MultiClientSet
+	dynamicClients   *framework.MultiDynamicClient
 	clusterConfig    *config.ClusterConfig
 	templateProvider *config.TemplateProvider
 
@@ -36,9 +37,10 @@ type MeasurementManager struct {
 }
 
 // CreateMeasurementManager creates new instance of MeasurementManager.
-func CreateMeasurementManager(clientSets *framework.MultiClientSet, clusterConfig *config.ClusterConfig, templateProvider *config.TemplateProvider) *MeasurementManager {
+func CreateMeasurementManager(f *framework.Framework, clusterConfig *config.ClusterConfig, templateProvider *config.TemplateProvider) *MeasurementManager {
 	return &MeasurementManager{
-		clientSets:       clientSets,
+		clientSets:       f.GetClientSets(),
+		dynamicClients:   f.GetDynamicClients(),
 		clusterConfig:    clusterConfig,
 		templateProvider: templateProvider,
 		measurements:     make(map[string]map[string]Measurement),
@@ -54,6 +56,7 @@ func (mm *MeasurementManager) Execute(methodName string, identifier string, para
 	}
 	config := &MeasurementConfig{
 		ClientSets:       mm.clientSets,
+		DynamicClients:   mm.dynamicClients,
 		ClusterConfig:    mm.clusterConfig,
 		Params:           params,
 		TemplateProvider: mm.templateProvider,

--- a/clusterloader2/pkg/measurement/util/runtimeobjects/runtimeobjects.go
+++ b/clusterloader2/pkg/measurement/util/runtimeobjects/runtimeobjects.go
@@ -33,8 +33,8 @@ import (
 	"k8s.io/perf-tests/clusterloader2/pkg/framework/client"
 )
 
-// TODO: using dynamic interface rather than clientset interface
 // ListRuntimeObjectsForKind returns objects of given kind that satisfy given namespace, labelSelector and fieldSelector.
+// TODO: using dynamic interface rather than clientset interface
 func ListRuntimeObjectsForKind(c clientset.Interface, kind, namespace, labelSelector, fieldSelector string) ([]runtime.Object, error) {
 	var runtimeObjectsList []runtime.Object
 	var listFunc func() error

--- a/clusterloader2/pkg/measurement/util/runtimeobjects/runtimeobjects_test.go
+++ b/clusterloader2/pkg/measurement/util/runtimeobjects/runtimeobjects_test.go
@@ -1,0 +1,332 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package runtimeobjects_test
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	apps "k8s.io/api/apps/v1"
+	batch "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	extensions "k8s.io/api/extensions/v1beta1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/perf-tests/clusterloader2/pkg/measurement/util/runtimeobjects"
+)
+
+var (
+	controllerName         = "foobar"
+	testNamespace          = "test-namespace"
+	defaultResourceVersion = "1"
+	defaultReplicas        = int32(10)
+)
+
+var (
+	simpleLabel = map[string]string{"foo": "bar"}
+)
+
+var replicationcontroller = &corev1.ReplicationController{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:            controllerName,
+		Namespace:       testNamespace,
+		ResourceVersion: defaultResourceVersion,
+	},
+	Spec: corev1.ReplicationControllerSpec{
+		Replicas: &defaultReplicas,
+		Selector: simpleLabel,
+		Template: &v1.PodTemplateSpec{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: simpleLabel,
+			},
+			Spec: resourcePodSpec("", "50M", "0.5"),
+		},
+	},
+}
+
+var replicaset = &extensions.ReplicaSet{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:            controllerName,
+		Namespace:       testNamespace,
+		ResourceVersion: defaultResourceVersion,
+	},
+	Spec: extensions.ReplicaSetSpec{
+		Replicas: &defaultReplicas,
+		Selector: &metav1.LabelSelector{
+			MatchLabels: simpleLabel,
+		},
+		Template: v1.PodTemplateSpec{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: simpleLabel,
+			},
+			Spec: resourcePodSpec("", "50M", "0.5"),
+		},
+	},
+}
+
+var deployment = &apps.Deployment{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:            controllerName,
+		Namespace:       testNamespace,
+		ResourceVersion: defaultResourceVersion,
+	},
+	Spec: apps.DeploymentSpec{
+		Replicas: &defaultReplicas,
+		Selector: &metav1.LabelSelector{
+			MatchLabels: simpleLabel,
+		},
+		Template: v1.PodTemplateSpec{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: simpleLabel,
+			},
+			Spec: resourcePodSpec("", "50M", "0.5"),
+		},
+	},
+}
+
+var daemonset = &apps.DaemonSet{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:            controllerName,
+		Namespace:       testNamespace,
+		ResourceVersion: defaultResourceVersion,
+	},
+	Spec: apps.DaemonSetSpec{
+		Selector: &metav1.LabelSelector{
+			MatchLabels: simpleLabel,
+		},
+		Template: v1.PodTemplateSpec{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: simpleLabel,
+			},
+			Spec: resourcePodSpec("", "50M", "0.5"),
+		},
+	},
+}
+
+var job = &batch.Job{
+	TypeMeta: metav1.TypeMeta{Kind: "Job"},
+	ObjectMeta: metav1.ObjectMeta{
+		Name:            controllerName,
+		Namespace:       testNamespace,
+		ResourceVersion: defaultResourceVersion,
+	},
+	Spec: batch.JobSpec{
+		Parallelism: &defaultReplicas,
+		Selector: &metav1.LabelSelector{
+			MatchLabels: simpleLabel,
+		},
+		Template: v1.PodTemplateSpec{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: simpleLabel,
+			},
+			Spec: resourcePodSpec("", "50M", "0.5"),
+		},
+	},
+}
+
+func resourcePodSpec(nodeName, memory, cpu string) v1.PodSpec {
+	return v1.PodSpec{
+		NodeName: nodeName,
+		Containers: []v1.Container{{
+			Resources: v1.ResourceRequirements{
+				Requests: allocatableResources(memory, cpu),
+			},
+		}},
+	}
+}
+
+func allocatableResources(memory, cpu string) v1.ResourceList {
+	return v1.ResourceList{
+		v1.ResourceMemory: resource.MustParse(memory),
+		v1.ResourceCPU:    resource.MustParse(cpu),
+		v1.ResourcePods:   resource.MustParse("100"),
+	}
+}
+
+func TestGetNameFromRuntimeObject(t *testing.T) {
+	objects := []runtime.Object{
+		replicationcontroller,
+		replicaset,
+		deployment,
+		job,
+		daemonset,
+	}
+
+	for _, obj := range objects {
+		unstructured := &unstructured.Unstructured{}
+		if err := scheme.Scheme.Convert(obj, unstructured, nil); err != nil {
+			t.Fatalf("error converting controller to unstructured: %v", err)
+		}
+		name, err := runtimeobjects.GetNameFromRuntimeObject(unstructured)
+		if err != nil {
+			t.Fatalf("get name from runtime object failed: %v", err)
+		}
+
+		if controllerName != name {
+			t.Fatalf("Unexpected name from runtime object, expected: %s, actual: %s", controllerName, name)
+		}
+	}
+}
+
+func TestGetNamespaceFromRuntimeObject(t *testing.T) {
+	objects := []runtime.Object{
+		replicationcontroller,
+		replicaset,
+		deployment,
+		job,
+		daemonset,
+	}
+	for _, obj := range objects {
+		unstructured := &unstructured.Unstructured{}
+		if err := scheme.Scheme.Convert(obj, unstructured, nil); err != nil {
+			t.Fatalf("error converting controller to unstructured: %v", err)
+		}
+		namespace, err := runtimeobjects.GetNamespaceFromRuntimeObject(unstructured)
+		if err != nil {
+			t.Fatalf("get namespace from runtime object failed: %v", err)
+		}
+
+		if testNamespace != namespace {
+			t.Fatalf("Unexpected namespace from runtime object, expected: %s, actual: %s", testNamespace, namespace)
+		}
+	}
+}
+
+func TestGetResourceVersionFromRuntimeObject(t *testing.T) {
+	objects := []runtime.Object{
+		replicationcontroller,
+		replicaset,
+		deployment,
+		job,
+		daemonset,
+	}
+	for _, obj := range objects {
+		unstructured := &unstructured.Unstructured{}
+		if err := scheme.Scheme.Convert(obj, unstructured, nil); err != nil {
+			t.Fatalf("error converting controller to unstructured: %v", err)
+		}
+		rv, err := runtimeobjects.GetResourceVersionFromRuntimeObject(unstructured)
+		if err != nil {
+			t.Fatalf("get resource version from runtime object failed: %v", err)
+		}
+
+		if defaultResourceVersion != fmt.Sprint(rv) {
+			t.Fatalf("Unexpected resource version from runtime object, expected: %s, actual: %v", defaultResourceVersion, rv)
+		}
+	}
+}
+
+func TestGetSelectorFromRuntimeObject(t *testing.T) {
+	objects := []runtime.Object{
+		replicationcontroller,
+		replicaset,
+		deployment,
+		job,
+		daemonset,
+	}
+
+	ps := &metav1.LabelSelector{
+		MatchLabels: simpleLabel,
+	}
+	expected, err := metav1.LabelSelectorAsSelector(ps)
+	if err != nil {
+		t.Fatalf("create label selector failed: %v", err)
+	}
+	for _, obj := range objects {
+		unstructured := &unstructured.Unstructured{}
+		if err := scheme.Scheme.Convert(obj, unstructured, nil); err != nil {
+			t.Fatalf("error converting controller to unstructured: %v", err)
+		}
+		selector, err := runtimeobjects.GetSelectorFromRuntimeObject(unstructured)
+		if err != nil {
+			t.Fatalf("get selector from runtime object failed: %v", err)
+		}
+
+		if !reflect.DeepEqual(expected, selector) {
+			t.Fatalf("Unexpected selector from runtime object, expected: %d, actual: %d", expected, selector)
+		}
+	}
+}
+func TestGetSpecFromRuntimeObject(t *testing.T) {
+	objects := []runtime.Object{
+		replicationcontroller,
+		replicaset,
+		deployment,
+		job,
+		daemonset,
+	}
+	expected := []interface{}{
+		replicationcontroller.Spec,
+		replicaset.Spec,
+		deployment.Spec,
+		job.Spec,
+		daemonset.Spec,
+	}
+	for i, obj := range objects {
+		unstructured := &unstructured.Unstructured{}
+		if err := scheme.Scheme.Convert(obj, unstructured, nil); err != nil {
+			t.Fatalf("error converting controller to unstructured: %v", err)
+		}
+		spec, err := runtimeobjects.GetSpecFromRuntimeObject(unstructured)
+		if err != nil {
+			t.Fatalf("get spec from runtime object failed: %v", err)
+		}
+		target, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&expected[i])
+		if err != nil {
+			t.Fatalf("error converting target spec to unstructured: %v", err)
+		}
+
+		if !reflect.DeepEqual(target, spec) {
+			t.Fatalf("Unexpected spec from runtime object, expected: %v, actual: %v", expected[i], spec)
+		}
+	}
+}
+
+func TestGetReplicasFromRuntimeObject(t *testing.T) {
+	objects := []runtime.Object{
+		replicationcontroller,
+		replicaset,
+		deployment,
+		job,
+		daemonset,
+	}
+	expected := []int32{
+		defaultReplicas,
+		defaultReplicas,
+		defaultReplicas,
+		defaultReplicas,
+		0,
+	}
+	for i, obj := range objects {
+		unstructured := &unstructured.Unstructured{}
+		if err := scheme.Scheme.Convert(obj, unstructured, nil); err != nil {
+			t.Fatalf("error converting controller to unstructured: %v", err)
+		}
+		replicas, err := runtimeobjects.GetReplicasFromRuntimeObject(unstructured)
+		if err != nil {
+			t.Fatalf("get replicas from runtime object failed: %v", err)
+		}
+
+		if expected[i] != replicas {
+			t.Fatalf("Unexpected replicas from runtime object, expected: %d, actual: %d", expected[i], replicas)
+		}
+	}
+}

--- a/clusterloader2/pkg/measurement/util/runtimeobjects/runtimeobjects_test.go
+++ b/clusterloader2/pkg/measurement/util/runtimeobjects/runtimeobjects_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package runtimeobjects_test
 
 import (

--- a/clusterloader2/pkg/test/simple_context.go
+++ b/clusterloader2/pkg/test/simple_context.go
@@ -45,7 +45,7 @@ func createSimpleContext(c *config.ClusterLoaderConfig, f *framework.Framework, 
 		state:               s,
 		templateProvider:    templateProvider,
 		tuningSetFactory:    tuningset.NewTuningSetFactory(),
-		measurementManager:  measurement.CreateMeasurementManager(f.GetClientSets(), &c.ClusterConfig, templateProvider),
+		measurementManager:  measurement.CreateMeasurementManager(f, &c.ClusterConfig, templateProvider),
 		chaosMonkey:         chaos.NewMonkey(f.GetClientSets().GetClient(), c.ClusterConfig.Provider),
 	}
 }

--- a/clusterloader2/testing/density/config.yaml
+++ b/clusterloader2/testing/density/config.yaml
@@ -66,7 +66,7 @@ steps:
   - Identifier: WaitForRunningSaturationRCs
     Method: WaitForControlledPodsRunning
     Params:
-      actiom: start
+      action: start
       apiVersion: v1
       kind: ReplicationController
       labelSelector: group = saturation

--- a/clusterloader2/testing/density/config.yaml
+++ b/clusterloader2/testing/density/config.yaml
@@ -66,7 +66,8 @@ steps:
   - Identifier: WaitForRunningSaturationRCs
     Method: WaitForControlledPodsRunning
     Params:
-      action: start
+      actiom: start
+      apiVersion: v1
       kind: ReplicationController
       labelSelector: group = saturation
       operationTimeout: {{$saturationRCHardTimeout}}s
@@ -118,6 +119,7 @@ steps:
     Method: WaitForControlledPodsRunning
     Params:
       action: start
+      apiVersion: v1
       kind: ReplicationController
       labelSelector: group = latency
       operationTimeout: 15m

--- a/clusterloader2/testing/load/config.yaml
+++ b/clusterloader2/testing/load/config.yaml
@@ -93,6 +93,7 @@ steps:
     Method: WaitForControlledPodsRunning
     Params:
       action: start
+      apiVersion: v1
       kind: ReplicationController
       labelSelector: group = load
       operationTimeout: 15m

--- a/clusterloader2/testing/node-throughput/config.yaml
+++ b/clusterloader2/testing/node-throughput/config.yaml
@@ -27,6 +27,7 @@ steps:
     Method: WaitForControlledPodsRunning
     Params:
       action: start
+      apiVersion: v1
       kind: ReplicationController
       labelSelector: group = latency
       operationTimeout: 15m

--- a/clusterloader2/vendor/k8s.io/client-go/dynamic/dynamicinformer/informer.go
+++ b/clusterloader2/vendor/k8s.io/client-go/dynamic/dynamicinformer/informer.go
@@ -45,6 +45,7 @@ func NewFilteredDynamicSharedInformerFactory(client dynamic.Interface, defaultRe
 		namespace:        metav1.NamespaceAll,
 		informers:        map[schema.GroupVersionResource]informers.GenericInformer{},
 		startedInformers: make(map[schema.GroupVersionResource]bool),
+		tweakListOptions: tweakListOptions,
 	}
 }
 
@@ -58,6 +59,7 @@ type dynamicSharedInformerFactory struct {
 	// startedInformers is used for tracking which informers have been started.
 	// This allows Start() to be called multiple times safely.
 	startedInformers map[schema.GroupVersionResource]bool
+	tweakListOptions TweakListOptionsFunc
 }
 
 var _ DynamicSharedInformerFactory = &dynamicSharedInformerFactory{}
@@ -72,7 +74,7 @@ func (f *dynamicSharedInformerFactory) ForResource(gvr schema.GroupVersionResour
 		return informer
 	}
 
-	informer = NewFilteredDynamicInformer(f.client, gvr, f.namespace, f.defaultResync, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, nil)
+	informer = NewFilteredDynamicInformer(f.client, gvr, f.namespace, f.defaultResync, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
 	f.informers[key] = informer
 
 	return informer

--- a/clusterloader2/vendor/k8s.io/client-go/dynamic/dynamicinformer/informer.go
+++ b/clusterloader2/vendor/k8s.io/client-go/dynamic/dynamicinformer/informer.go
@@ -1,0 +1,155 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dynamicinformer
+
+import (
+	"sync"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/dynamic/dynamiclister"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/tools/cache"
+)
+
+// NewDynamicSharedInformerFactory constructs a new instance of dynamicSharedInformerFactory for all namespaces.
+func NewDynamicSharedInformerFactory(client dynamic.Interface, defaultResync time.Duration) DynamicSharedInformerFactory {
+	return NewFilteredDynamicSharedInformerFactory(client, defaultResync, metav1.NamespaceAll, nil)
+}
+
+// NewFilteredDynamicSharedInformerFactory constructs a new instance of dynamicSharedInformerFactory.
+// Listers obtained via this factory will be subject to the same filters as specified here.
+func NewFilteredDynamicSharedInformerFactory(client dynamic.Interface, defaultResync time.Duration, namespace string, tweakListOptions TweakListOptionsFunc) DynamicSharedInformerFactory {
+	return &dynamicSharedInformerFactory{
+		client:           client,
+		defaultResync:    defaultResync,
+		namespace:        metav1.NamespaceAll,
+		informers:        map[schema.GroupVersionResource]informers.GenericInformer{},
+		startedInformers: make(map[schema.GroupVersionResource]bool),
+	}
+}
+
+type dynamicSharedInformerFactory struct {
+	client        dynamic.Interface
+	defaultResync time.Duration
+	namespace     string
+
+	lock      sync.Mutex
+	informers map[schema.GroupVersionResource]informers.GenericInformer
+	// startedInformers is used for tracking which informers have been started.
+	// This allows Start() to be called multiple times safely.
+	startedInformers map[schema.GroupVersionResource]bool
+}
+
+var _ DynamicSharedInformerFactory = &dynamicSharedInformerFactory{}
+
+func (f *dynamicSharedInformerFactory) ForResource(gvr schema.GroupVersionResource) informers.GenericInformer {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+
+	key := gvr
+	informer, exists := f.informers[key]
+	if exists {
+		return informer
+	}
+
+	informer = NewFilteredDynamicInformer(f.client, gvr, f.namespace, f.defaultResync, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, nil)
+	f.informers[key] = informer
+
+	return informer
+}
+
+// Start initializes all requested informers.
+func (f *dynamicSharedInformerFactory) Start(stopCh <-chan struct{}) {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+
+	for informerType, informer := range f.informers {
+		if !f.startedInformers[informerType] {
+			go informer.Informer().Run(stopCh)
+			f.startedInformers[informerType] = true
+		}
+	}
+}
+
+// WaitForCacheSync waits for all started informers' cache were synced.
+func (f *dynamicSharedInformerFactory) WaitForCacheSync(stopCh <-chan struct{}) map[schema.GroupVersionResource]bool {
+	informers := func() map[schema.GroupVersionResource]cache.SharedIndexInformer {
+		f.lock.Lock()
+		defer f.lock.Unlock()
+
+		informers := map[schema.GroupVersionResource]cache.SharedIndexInformer{}
+		for informerType, informer := range f.informers {
+			if f.startedInformers[informerType] {
+				informers[informerType] = informer.Informer()
+			}
+		}
+		return informers
+	}()
+
+	res := map[schema.GroupVersionResource]bool{}
+	for informType, informer := range informers {
+		res[informType] = cache.WaitForCacheSync(stopCh, informer.HasSynced)
+	}
+	return res
+}
+
+// NewFilteredDynamicInformer constructs a new informer for a dynamic type.
+func NewFilteredDynamicInformer(client dynamic.Interface, gvr schema.GroupVersionResource, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions TweakListOptionsFunc) informers.GenericInformer {
+	return &dynamicInformer{
+		gvr: gvr,
+		informer: cache.NewSharedIndexInformer(
+			&cache.ListWatch{
+				ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+					if tweakListOptions != nil {
+						tweakListOptions(&options)
+					}
+					return client.Resource(gvr).Namespace(namespace).List(options)
+				},
+				WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+					if tweakListOptions != nil {
+						tweakListOptions(&options)
+					}
+					return client.Resource(gvr).Namespace(namespace).Watch(options)
+				},
+			},
+			&unstructured.Unstructured{},
+			resyncPeriod,
+			indexers,
+		),
+	}
+}
+
+type dynamicInformer struct {
+	informer cache.SharedIndexInformer
+	gvr      schema.GroupVersionResource
+}
+
+var _ informers.GenericInformer = &dynamicInformer{}
+
+func (d *dynamicInformer) Informer() cache.SharedIndexInformer {
+	return d.informer
+}
+
+func (d *dynamicInformer) Lister() cache.GenericLister {
+	return dynamiclister.NewRuntimeObjectShim(dynamiclister.New(d.informer.GetIndexer(), d.gvr))
+}

--- a/clusterloader2/vendor/k8s.io/client-go/dynamic/dynamicinformer/interface.go
+++ b/clusterloader2/vendor/k8s.io/client-go/dynamic/dynamicinformer/interface.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dynamicinformer
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/informers"
+)
+
+// DynamicSharedInformerFactory provides access to a shared informer and lister for dynamic client
+type DynamicSharedInformerFactory interface {
+	Start(stopCh <-chan struct{})
+	ForResource(gvr schema.GroupVersionResource) informers.GenericInformer
+	WaitForCacheSync(stopCh <-chan struct{}) map[schema.GroupVersionResource]bool
+}
+
+// TweakListOptionsFunc defines the signature of a helper function
+// that wants to provide more listing options to API
+type TweakListOptionsFunc func(*metav1.ListOptions)

--- a/clusterloader2/vendor/k8s.io/client-go/dynamic/dynamiclister/interface.go
+++ b/clusterloader2/vendor/k8s.io/client-go/dynamic/dynamiclister/interface.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dynamiclister
+
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+// Lister helps list resources.
+type Lister interface {
+	// List lists all resources in the indexer.
+	List(selector labels.Selector) (ret []*unstructured.Unstructured, err error)
+	// Get retrieves a resource from the indexer with the given name
+	Get(name string) (*unstructured.Unstructured, error)
+	// Namespace returns an object that can list and get resources in a given namespace.
+	Namespace(namespace string) NamespaceLister
+}
+
+// NamespaceLister helps list and get resources.
+type NamespaceLister interface {
+	// List lists all resources in the indexer for a given namespace.
+	List(selector labels.Selector) (ret []*unstructured.Unstructured, err error)
+	// Get retrieves a resource from the indexer for a given namespace and name.
+	Get(name string) (*unstructured.Unstructured, error)
+}

--- a/clusterloader2/vendor/k8s.io/client-go/dynamic/dynamiclister/lister.go
+++ b/clusterloader2/vendor/k8s.io/client-go/dynamic/dynamiclister/lister.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dynamiclister
+
+import (
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/tools/cache"
+)
+
+var _ Lister = &dynamicLister{}
+var _ NamespaceLister = &dynamicNamespaceLister{}
+
+// dynamicLister implements the Lister interface.
+type dynamicLister struct {
+	indexer cache.Indexer
+	gvr     schema.GroupVersionResource
+}
+
+// New returns a new Lister.
+func New(indexer cache.Indexer, gvr schema.GroupVersionResource) Lister {
+	return &dynamicLister{indexer: indexer, gvr: gvr}
+}
+
+// List lists all resources in the indexer.
+func (l *dynamicLister) List(selector labels.Selector) (ret []*unstructured.Unstructured, err error) {
+	err = cache.ListAll(l.indexer, selector, func(m interface{}) {
+		ret = append(ret, m.(*unstructured.Unstructured))
+	})
+	return ret, err
+}
+
+// Get retrieves a resource from the indexer with the given name
+func (l *dynamicLister) Get(name string) (*unstructured.Unstructured, error) {
+	obj, exists, err := l.indexer.GetByKey(name)
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		return nil, errors.NewNotFound(l.gvr.GroupResource(), name)
+	}
+	return obj.(*unstructured.Unstructured), nil
+}
+
+// Namespace returns an object that can list and get resources from a given namespace.
+func (l *dynamicLister) Namespace(namespace string) NamespaceLister {
+	return &dynamicNamespaceLister{indexer: l.indexer, namespace: namespace, gvr: l.gvr}
+}
+
+// dynamicNamespaceLister implements the NamespaceLister interface.
+type dynamicNamespaceLister struct {
+	indexer   cache.Indexer
+	namespace string
+	gvr       schema.GroupVersionResource
+}
+
+// List lists all resources in the indexer for a given namespace.
+func (l *dynamicNamespaceLister) List(selector labels.Selector) (ret []*unstructured.Unstructured, err error) {
+	err = cache.ListAllByNamespace(l.indexer, l.namespace, selector, func(m interface{}) {
+		ret = append(ret, m.(*unstructured.Unstructured))
+	})
+	return ret, err
+}
+
+// Get retrieves a resource from the indexer for a given namespace and name.
+func (l *dynamicNamespaceLister) Get(name string) (*unstructured.Unstructured, error) {
+	obj, exists, err := l.indexer.GetByKey(l.namespace + "/" + name)
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		return nil, errors.NewNotFound(l.gvr.GroupResource(), name)
+	}
+	return obj.(*unstructured.Unstructured), nil
+}

--- a/clusterloader2/vendor/k8s.io/client-go/dynamic/dynamiclister/shim.go
+++ b/clusterloader2/vendor/k8s.io/client-go/dynamic/dynamiclister/shim.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dynamiclister
+
+import (
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/cache"
+)
+
+var _ cache.GenericLister = &dynamicListerShim{}
+var _ cache.GenericNamespaceLister = &dynamicNamespaceListerShim{}
+
+// dynamicListerShim implements the cache.GenericLister interface.
+type dynamicListerShim struct {
+	lister Lister
+}
+
+// NewRuntimeObjectShim returns a new shim for Lister.
+// It wraps Lister so that it implements cache.GenericLister interface
+func NewRuntimeObjectShim(lister Lister) cache.GenericLister {
+	return &dynamicListerShim{lister: lister}
+}
+
+// List will return all objects across namespaces
+func (s *dynamicListerShim) List(selector labels.Selector) (ret []runtime.Object, err error) {
+	objs, err := s.lister.List(selector)
+	if err != nil {
+		return nil, err
+	}
+
+	ret = make([]runtime.Object, len(objs))
+	for index, obj := range objs {
+		ret[index] = obj
+	}
+	return ret, err
+}
+
+// Get will attempt to retrieve assuming that name==key
+func (s *dynamicListerShim) Get(name string) (runtime.Object, error) {
+	return s.lister.Get(name)
+}
+
+func (s *dynamicListerShim) ByNamespace(namespace string) cache.GenericNamespaceLister {
+	return &dynamicNamespaceListerShim{
+		namespaceLister: s.lister.Namespace(namespace),
+	}
+}
+
+// dynamicNamespaceListerShim implements the NamespaceLister interface.
+// It wraps NamespaceLister so that it implements cache.GenericNamespaceLister interface
+type dynamicNamespaceListerShim struct {
+	namespaceLister NamespaceLister
+}
+
+// List will return all objects in this namespace
+func (ns *dynamicNamespaceListerShim) List(selector labels.Selector) (ret []runtime.Object, err error) {
+	objs, err := ns.namespaceLister.List(selector)
+	if err != nil {
+		return nil, err
+	}
+
+	ret = make([]runtime.Object, len(objs))
+	for index, obj := range objs {
+		ret[index] = obj
+	}
+	return ret, err
+}
+
+// Get will attempt to retrieve by namespace and name
+func (ns *dynamicNamespaceListerShim) Get(name string) (runtime.Object, error) {
+	return ns.namespaceLister.Get(name)
+}


### PR DESCRIPTION
**Why we need it**:
Fix https://github.com/kubernetes/perf-tests/issues/414

**What this PR does**:
1. Add vendor k8s.io/client-go/dynamic/dynamicinformer
 (There is still a bug fix not merged https://github.com/kubernetes/kubernetes/pull/74344, but in my PR, it's the fixed version)
2. Add parameter apiVersion for `WaitForControlledPodsRunning`
3. Support dynamic informer for `WaitForControlledPodsRunning`

**Something not sure**:
1. I think my PR handle tombstone in a wrong way, but i do not what's right.
https://github.com/Betula-L/perf-tests/blob/60100ff37cf2ad366366dd7b298602da14fe602c/clusterloader2/pkg/measurement/common/simple/wait_for_controlled_pods.go#L179
2. I prefer to remove the useless `switch-case` for followed code.
https://github.com/kubernetes/perf-tests/blob/3ea5f47bceb00d54f6edb3cf36bb1ce98646577d/clusterloader2/pkg/measurement/util/runtimeobjects/runtimeobjects.go#L169

**Something need to be improved**:
It still has `switch-case` in the code. I do not modify the followed code due to the complex reference for it. 
https://github.com/Betula-L/perf-tests/blob/60100ff37cf2ad366366dd7b298602da14fe602c/clusterloader2/pkg/measurement/util/runtimeobjects/runtimeobjects.go#L34