### PR TITLE
Recording rule for Network Programming Latency.

### DIFF
--- a/clusterloader2/pkg/prometheus/manifests/grafana-dashboardDefinitions.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/grafana-dashboardDefinitions.yaml
@@ -25,22 +25,9 @@ items:
           "editable": true,
           "gnetId": null,
           "graphTooltip": 0,
-          "id": 10,
+          "id": 2,
           "links": [],
           "panels": [
-            {
-              "collapsed": false,
-              "gridPos": {
-                "h": 1,
-                "w": 24,
-                "x": 0,
-                "y": 0
-              },
-              "id": 4,
-              "panels": [],
-              "title": "Network Programming Latency",
-              "type": "row"
-            },
             {
               "aliasColors": {},
               "bars": false,
@@ -49,10 +36,10 @@ items:
               "datasource": "prometheus",
               "fill": 1,
               "gridPos": {
-                "h": 11,
-                "w": 13,
+                "h": 18,
+                "w": 12,
                 "x": 0,
-                "y": 1
+                "y": 0
               },
               "id": 2,
               "legend": {
@@ -77,32 +64,186 @@ items:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "histogram_quantile(0.99, sum(rate(kubeproxy_network_programming_latency_seconds_bucket[10m])) by (le))",
+                  "expr": "kubeproxy:kubeproxy_network_programming_latency:histogram_quantile",
                   "format": "time_series",
                   "intervalFactor": 1,
-                  "legendFormat": "99pctl",
+                  "legendFormat": "",
                   "refId": "A"
-                },
-                {
-                  "expr": "histogram_quantile(0.95, sum(rate(kubeproxy_network_programming_latency_seconds_bucket[10m])) by (le))",
-                  "format": "time_series",
-                  "intervalFactor": 1,
-                  "legendFormat": "90pctl",
-                  "refId": "B"
-                },
-                {
-                  "expr": "histogram_quantile(0.50, sum(rate(kubeproxy_network_programming_latency_seconds_bucket[10m])) by (le))",
-                  "format": "time_series",
-                  "intervalFactor": 1,
-                  "legendFormat": "50pctl",
-                  "refId": "C"
                 }
               ],
               "thresholds": [],
               "timeFrom": null,
               "timeRegions": [],
               "timeShift": null,
-              "title": "Network Programming Latency [s]",
+              "title": "Network Programming Latency",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                }
+              ],
+              "yaxis": {
+                "align": false,
+                "alignLevel": null
+              }
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": "prometheus",
+              "fill": 1,
+              "gridPos": {
+                "h": 9,
+                "w": 12,
+                "x": 12,
+                "y": 0
+              },
+              "id": 4,
+              "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "nullPointMode": "null",
+              "paceLength": 10,
+              "percentage": false,
+              "pointradius": 2,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "kubeproxy:kubeproxy_network_programming_latency:histogram_quantile{quantile='0.99'}",
+                  "format": "time_series",
+                  "intervalFactor": 1,
+                  "legendFormat": "",
+                  "refId": "A"
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeRegions": [],
+              "timeShift": null,
+              "title": "Network Programming Latency SLI (99pctl)",
+              "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+              },
+              "type": "graph",
+              "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+              },
+              "yaxes": [
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                },
+                {
+                  "format": "short",
+                  "label": null,
+                  "logBase": 1,
+                  "max": null,
+                  "min": null,
+                  "show": true
+                }
+              ],
+              "yaxis": {
+                "align": false,
+                "alignLevel": null
+              }
+            },
+            {
+              "aliasColors": {},
+              "bars": false,
+              "dashLength": 10,
+              "dashes": false,
+              "datasource": "prometheus",
+              "fill": 1,
+              "gridPos": {
+                "h": 9,
+                "w": 12,
+                "x": 12,
+                "y": 9
+              },
+              "id": 3,
+              "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+              },
+              "lines": true,
+              "linewidth": 1,
+              "nullPointMode": "null",
+              "paceLength": 10,
+              "percentage": false,
+              "pointradius": 2,
+              "points": false,
+              "renderer": "flot",
+              "seriesOverrides": [],
+              "stack": false,
+              "steppedLine": false,
+              "targets": [
+                {
+                  "expr": "quantile_over_time(0.99, kubeproxy:kubeproxy_network_programming_latency:histogram_quantile{quantile='0.99'}[1h])",
+                  "format": "time_series",
+                  "intervalFactor": 1,
+                  "legendFormat": "99pctl of SLI over last 1h",
+                  "refId": "A"
+                }
+              ],
+              "thresholds": [],
+              "timeFrom": null,
+              "timeRegions": [],
+              "timeShift": null,
+              "title": "99pctl of SLI over last 1h",
               "tooltip": {
                 "shared": true,
                 "sort": 0,
@@ -148,7 +289,7 @@ items:
             "list": []
           },
           "time": {
-            "from": "now-1h",
+            "from": "now-3h",
             "to": "now"
           },
           "timepicker": {
@@ -178,6 +319,6 @@ items:
           },
           "timezone": "",
           "title": "Network Programming Latency",
-          "uid": "jYJO9Sriz",
-          "version": 3
+          "uid": "-9FDjs9mz",
+          "version": 10
         }

--- a/clusterloader2/pkg/prometheus/manifests/prometheus-rules.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/prometheus-rules.yaml
@@ -1,0 +1,27 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: k8s
+    role: alert-rules
+  name: prometheus-k8s-rules
+  namespace: monitoring
+spec:
+  groups:
+  - name: kube-proxy.rules
+    rules:
+    - expr: |
+        histogram_quantile(0.99, sum(rate(kubeproxy_network_programming_latency_seconds_bucket[5m])) by (le))
+      record: kubeproxy:kubeproxy_network_programming_latency:histogram_quantile
+      labels:
+        quantile: "0.99"
+    - expr: |
+        histogram_quantile(0.90, sum(rate(kubeproxy_network_programming_latency_seconds_bucket[5m])) by (le))
+      record: kubeproxy:kubeproxy_network_programming_latency:histogram_quantile
+      labels:
+        quantile: "0.90"
+    - expr: |
+        histogram_quantile(0.50, sum(rate(kubeproxy_network_programming_latency_seconds_bucket[5m])) by (le))
+      record: kubeproxy:kubeproxy_network_programming_latency:histogram_quantile
+      labels:
+        quantile: "0.50"

--- a/clusterloader2/pkg/prometheus/manifests/prometheus-serviceMonitorKubeProxy.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/prometheus-serviceMonitorKubeProxy.yaml
@@ -9,12 +9,10 @@ spec:
   endpoints:
       # We modify interval depending on the cluster size to avoid collecting too many samples for
       # large clusters. Also because the tests run longer in bigger clusters we don't need to
-      # collect them as often as in smaller clusters. For example if in 100 node cluster the test
-      # takes 10min it's useful to gather metrics every 30s. On the other hand if the test takes
-      # 10h collecting metrics every 5min is still good enough. The expression below should give us
-      # 30s interval for small clusters (up to 500 nodes), 2.5min interval for 2K node clusters and
-      # 5.5min interval for 5K node clusters.
-    - interval: {{MultiplyInt 30 (AddInt 1 (DivideInt .Nodes 500))}}s
+      # collect them as often as in smaller clusters. We use 30s interval for small clusters
+      # (# nodes <= 1000) and 1min interval in big clusters (# nodes > 1000)
+    - # TODO(mm4tt): Once we prove the interval works in big clusters, simplify the expression.
+    - interval: {{MinInt 60 (MultiplyInt 30 (AddInt 1 (DivideInt .Nodes 1001)))}}s
       port: http-metrics
   jobLabel: k8s-app
   namespaceSelector:


### PR DESCRIPTION
The rule will be used in the Network Programming Latency dashboard.
It's recommended by Prometheus documentation to use recording rules for
dashboards, see https://prometheus.io/docs/prometheus/latest/configuration/recording_rules/

I've also modified the Network Programming Latency dashboard to align it with the SLI/SLO definition.

I also modified the kube-proxy scrape interval, as now thanks to the recording rule we should be able to scrape the metrics more often.
