### PR TITLE
Add ability to tear down prometheus stack.

### DIFF
--- a/clusterloader2/cmd/clusterloader.go
+++ b/clusterloader2/cmd/clusterloader.go
@@ -68,6 +68,7 @@ func validateClusterFlags() *errors.ErrorList {
 func initFlags() {
 	flags.StringVar(&clusterLoaderConfig.ReportDir, "report-dir", "", "Path to the directory where the reports should be saved. Default is empty, which cause reports being written to standard output.")
 	flags.BoolVar(&clusterLoaderConfig.EnablePrometheusServer, "enable-prometheus-server", false, "Whether to set-up the prometheus server in the cluster.")
+	flags.BoolVar(&clusterLoaderConfig.TearDownPrometheusServer, "tear-down-prometheus-server", true, "Whether to tear-down the prometheus server after tests (if set-up).")
 	flags.StringArrayVar(&testConfigPaths, "testconfig", []string{}, "Paths to the test config files")
 	flags.StringArrayVar(&clusterLoaderConfig.TestOverridesPath, "testoverrides", []string{}, "Paths to the config overrides file. The latter overrides take precedence over changes in former files.")
 	initClusterFlags()
@@ -222,5 +223,11 @@ func main() {
 	junitReporter.SpecSuiteDidEnd(suiteSummary)
 	if suiteSummary.NumberOfFailedSpecs > 0 {
 		klog.Fatalf("%d tests have failed!", suiteSummary.NumberOfFailedSpecs)
+	}
+
+	if clusterLoaderConfig.EnablePrometheusServer && clusterLoaderConfig.TearDownPrometheusServer {
+		if err := prometheus.TearDownPrometheusStack(f); err != nil {
+			klog.Errorf("Error while tearing down prometheus stack: %v", err)
+		}
 	}
 }

--- a/clusterloader2/pkg/config/cluster.go
+++ b/clusterloader2/pkg/config/cluster.go
@@ -18,11 +18,12 @@ package config
 
 // ClusterLoaderConfig represents all flags used by CLusterLoader
 type ClusterLoaderConfig struct {
-	ClusterConfig          ClusterConfig `json: clusterConfig`
-	ReportDir              string        `json: reportDir`
-	EnablePrometheusServer bool          `json: enablePrometheusServer`
-	TestConfigPath         string        `json: testConfigPath`
-	TestOverridesPath      []string      `json: testOverrides`
+	ClusterConfig            ClusterConfig `json: clusterConfig`
+	ReportDir                string        `json: reportDir`
+	EnablePrometheusServer   bool          `json: enablePrometheusServer`
+	TearDownPrometheusServer bool          `json: tearDownPrometheusServer`
+	TestConfigPath           string        `json: testConfigPath`
+	TestOverridesPath        []string      `json: testOverrides`
 }
 
 // ClusterConfig is a structure that represents cluster description.

--- a/clusterloader2/pkg/prometheus/prometheus.go
+++ b/clusterloader2/pkg/prometheus/prometheus.go
@@ -48,6 +48,19 @@ func SetUpPrometheusStack(
 	return nil
 }
 
+// TearDownPrometheusStack tears down prometheus stack, releasing all prometheus resources.
+func TearDownPrometheusStack(framework *framework.Framework) error {
+	klog.Info("Tearing down prometheus stack")
+	k8sClient := framework.GetClientSets().GetClient()
+	if err := client.DeleteNamespace(k8sClient, namespace); err != nil {
+		return err
+	}
+	if err := client.WaitForDeleteNamespace(k8sClient, namespace); err != nil {
+		return err
+	}
+	return nil
+}
+
 func applyManifests(
 	framework *framework.Framework, clusterLoaderConfig *config.ClusterLoaderConfig) error {
 	// TODO(mm4tt): Consider using the out-of-the-box "kubectl create -f".

--- a/verify/verify-flags/known-flags.txt
+++ b/verify/verify-flags/known-flags.txt
@@ -16,3 +16,4 @@ right-job-name
 run-selection-scheme
 report-dir
 enable-prometheus-server
+tear-down-prometheus-server


### PR DESCRIPTION
I cofirmed that deleting the namespace deletes the PV which in turns deletes disks in GCE.
This should help us fix the "leaked resources" errors, e.g. https://gubernator.k8s.io/build/kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-scalability-killer/1964

Putting this behind a flag, so one can disable it and leave prometheus stack for further analysis when running tests manually.