### PR TITLE
Clusterloader - update vendor client-go dynamic package

### DIFF
--- a/clusterloader2/vendor/k8s.io/client-go/dynamic/dynamicinformer/informer.go
+++ b/clusterloader2/vendor/k8s.io/client-go/dynamic/dynamicinformer/informer.go
@@ -1,0 +1,157 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dynamicinformer
+
+import (
+	"sync"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/dynamic/dynamiclister"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/tools/cache"
+)
+
+// NewDynamicSharedInformerFactory constructs a new instance of dynamicSharedInformerFactory for all namespaces.
+func NewDynamicSharedInformerFactory(client dynamic.Interface, defaultResync time.Duration) DynamicSharedInformerFactory {
+	return NewFilteredDynamicSharedInformerFactory(client, defaultResync, metav1.NamespaceAll, nil)
+}
+
+// NewFilteredDynamicSharedInformerFactory constructs a new instance of dynamicSharedInformerFactory.
+// Listers obtained via this factory will be subject to the same filters as specified here.
+func NewFilteredDynamicSharedInformerFactory(client dynamic.Interface, defaultResync time.Duration, namespace string, tweakListOptions TweakListOptionsFunc) DynamicSharedInformerFactory {
+	return &dynamicSharedInformerFactory{
+		client:           client,
+		defaultResync:    defaultResync,
+		namespace:        metav1.NamespaceAll,
+		informers:        map[schema.GroupVersionResource]informers.GenericInformer{},
+		startedInformers: make(map[schema.GroupVersionResource]bool),
+		tweakListOptions: tweakListOptions,
+	}
+}
+
+type dynamicSharedInformerFactory struct {
+	client        dynamic.Interface
+	defaultResync time.Duration
+	namespace     string
+
+	lock      sync.Mutex
+	informers map[schema.GroupVersionResource]informers.GenericInformer
+	// startedInformers is used for tracking which informers have been started.
+	// This allows Start() to be called multiple times safely.
+	startedInformers map[schema.GroupVersionResource]bool
+	tweakListOptions TweakListOptionsFunc
+}
+
+var _ DynamicSharedInformerFactory = &dynamicSharedInformerFactory{}
+
+func (f *dynamicSharedInformerFactory) ForResource(gvr schema.GroupVersionResource) informers.GenericInformer {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+
+	key := gvr
+	informer, exists := f.informers[key]
+	if exists {
+		return informer
+	}
+
+	informer = NewFilteredDynamicInformer(f.client, gvr, f.namespace, f.defaultResync, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	f.informers[key] = informer
+
+	return informer
+}
+
+// Start initializes all requested informers.
+func (f *dynamicSharedInformerFactory) Start(stopCh <-chan struct{}) {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+
+	for informerType, informer := range f.informers {
+		if !f.startedInformers[informerType] {
+			go informer.Informer().Run(stopCh)
+			f.startedInformers[informerType] = true
+		}
+	}
+}
+
+// WaitForCacheSync waits for all started informers' cache were synced.
+func (f *dynamicSharedInformerFactory) WaitForCacheSync(stopCh <-chan struct{}) map[schema.GroupVersionResource]bool {
+	informers := func() map[schema.GroupVersionResource]cache.SharedIndexInformer {
+		f.lock.Lock()
+		defer f.lock.Unlock()
+
+		informers := map[schema.GroupVersionResource]cache.SharedIndexInformer{}
+		for informerType, informer := range f.informers {
+			if f.startedInformers[informerType] {
+				informers[informerType] = informer.Informer()
+			}
+		}
+		return informers
+	}()
+
+	res := map[schema.GroupVersionResource]bool{}
+	for informType, informer := range informers {
+		res[informType] = cache.WaitForCacheSync(stopCh, informer.HasSynced)
+	}
+	return res
+}
+
+// NewFilteredDynamicInformer constructs a new informer for a dynamic type.
+func NewFilteredDynamicInformer(client dynamic.Interface, gvr schema.GroupVersionResource, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions TweakListOptionsFunc) informers.GenericInformer {
+	return &dynamicInformer{
+		gvr: gvr,
+		informer: cache.NewSharedIndexInformer(
+			&cache.ListWatch{
+				ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+					if tweakListOptions != nil {
+						tweakListOptions(&options)
+					}
+					return client.Resource(gvr).Namespace(namespace).List(options)
+				},
+				WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+					if tweakListOptions != nil {
+						tweakListOptions(&options)
+					}
+					return client.Resource(gvr).Namespace(namespace).Watch(options)
+				},
+			},
+			&unstructured.Unstructured{},
+			resyncPeriod,
+			indexers,
+		),
+	}
+}
+
+type dynamicInformer struct {
+	informer cache.SharedIndexInformer
+	gvr      schema.GroupVersionResource
+}
+
+var _ informers.GenericInformer = &dynamicInformer{}
+
+func (d *dynamicInformer) Informer() cache.SharedIndexInformer {
+	return d.informer
+}
+
+func (d *dynamicInformer) Lister() cache.GenericLister {
+	return dynamiclister.NewRuntimeObjectShim(dynamiclister.New(d.informer.GetIndexer(), d.gvr))
+}

--- a/clusterloader2/vendor/k8s.io/client-go/dynamic/dynamicinformer/interface.go
+++ b/clusterloader2/vendor/k8s.io/client-go/dynamic/dynamicinformer/interface.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dynamicinformer
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/informers"
+)
+
+// DynamicSharedInformerFactory provides access to a shared informer and lister for dynamic client
+type DynamicSharedInformerFactory interface {
+	Start(stopCh <-chan struct{})
+	ForResource(gvr schema.GroupVersionResource) informers.GenericInformer
+	WaitForCacheSync(stopCh <-chan struct{}) map[schema.GroupVersionResource]bool
+}
+
+// TweakListOptionsFunc defines the signature of a helper function
+// that wants to provide more listing options to API
+type TweakListOptionsFunc func(*metav1.ListOptions)

--- a/clusterloader2/vendor/k8s.io/client-go/dynamic/dynamiclister/interface.go
+++ b/clusterloader2/vendor/k8s.io/client-go/dynamic/dynamiclister/interface.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dynamiclister
+
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+// Lister helps list resources.
+type Lister interface {
+	// List lists all resources in the indexer.
+	List(selector labels.Selector) (ret []*unstructured.Unstructured, err error)
+	// Get retrieves a resource from the indexer with the given name
+	Get(name string) (*unstructured.Unstructured, error)
+	// Namespace returns an object that can list and get resources in a given namespace.
+	Namespace(namespace string) NamespaceLister
+}
+
+// NamespaceLister helps list and get resources.
+type NamespaceLister interface {
+	// List lists all resources in the indexer for a given namespace.
+	List(selector labels.Selector) (ret []*unstructured.Unstructured, err error)
+	// Get retrieves a resource from the indexer for a given namespace and name.
+	Get(name string) (*unstructured.Unstructured, error)
+}

--- a/clusterloader2/vendor/k8s.io/client-go/dynamic/dynamiclister/lister.go
+++ b/clusterloader2/vendor/k8s.io/client-go/dynamic/dynamiclister/lister.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dynamiclister
+
+import (
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/tools/cache"
+)
+
+var _ Lister = &dynamicLister{}
+var _ NamespaceLister = &dynamicNamespaceLister{}
+
+// dynamicLister implements the Lister interface.
+type dynamicLister struct {
+	indexer cache.Indexer
+	gvr     schema.GroupVersionResource
+}
+
+// New returns a new Lister.
+func New(indexer cache.Indexer, gvr schema.GroupVersionResource) Lister {
+	return &dynamicLister{indexer: indexer, gvr: gvr}
+}
+
+// List lists all resources in the indexer.
+func (l *dynamicLister) List(selector labels.Selector) (ret []*unstructured.Unstructured, err error) {
+	err = cache.ListAll(l.indexer, selector, func(m interface{}) {
+		ret = append(ret, m.(*unstructured.Unstructured))
+	})
+	return ret, err
+}
+
+// Get retrieves a resource from the indexer with the given name
+func (l *dynamicLister) Get(name string) (*unstructured.Unstructured, error) {
+	obj, exists, err := l.indexer.GetByKey(name)
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		return nil, errors.NewNotFound(l.gvr.GroupResource(), name)
+	}
+	return obj.(*unstructured.Unstructured), nil
+}
+
+// Namespace returns an object that can list and get resources from a given namespace.
+func (l *dynamicLister) Namespace(namespace string) NamespaceLister {
+	return &dynamicNamespaceLister{indexer: l.indexer, namespace: namespace, gvr: l.gvr}
+}
+
+// dynamicNamespaceLister implements the NamespaceLister interface.
+type dynamicNamespaceLister struct {
+	indexer   cache.Indexer
+	namespace string
+	gvr       schema.GroupVersionResource
+}
+
+// List lists all resources in the indexer for a given namespace.
+func (l *dynamicNamespaceLister) List(selector labels.Selector) (ret []*unstructured.Unstructured, err error) {
+	err = cache.ListAllByNamespace(l.indexer, l.namespace, selector, func(m interface{}) {
+		ret = append(ret, m.(*unstructured.Unstructured))
+	})
+	return ret, err
+}
+
+// Get retrieves a resource from the indexer for a given namespace and name.
+func (l *dynamicNamespaceLister) Get(name string) (*unstructured.Unstructured, error) {
+	obj, exists, err := l.indexer.GetByKey(l.namespace + "/" + name)
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		return nil, errors.NewNotFound(l.gvr.GroupResource(), name)
+	}
+	return obj.(*unstructured.Unstructured), nil
+}

--- a/clusterloader2/vendor/k8s.io/client-go/dynamic/dynamiclister/shim.go
+++ b/clusterloader2/vendor/k8s.io/client-go/dynamic/dynamiclister/shim.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dynamiclister
+
+import (
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/cache"
+)
+
+var _ cache.GenericLister = &dynamicListerShim{}
+var _ cache.GenericNamespaceLister = &dynamicNamespaceListerShim{}
+
+// dynamicListerShim implements the cache.GenericLister interface.
+type dynamicListerShim struct {
+	lister Lister
+}
+
+// NewRuntimeObjectShim returns a new shim for Lister.
+// It wraps Lister so that it implements cache.GenericLister interface
+func NewRuntimeObjectShim(lister Lister) cache.GenericLister {
+	return &dynamicListerShim{lister: lister}
+}
+
+// List will return all objects across namespaces
+func (s *dynamicListerShim) List(selector labels.Selector) (ret []runtime.Object, err error) {
+	objs, err := s.lister.List(selector)
+	if err != nil {
+		return nil, err
+	}
+
+	ret = make([]runtime.Object, len(objs))
+	for index, obj := range objs {
+		ret[index] = obj
+	}
+	return ret, err
+}
+
+// Get will attempt to retrieve assuming that name==key
+func (s *dynamicListerShim) Get(name string) (runtime.Object, error) {
+	return s.lister.Get(name)
+}
+
+func (s *dynamicListerShim) ByNamespace(namespace string) cache.GenericNamespaceLister {
+	return &dynamicNamespaceListerShim{
+		namespaceLister: s.lister.Namespace(namespace),
+	}
+}
+
+// dynamicNamespaceListerShim implements the NamespaceLister interface.
+// It wraps NamespaceLister so that it implements cache.GenericNamespaceLister interface
+type dynamicNamespaceListerShim struct {
+	namespaceLister NamespaceLister
+}
+
+// List will return all objects in this namespace
+func (ns *dynamicNamespaceListerShim) List(selector labels.Selector) (ret []runtime.Object, err error) {
+	objs, err := ns.namespaceLister.List(selector)
+	if err != nil {
+		return nil, err
+	}
+
+	ret = make([]runtime.Object, len(objs))
+	for index, obj := range objs {
+		ret[index] = obj
+	}
+	return ret, err
+}
+
+// Get will attempt to retrieve by namespace and name
+func (ns *dynamicNamespaceListerShim) Get(name string) (runtime.Object, error) {
+	return ns.namespaceLister.Get(name)
+}

--- a/clusterloader2/vendor/vendor.json
+++ b/clusterloader2/vendor/vendor.json
@@ -1593,6 +1593,18 @@
 			"revisionTime": "2019-01-25T16:53:23Z"
 		},
 		{
+			"checksumSHA1": "f+ceByRAeMWUaJSXOyl6XU+sCZM=",
+			"path": "k8s.io/client-go/dynamic/dynamicinformer",
+			"revision": "bad694ec20e3ad1bf3ede898519b4948962639b7",
+			"revisionTime": "2019-02-27T19:13:30Z"
+		},
+		{
+			"checksumSHA1": "WfKRROXLQa2PlkzPSYkShi2PMt0=",
+			"path": "k8s.io/client-go/dynamic/dynamiclister",
+			"revision": "bad694ec20e3ad1bf3ede898519b4948962639b7",
+			"revisionTime": "2019-02-27T19:13:30Z"
+		},
+		{
 			"checksumSHA1": "5pTv/cMlAwArcD8Kyx2VjL63O+Y=",
 			"path": "k8s.io/client-go/informers",
 			"revision": "6134db91200ea474868bc6775e62cc294a74c6c6",


### PR DESCRIPTION
**Why we need it**:
https://github.com/kubernetes/perf-tests/issues/414

**What this PR does**:
Related to https://github.com/kubernetes/perf-tests/pull/423

This PR only update packages `k8s.io/client-go/dynamic/dynamicinformer` and `k8s.io/client-go/dynamic/dynamiclister`, so that their revisions are different from package `k8s.io/client-go/dynamic`. However, it's compatible.

**What not update `k8s.io/client-go/dynamic`**:

This commit update `k8s.io/apimachinery/pkg/apis/meta/v1`, https://github.com/kubernetes/kubernetes/commit/0e1d50e70fdc9ed838d75a7a1abbe5fa607d22a1, but i think i should not update it.
