### PR TITLE
ClusterLoader - Replace clientset by dynamic client

### DIFF
--- a/clusterloader2/pkg/measurement/common/simple/wait_for_controlled_pods.go
+++ b/clusterloader2/pkg/measurement/common/simple/wait_for_controlled_pods.go
@@ -14,11 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-/*
-TODO(krzysied): Replace ClientSet interface with dynamic client.
-This will allow more generic approach.
-*/
-
 package simple
 
 import (
@@ -27,12 +22,16 @@ import (
 	"sync"
 	"time"
 
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/dynamic/dynamicinformer"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog"
+
 	"k8s.io/perf-tests/clusterloader2/pkg/errors"
 	"k8s.io/perf-tests/clusterloader2/pkg/framework"
 	"k8s.io/perf-tests/clusterloader2/pkg/measurement"
@@ -62,6 +61,7 @@ func createWaitForControlledPodsRunningMeasurement() measurement.Measurement {
 
 type waitForControlledPodsRunningMeasurement struct {
 	informer          cache.SharedInformer
+	apiVersion        string
 	kind              string
 	namespace         string
 	labelSelector     string
@@ -74,6 +74,7 @@ type waitForControlledPodsRunningMeasurement struct {
 	handlingGroup     wait.Group
 	lock              sync.Mutex
 	opResourceVersion uint64
+	gvr               schema.GroupVersionResource
 	checkerMap        map[string]*objectChecker
 	clients           multiClients
 }
@@ -104,6 +105,10 @@ func (w *waitForControlledPodsRunningMeasurement) Execute(config *measurement.Me
 
 	switch action {
 	case "start":
+		w.apiVersion, err = util.GetString(config.Params, "apiVersion")
+		if err != nil {
+			return summaries, err
+		}
 		w.kind, err = util.GetString(config.Params, "kind")
 		if err != nil {
 			return summaries, err
@@ -154,25 +159,20 @@ func (*waitForControlledPodsRunningMeasurement) String() string {
 	return waitForControlledPodsRunningName
 }
 
-func (w *waitForControlledPodsRunningMeasurement) start() error {
-	if w.informer != nil {
-		klog.Infof("%v: wait for controlled pods measurement already running", w)
-		return nil
-	}
-	klog.Infof("%v: starting wait for controlled pods measurement...", w)
+func (w *waitForControlledPodsRunningMeasurement) newInformer() (cache.SharedInformer, error) {
 	optionsModifier := func(options *metav1.ListOptions) {
 		options.FieldSelector = w.fieldSelector
 		options.LabelSelector = w.labelSelector
 	}
-	c := w.clients.MultiClientSet
+	c := w.clients.DynamicClients
 	if c == nil {
-		return fmt.Errorf("no clientsets for measurement")
+		return nil, fmt.Errorf("no clientsets for measurement")
 	}
-	listerWatcher := cache.NewFilteredListWatchFromClient(c.GetClient().CoreV1().RESTClient(), w.kind+"s", w.namespace, optionsModifier)
-	w.isRunning = true
-	w.stopCh = make(chan struct{})
-	w.informer = cache.NewSharedInformer(listerWatcher, nil, 0)
-	w.informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	tweakListOptions := dynamicinformer.TweakListOptionsFunc(optionsModifier)
+	dInformerFactory := dynamicinformer.NewFilteredDynamicSharedInformerFactory(c.GetClient(), 0, w.namespace, tweakListOptions)
+
+	informer := dInformerFactory.ForResource(w.gvr).Informer()
+	informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			addF := func() {
 				w.handleObject(nil, obj)
@@ -196,6 +196,31 @@ func (w *waitForControlledPodsRunningMeasurement) start() error {
 			w.queue.Add(&deleteF)
 		},
 	})
+
+	return informer, nil
+}
+func (w *waitForControlledPodsRunningMeasurement) start() error {
+	gv, err := schema.ParseGroupVersion(w.apiVersion)
+	if err != nil {
+		return err
+	}
+	gvk := gv.WithKind(w.kind)
+	w.gvr, _ = meta.UnsafeGuessKindToResource(gvk)
+
+	if w.informer != nil {
+		klog.Infof("%v: wait for controlled pods measurement already running", w)
+		return nil
+	}
+	klog.Infof("%v: starting wait for controlled pods measurement...", w)
+
+	w.isRunning = true
+	w.stopCh = make(chan struct{})
+
+	w.informer, err = w.newInformer()
+	if err != nil {
+		klog.Infof("%v: create dynamic informer failed.", w)
+		return err
+	}
 
 	for i := 0; i < waitForControlledPodsWorkers; i++ {
 		w.workerGroup.Start(w.worker)

--- a/clusterloader2/testing/density/config.yaml
+++ b/clusterloader2/testing/density/config.yaml
@@ -67,6 +67,7 @@ steps:
     Method: WaitForControlledPodsRunning
     Params:
       action: start
+      apiVersion: v1
       kind: ReplicationController
       labelSelector: group = saturation
       operationTimeout: {{$saturationRCHardTimeout}}s
@@ -118,6 +119,7 @@ steps:
     Method: WaitForControlledPodsRunning
     Params:
       action: start
+      apiVersion: v1
       kind: ReplicationController
       labelSelector: group = latency
       operationTimeout: 15m

--- a/clusterloader2/testing/load/config.yaml
+++ b/clusterloader2/testing/load/config.yaml
@@ -93,6 +93,7 @@ steps:
     Method: WaitForControlledPodsRunning
     Params:
       action: start
+      apiVersion: v1
       kind: ReplicationController
       labelSelector: group = load
       operationTimeout: 15m

--- a/clusterloader2/testing/node-throughput/config.yaml
+++ b/clusterloader2/testing/node-throughput/config.yaml
@@ -27,6 +27,7 @@ steps:
     Method: WaitForControlledPodsRunning
     Params:
       action: start
+      apiVersion: v1
       kind: ReplicationController
       labelSelector: group = latency
       operationTimeout: 15m


### PR DESCRIPTION
**Why we need it**:
This is the final PR for fixing https://github.com/kubernetes/perf-tests/issues/414

**What this PR does**:
Related to https://github.com/kubernetes/perf-tests/pull/423

1. Replace clientset by dynamic client.
2. Update clusterloader2 testing configs

**What is not sure for me**:
I don't know whether it handles tombstone correctly.
