### PR TITLE
Bump l7-lb-controller cpu constraint to 0.20

### DIFF
--- a/clusterloader2/testing/density/100_nodes/constraints.yaml
+++ b/clusterloader2/testing/density/100_nodes/constraints.yaml
@@ -27,5 +27,5 @@ kube-scheduler:
   cpuConstraint: 0.35
   memoryConstraint: 125829120 #120 * (1024 * 1024)
 l7-lb-controller:
-  cpuConstraint: 0.15
+  cpuConstraint: 0.20
   memoryConstraint: 83886080 #80 * (1024 * 1024)


### PR DESCRIPTION
This is to address the following test failure (flakiness): https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-scalability-killer/2153