### PR TITLE
Prometheus - disable creating Kublet Endpoints

### DIFF
--- a/clusterloader2/pkg/prometheus/manifests/0prometheus-operator-deployment.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/0prometheus-operator-deployment.yaml
@@ -17,7 +17,6 @@ spec:
     spec:
       containers:
       - args:
-        - --kubelet-service=kube-system/kubelet
         - --logtostderr=true
         - --config-reloader-image=quay.io/coreos/configmap-reload:v0.0.1
         - --prometheus-config-reloader=quay.io/coreos/prometheus-config-reloader:v0.28.0


### PR DESCRIPTION
We don't monitor kubelets via Prometheus in scale tests, thus we can disable creation of the Endpoints object for kubelets.

An alternative would be to wait for the Kubelet Endpoints object to be created before running tests. 
But, for now, disabling the Kubelet Endpoints object creation is simply a better solution.

Ref. https://github.com/kubernetes/kubernetes/issues/75284