### PR TITLE
CL2 should fail on Prometheus set-up errors.

### DIFF
--- a/clusterloader2/cmd/clusterloader.go
+++ b/clusterloader2/cmd/clusterloader.go
@@ -188,7 +188,7 @@ func main() {
 	}
 	if clusterLoaderConfig.EnablePrometheusServer {
 		if err := prometheus.SetUpPrometheusStack(f, &clusterLoaderConfig); err != nil {
-			klog.Errorf("Error while setting up prometheus stack: %v", err)
+			klog.Fatalf("Error while setting up prometheus stack: %v", err)
 		}
 	}
 


### PR DESCRIPTION
As the Prometheus Server is going to become a standard way of measuring SLIs in scale-tests we should make the ClusterLoader2 fail if it's not able to set up the Prometheus stack. 
It doesn't make sense to run tests if we're not able to measure SLIs.

Ref. https://github.com/kubernetes/kubernetes/issues/75284