### PR TITLE
Introduce KUBEMARK_ROOT_KUBECONFIG env variable.

### DIFF
--- a/clusterloader2/cmd/clusterloader.go
+++ b/clusterloader2/cmd/clusterloader.go
@@ -55,8 +55,7 @@ func initClusterFlags() {
 	flags.StringEnvVar(&clusterLoaderConfig.ClusterConfig.Provider, "provider", "PROVIDER", "", "Cluster provider")
 	flags.StringEnvVar(&clusterLoaderConfig.ClusterConfig.MasterName, "mastername", "MASTER_NAME", "", "Name of the masternode")
 	flags.StringEnvVar(&clusterLoaderConfig.ClusterConfig.MasterIP, "masterip", "MASTER_IP", "", "Hostname/IP of the masternode")
-	// TODO(mm4tt): Consider introducing new env variable with a better name that would replace the DEFAULT_KUBECONFIG.
-	flags.StringEnvVar(&clusterLoaderConfig.ClusterConfig.KubemarkRootKubeConfigPath, "kubemark-root-kubeconfig", "DEFAULT_KUBECONFIG", "",
+	flags.StringEnvVar(&clusterLoaderConfig.ClusterConfig.KubemarkRootKubeConfigPath, "kubemark-root-kubeconfig", "KUBEMARK_ROOT_KUBECONFIG", "",
 		"Path the to kubemark root kubeconfig file, i.e. kubeconfig of the cluster where kubemark cluster is run. Ignored if provider != kubemark")
 }
 

--- a/clusterloader2/run-e2e.sh
+++ b/clusterloader2/run-e2e.sh
@@ -20,6 +20,7 @@ set -o pipefail
 
 CLUSTERLOADER_ROOT=$(dirname "${BASH_SOURCE}")
 export KUBECONFIG="${KUBECONFIG:-${HOME}/.kube/config}"
+export KUBEMARK_ROOT_KUBECONFIG="${KUBEMARK_ROOT_KUBECONFIG:-${HOME}/.kube/config}"
 
 cd ${CLUSTERLOADER_ROOT}/ && go build -o clusterloader './cmd/'
 ./clusterloader --alsologtostderr "$@"


### PR DESCRIPTION
The KUBEMARK_ROOT_KUBECONFIG variable is replacing DEFAULT_KUBECONFIG that turned out to be not propagated to clusterloader2.