### PR TITLE
Use $MASTER_IP to scrape kubemark's apiserver metrics

### DIFF
--- a/clusterloader2/pkg/prometheus/manifests/kubemark/kube-apiserver-endpoints.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/kubemark/kube-apiserver-endpoints.yaml
@@ -8,7 +8,7 @@ metadata:
     k8s-app: kube-apiserver
 subsets:
   - addresses:
-      - ip: {{.KubemarkMasterClusterIp}}
+      - ip: {{.KubemarkMasterIp}}
     ports:
       - name: https
         port: 443

--- a/clusterloader2/pkg/prometheus/prometheus.go
+++ b/clusterloader2/pkg/prometheus/prometheus.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"time"
 
@@ -78,10 +77,7 @@ func NewPrometheusController(clusterLoaderConfig *config.ClusterLoaderConfig) (p
 		return nil, errList
 	}
 	if pc.isKubemark {
-		mapping["KubemarkMasterClusterIp"], err = getKubemarkMasterClusterIp()
-		if err != nil {
-			return nil, err
-		}
+		mapping["KubemarkMasterIp"] = clusterLoaderConfig.ClusterConfig.MasterIP
 	}
 	pc.templateMapping = mapping
 
@@ -268,13 +264,6 @@ type targetsData struct {
 type target struct {
 	Labels map[string]string `json:"labels"`
 	Health string            `json:"health"`
-}
-
-func getKubemarkMasterClusterIp() (string, error) {
-	cmd := exec.Command("gcloud", "compute", "instances", "list",
-		"--format", "value(networkInterfaces[0].networkIP)", "--filter", "name ~ kubemark-master")
-	output, err := cmd.Output()
-	return string(output), err
 }
 
 func retryCreateFunction(f func() error) error {


### PR DESCRIPTION
Previously we've used kubemark master's cluster ip, but I don't think there is any gain in doing that.
What's more the way we implemented getting the master's cluster ip turned out to be not safe when there are multiple clusters running in the same gcp project, see https://github.com/kubernetes/perf-tests/issues/459

Below a proof that the kubemark master can be successfully scraped over public ip
![5iggcC0AvTq](https://user-images.githubusercontent.com/2604887/54930859-56779e00-4f18-11e9-93af-fed8fb3c0d1b.png)
