### PR TITLE
Retry 404 errors when creating prometheus objects

### DIFF
--- a/clusterloader2/pkg/prometheus/prometheus.go
+++ b/clusterloader2/pkg/prometheus/prometheus.go
@@ -149,12 +149,12 @@ func (pc *PrometheusController) applyManifests(manifestGlob string) error {
 				return err
 			}
 			for _, item := range objList.Items {
-				if err := pc.framework.CreateObject(item.GetNamespace(), item.GetName(), &item); err != nil {
+				if err := pc.framework.CreateObject(item.GetNamespace(), item.GetName(), &item, client.Retry(apierrs.IsNotFound)); err != nil {
 					return fmt.Errorf("error while applying (%s): %v", manifest, err)
 				}
 			}
 		} else {
-			if err := pc.framework.CreateObject(obj.GetNamespace(), obj.GetName(), obj); err != nil {
+			if err := pc.framework.CreateObject(obj.GetNamespace(), obj.GetName(), obj, client.Retry(apierrs.IsNotFound)); err != nil {
 				return fmt.Errorf("error while applying (%s): %v", manifest, err)
 			}
 		}


### PR DESCRIPTION
The 404 errors during object creations may be caused by races.
E.g. when a ServiceAccount is created the associated token is created asynchronously, when creating an object that needs the token we may get a retryable 404 error if the token has not been created yet.

This should fix the issue described in https://github.com/kubernetes/kubernetes/issues/74213#issuecomment-476247400