### PR TITLE
Change objects API to allow specifying options

### DIFF
--- a/clusterloader2/pkg/framework/framework.go
+++ b/clusterloader2/pkg/framework/framework.go
@@ -131,22 +131,22 @@ func (f *Framework) DeleteAutomanagedNamespaces() *errors.ErrorList {
 }
 
 // CreateObject creates object base on given object description.
-func (f *Framework) CreateObject(namespace string, name string, obj *unstructured.Unstructured) error {
-	return client.CreateObject(f.dynamicClients.GetClient(), namespace, name, obj)
+func (f *Framework) CreateObject(namespace string, name string, obj *unstructured.Unstructured, options ...*client.ApiCallOptions) error {
+	return client.CreateObject(f.dynamicClients.GetClient(), namespace, name, obj, options...)
 }
 
 // PatchObject updates object (using patch) with given name using given object description.
-func (f *Framework) PatchObject(namespace string, name string, obj *unstructured.Unstructured) error {
+func (f *Framework) PatchObject(namespace string, name string, obj *unstructured.Unstructured, options ...*client.ApiCallOptions) error {
 	return client.PatchObject(f.dynamicClients.GetClient(), namespace, name, obj)
 }
 
 // DeleteObject deletes object with given name and group-version-kind.
-func (f *Framework) DeleteObject(gvk schema.GroupVersionKind, namespace string, name string) error {
+func (f *Framework) DeleteObject(gvk schema.GroupVersionKind, namespace string, name string, options ...*client.ApiCallOptions) error {
 	return client.DeleteObject(f.dynamicClients.GetClient(), gvk, namespace, name)
 }
 
 // GetObject retrieves object with given name and group-version-kind.
-func (f *Framework) GetObject(gvk schema.GroupVersionKind, namespace string, name string) (*unstructured.Unstructured, error) {
+func (f *Framework) GetObject(gvk schema.GroupVersionKind, namespace string, name string, options ...*client.ApiCallOptions) (*unstructured.Unstructured, error) {
 	return client.GetObject(f.dynamicClients.GetClient(), gvk, namespace, name)
 }
 

--- a/clusterloader2/pkg/measurement/util/runtimeobjects/runtimeobjects.go
+++ b/clusterloader2/pkg/measurement/util/runtimeobjects/runtimeobjects.go
@@ -107,7 +107,7 @@ func ListRuntimeObjectsForKind(c clientset.Interface, kind, namespace, labelSele
 		return nil, fmt.Errorf("unsupported kind when getting runtime object: %v", kind)
 	}
 
-	if err := client.RetryWithExponentialBackOff(client.RetryFunction(listFunc, nil)); err != nil {
+	if err := client.RetryWithExponentialBackOff(client.RetryFunction(listFunc)); err != nil {
 		return nil, err
 	}
 	return runtimeObjectsList, nil

--- a/clusterloader2/pkg/prometheus/prometheus.go
+++ b/clusterloader2/pkg/prometheus/prometheus.go
@@ -267,5 +267,6 @@ type target struct {
 }
 
 func retryCreateFunction(f func() error) error {
-	return client.RetryWithExponentialBackOff(client.RetryFunction(f, apierrs.IsAlreadyExists))
+	return client.RetryWithExponentialBackOff(
+		client.RetryFunction(f, client.Allow(apierrs.IsAlreadyExists)))
 }


### PR DESCRIPTION
Options will allow stating how particular errors should be treated, e.g. which additional errors should be allowed (ignored), which should be retried.

This change is almost transparent to the existing code, e.g. the old code like

```
framework.CreateObject(item.GetNamespace(), item.GetName(), &item)
```
will be still valid and will behave as it used to, but it will be also possible to do something like

```
framework.CreateObject(item.GetNamespace(), item.GetName(), &item, client.Allow(apierrs.IsUnauthorized), client.Retry(apierrs.IsNotFound))
```

which in addition will allow IsUnauthorized errors and will retry IsNotFound.

This PR is to address https://github.com/kubernetes/perf-tests/pull/466#discussion_r268795519