### PR TITLE
Pull prometheus images from gcr.io.

### DIFF
--- a/clusterloader2/pkg/prometheus/manifests/0prometheus-operator-deployment.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/0prometheus-operator-deployment.yaml
@@ -18,9 +18,9 @@ spec:
       containers:
       - args:
         - --logtostderr=true
-        - --config-reloader-image=quay.io/coreos/configmap-reload:v0.0.1
-        - --prometheus-config-reloader=quay.io/coreos/prometheus-config-reloader:v0.28.0
-        image: quay.io/coreos/prometheus-operator:v0.28.0
+        - --config-reloader-image=gcr.io/k8s-testimages/quay.io/coreos/configmap-reload:v0.0.1
+        - --prometheus-config-reloader=gcr.io/k8s-testimages/quay.io/coreos/prometheus-config-reloader:v0.28.0
+        image: gcr.io/k8s-testimages/quay.io/coreos/prometheus-operator:v0.28.0
         name: prometheus-operator
         ports:
         - containerPort: 8080

--- a/clusterloader2/pkg/prometheus/manifests/grafana-deployment.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/grafana-deployment.yaml
@@ -16,7 +16,7 @@ spec:
         app: grafana
     spec:
       containers:
-      - image: grafana/grafana:6.0.0
+      - image: gcr.io/k8s-testimages/grafana/grafana:6.0.0
         name: grafana
         ports:
         - containerPort: 3000

--- a/clusterloader2/pkg/prometheus/manifests/prometheus-prometheus.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/prometheus-prometheus.yaml
@@ -11,7 +11,7 @@ spec:
     - name: alertmanager-main
       namespace: monitoring
       port: web
-  baseImage: quay.io/prometheus/prometheus
+  baseImage: gcr.io/k8s-testimages/quay.io/prometheus/prometheus
   nodeSelector:
     beta.kubernetes.io/os: linux
   replicas: 1


### PR DESCRIPTION
This is to stop using external registries in our scalability tests.
I copied all the images used by prometheus to gcr.io/k8s-testimages