### PR TITLE
Add service account reference to Pod definition.

### DIFF
--- a/slo-monitor/slo-monitor-pod.yaml
+++ b/slo-monitor/slo-monitor-pod.yaml
@@ -29,3 +29,4 @@ spec:
         cpu: 300m
         memory: 100Mi
   restartPolicy: Always
+  serviceAccountName: slo-monitor


### PR DESCRIPTION
serviceAccountName: slo-monitor is missed and slo-monitor cannot list pod and event.