### PR TITLE
Increment version number for slo-monitor to 0.11.1

### DIFF
--- a/slo-monitor/slo-monitor-deployment.yaml
+++ b/slo-monitor/slo-monitor-deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
       - name: slo-monitor
-        image: gcr.io/google-containers/slo-monitor:0.11.0
+        image: gcr.io/google-containers/slo-monitor:0.11.1
         command:
           - /slo-monitor
           -  --alsologtostderr=true

--- a/slo-monitor/slo-monitor-pod.yaml
+++ b/slo-monitor/slo-monitor-pod.yaml
@@ -11,7 +11,7 @@ spec:
   hostNetwork: true
   containers:
   - name: slo-monitor
-    image: gcr.io/google-containers/slo-monitor:0.11.0
+    image: gcr.io/google-containers/slo-monitor:0.11.1
     command:
       - /slo-monitor
       -  --alsologtostderr=true


### PR DESCRIPTION
In https://github.com/kubernetes/perf-tests/pull/481 I updated the slo-monitor version in the Makefile but not in the yaml files. I noticed that the previous time the version number was incremented in https://github.com/kubernetes/perf-tests/pull/305 the yaml files were updated, so updating them for consistency.

cc @wojtek-t @listx 