### PR TITLE
Rebase slo-monitor to distroless

### DIFF
--- a/slo-monitor/Dockerfile
+++ b/slo-monitor/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.8
+FROM gcr.io/distroless/static:latest
 MAINTAINER Marek Grabowski <gmarek@google.com>
 ADD build/slo-monitor slo-monitor
 


### PR DESCRIPTION
This is part of the effort described in kep kubernetes/enhancements#900
Compariing to alpine, distroless can mitigate the influence due to CVE issues.