### PR TITLE
Set the prometheus data retention to 7d

### DIFF
--- a/clusterloader2/pkg/prometheus/manifests/prometheus-prometheus.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/prometheus-prometheus.yaml
@@ -31,6 +31,7 @@ spec:
   serviceMonitorNamespaceSelector: {}
   serviceMonitorSelector: {}
   version: v2.5.0
+  retention: 7d
   storage:
     volumeClaimTemplate:
       spec:


### PR DESCRIPTION
The default is 24h which may be not enough for long running / multiple runs of scalability tests.