### PR TITLE
Add missing prometheus services.

### DIFF
--- a/clusterloader2/pkg/prometheus/manifests/default/kube-controller-manager-service.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/default/kube-controller-manager-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: kube-system
+  name: kube-controller-manager
+  labels:
+    k8s-app: kube-controller-manager
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - name: http-metrics
+      port: 10252
+  selector:
+    component: kube-controller-manager

--- a/clusterloader2/pkg/prometheus/manifests/default/kube-scheduler-service.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/default/kube-scheduler-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: kube-system
+  name: kube-scheduler
+  labels:
+    k8s-app: kube-scheduler
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - name: http-metrics
+      port: 10251
+  selector:
+    component: kube-scheduler


### PR DESCRIPTION
This will fix scraping metrics from kube-scheduler and kube-controller-manager in non-kubemark clusters.

Ref. https://github.com/kubernetes/perf-tests/issues/503