### PR TITLE
Set MasterInternalIp in completeConfig if not set.

### DIFF
--- a/clusterloader2/cmd/clusterloader.go
+++ b/clusterloader2/cmd/clusterloader.go
@@ -25,6 +25,7 @@ import (
 	ginkgoconfig "github.com/onsi/ginkgo/config"
 	ginkgoreporters "github.com/onsi/ginkgo/reporters"
 	ginkgotypes "github.com/onsi/ginkgo/types"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog"
 	"k8s.io/perf-tests/clusterloader2/pkg/config"
@@ -112,12 +113,21 @@ func completeConfig(m *framework.MultiClientSet) error {
 		}
 	}
 	if clusterLoaderConfig.ClusterConfig.MasterIP == "" {
-		masterIP, err := util.GetMasterExternalIP(m.GetClient())
+		masterIP, err := util.GetMasterIP(m.GetClient(), corev1.NodeExternalIP)
 		if err == nil {
 			clusterLoaderConfig.ClusterConfig.MasterIP = masterIP
 			klog.Infof("ClusterConfig.MasterIP set to %v", masterIP)
 		} else {
-			klog.Errorf("Getting master ip error: %v", err)
+			klog.Errorf("Getting master external ip error: %v", err)
+		}
+	}
+	if clusterLoaderConfig.ClusterConfig.MasterInternalIP == "" {
+		masterIP, err := util.GetMasterIP(m.GetClient(), corev1.NodeInternalIP)
+		if err == nil {
+			clusterLoaderConfig.ClusterConfig.MasterInternalIP = masterIP
+			klog.Infof("ClusterConfig.MasterInternalIP set to %v", masterIP)
+		} else {
+			klog.Errorf("Getting master internal ip error: %v", err)
 		}
 	}
 	return nil

--- a/clusterloader2/pkg/util/cluster.go
+++ b/clusterloader2/pkg/util/cluster.go
@@ -135,8 +135,8 @@ func GetMasterName(c clientset.Interface) (string, error) {
 	return "", fmt.Errorf("master node not found")
 }
 
-// GetMasterExternalIP returns master node external ip.
-func GetMasterExternalIP(c clientset.Interface) (string, error) {
+// GetMasterIP returns master node ip of the given type.
+func GetMasterIP(c clientset.Interface, addressType corev1.NodeAddressType) (string, error) {
 	nodeList, err := client.ListNodes(c)
 	if err != nil {
 		return "", err
@@ -144,11 +144,11 @@ func GetMasterExternalIP(c clientset.Interface) (string, error) {
 	for i := range nodeList {
 		if system.IsMasterNode(nodeList[i].Name) {
 			for _, address := range nodeList[i].Status.Addresses {
-				if address.Type == corev1.NodeExternalIP {
+				if address.Type == addressType && address.Address != "" {
 					return address.Address, nil
 				}
 			}
-			return "", fmt.Errorf("extrnal IP of the master not found")
+			return "", fmt.Errorf("%s IP of the master not found", addressType)
 		}
 	}
 	return "", fmt.Errorf("master node not found")


### PR DESCRIPTION
This is to allow monitoring master's kubelet in non-kubemark clusters.
For kubemark clusters the MasterInternalIp will be always set via env variable, see https://github.com/kubernetes/test-infra/pull/12251

Ref. https://github.com/kubernetes/perf-tests/issues/503