### PR TITLE
Unify MasterIp variable used in prometheus templates.

### DIFF
--- a/clusterloader2/pkg/prometheus/manifests/kubemark/kube-apiserver-endpoints.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/kubemark/kube-apiserver-endpoints.yaml
@@ -8,7 +8,7 @@ metadata:
     k8s-app: kube-apiserver
 subsets:
   - addresses:
-      - ip: {{.KubemarkMasterIp}}
+      - ip: {{.MasterIp}}
     ports:
       - name: https
         port: 443


### PR DESCRIPTION
Currently we have KubemarkMasterIp used in kubemark clusters, but we will need the same variable to monitor master's kubemark in non-kubemark cluster.

Ref. https://github.com/kubernetes/perf-tests/issues/503