### PR TITLE
Scrape master's components every 5s.

### DIFF
--- a/clusterloader2/pkg/prometheus/manifests/default/prometheus-serviceMonitorApiserver.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/default/prometheus-serviceMonitorApiserver.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   endpoints:
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-    interval: 30s
+    interval: 5s
     port: https
     scheme: https
     tlsConfig:

--- a/clusterloader2/pkg/prometheus/manifests/default/prometheus-serviceMonitorKubeControllerManager.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/default/prometheus-serviceMonitorKubeControllerManager.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: monitoring
 spec:
   endpoints:
-  - interval: 30s
+  - interval: 5s
     metricRelabelings:
     - action: drop
       regex: etcd_(debugging|disk|request|server).*

--- a/clusterloader2/pkg/prometheus/manifests/default/prometheus-serviceMonitorKubeScheduler.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/default/prometheus-serviceMonitorKubeScheduler.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: monitoring
 spec:
   endpoints:
-  - interval: 30s
+  - interval: 5s
     port: http-metrics
   jobLabel: k8s-app
   namespaceSelector:


### PR DESCRIPTION
Scraping O(few) master components is relatively cheap (e.g. comparing to scraping 5K kube-proxy instances) and there is no reason for doing that every 30s.


Ref. https://github.com/kubernetes/perf-tests/issues/503