### PR TITLE
Don't drop any kube-apiserver metrics.

### DIFF
--- a/clusterloader2/pkg/prometheus/manifests/default/prometheus-serviceMonitorApiserver.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/default/prometheus-serviceMonitorApiserver.yaml
@@ -9,19 +9,6 @@ spec:
   endpoints:
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
     interval: 30s
-    metricRelabelings:
-    - action: drop
-      regex: etcd_(debugging|disk|request|server).*
-      sourceLabels:
-      - __name__
-    - action: drop
-      regex: apiserver_admission_controller_admission_latencies_seconds_.*
-      sourceLabels:
-      - __name__
-    - action: drop
-      regex: apiserver_admission_step_admission_latencies_seconds_.*
-      sourceLabels:
-      - __name__
     port: https
     scheme: https
     tlsConfig:

--- a/clusterloader2/pkg/prometheus/manifests/kubemark/prometheus-serviceMonitorApiserver.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/kubemark/prometheus-serviceMonitorApiserver.yaml
@@ -8,19 +8,6 @@ metadata:
 spec:
   endpoints:
   - interval: 30s
-    metricRelabelings:
-    - action: drop
-      regex: etcd_(debugging|disk|request|server).*
-      sourceLabels:
-      - __name__
-    - action: drop
-      regex: apiserver_admission_controller_admission_latencies_seconds_.*
-      sourceLabels:
-      - __name__
-    - action: drop
-      regex: apiserver_admission_step_admission_latencies_seconds_.*
-      sourceLabels:
-      - __name__
     port: https
     scheme: https
     tlsConfig:


### PR DESCRIPTION
There isn't that much difference in number of metrics with/without dropping:

```
curl -k https://10.40.0.13:443/metrics 2>/dev/null | wc -l
13635

curl -k https://10.40.0.13:443/metrics 2>/dev/null  | grep -v apiserver_admission_controller_admission_latencies_seconds_ | grep -v etcd_ | grep -v apiserver_admission_step_admission_latencies_seconds_ | wc -l
11527
```

Some of them might be useful when debugging, let's stop dropping them.
We may reconisder dropping if we ever run into performance / storage issues.