### PR TITLE
Experimental snapshotting of Prometheus's PD (GCP only).

### DIFF
--- a/clusterloader2/pkg/prometheus/experimental.go
+++ b/clusterloader2/pkg/prometheus/experimental.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package prometheus
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/spf13/pflag"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"os/exec"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog"
+)
+
+var (
+	shouldSnapshotPrometheusDisk = pflag.Bool("experimental-gcp-snapshot-prometheus-disk", false, "(experimental, provider=gce|gke only) whether to snapshot Prometheus disk before Prometheus stack is torn down")
+)
+
+func (pc *PrometheusController) snapshotPrometheusDiskIfEnabled() error {
+	if !*shouldSnapshotPrometheusDisk {
+		return nil
+	}
+	if pc.provider != "gce" && pc.provider != "gke" && pc.provider != "kubemark" {
+		return fmt.Errorf(
+			"snapshotting Prometheus' disk only available for GCP providers (gce, gke, kubemark), provider is: %s", pc.provider)
+	}
+	return wait.Poll(
+		10*time.Second,
+		2*time.Minute,
+		pc.trySnapshotPrometheusDisk)
+}
+
+func (pc *PrometheusController) trySnapshotPrometheusDisk() (bool, error) {
+	klog.Info("Trying to snapshot Prometheus' persistent disk...")
+	k8sClient := pc.framework.GetClientSets().GetClient()
+	list, err := k8sClient.CoreV1().PersistentVolumes().List(metav1.ListOptions{})
+	if err != nil {
+		return false, err
+	}
+	var pdName, zone string
+	for _, pv := range list.Items {
+		if pv.Spec.ClaimRef.Name != "prometheus-k8s-db-prometheus-k8s-0" {
+			continue
+		}
+		klog.Infof("Found Prometheus' PV with name: %s", pv.Name)
+		pdName = pv.Spec.GCEPersistentDisk.PDName
+		zone = pv.ObjectMeta.Labels["failure-domain.beta.kubernetes.io/zone"]
+		klog.Infof("PD name=%s, zone=%s", pdName, zone)
+	}
+	if pdName == "" || zone == "" {
+		klog.Warningf("missing zone or PD name, aborting")
+		klog.Info("PV list was:")
+		s, err := json.MarshalIndent(list, "" /*=prefix*/, "  " /*=indent*/)
+		if err != nil {
+			klog.Warningf("Error while marshalling response %v: %v", list, err)
+			return true, err
+		}
+		klog.Info(string(s))
+		return true, nil
+	}
+	snapshotName := pdName
+	klog.Infof("Snapshotting PD '%s' into snapshot '%s' in zone '%s'", pdName, snapshotName, zone)
+	cmd := exec.Command("gcloud", "compute", "disks", "snapshot", pdName, "--zone", zone, "--snapshot-names", snapshotName)
+	output, err := cmd.CombinedOutput()
+	klog.Infof("Creating disk snapshot finished with: %q\nError is: %v", string(output), err)
+	return true, err
+}

--- a/clusterloader2/pkg/prometheus/prometheus.go
+++ b/clusterloader2/pkg/prometheus/prometheus.go
@@ -114,6 +114,9 @@ func (pc *PrometheusController) SetUpPrometheusStack() error {
 
 // TearDownPrometheusStack tears down prometheus stack, releasing all prometheus resources.
 func (pc *PrometheusController) TearDownPrometheusStack() error {
+	if err := pc.snapshotPrometheusDiskIfEnabled(); err != nil {
+		klog.Warningf("Error while snapshotting prometheus disk: %v", err)
+	}
 	klog.Info("Tearing down prometheus stack")
 	k8sClient := pc.framework.GetClientSets().GetClient()
 	if err := client.DeleteNamespace(k8sClient, namespace); err != nil {

--- a/verify/verify-flags/known-flags.txt
+++ b/verify/verify-flags/known-flags.txt
@@ -1,5 +1,6 @@
 comparison-scheme
 enable-output-coloring
+experimental-gcp-snapshot-prometheus-disk
 kubernetes-url
 left-build-number
 left-job-name


### PR DESCRIPTION
Automatic snapshot of the prometheus disk after the tests might be extremely helpful in our large scale tests. Especially with the new debug dashboard that @mborsz is working on.
Two main use-cases are:

1. Manual testing, by setting this flag you can start your manual scale tests and analyze the prometheus graphs later, without worrying that it would be wiped by the next run
2. CI testing, we could start storing snapshots for few recent runs of scale tests for comparison / debugging purposes. Last time I checked these snapshots are only a few hundred MBs per run so they basically cost nothing comparing to the gcs storage we use per run. We'd have to come up with some automatic clean-up mechanism eventually, but we could start with manual clean-up every month or so. This scenarion might require more work, but it's something we should consider as a temporary solution given that it requires virtually no work to enable once this PR gets merged. 
