### PR TITLE
Experimental Prometheus remote write to Cortex.

### DIFF
--- a/clusterloader2/pkg/prometheus/experimental.go
+++ b/clusterloader2/pkg/prometheus/experimental.go
@@ -30,6 +30,7 @@ import (
 
 var (
 	shouldSnapshotPrometheusDisk = pflag.Bool("experimental-gcp-snapshot-prometheus-disk", false, "(experimental, provider=gce|gke only) whether to snapshot Prometheus disk before Prometheus stack is torn down")
+	cortexTenantId               = pflag.String("experimental-cortex-tenant-id", "", "(experimental) if set the remote write to cortex will be enabled with the given tenant id")
 )
 
 func (pc *PrometheusController) snapshotPrometheusDiskIfEnabled() error {
@@ -80,4 +81,11 @@ func (pc *PrometheusController) trySnapshotPrometheusDisk() (bool, error) {
 	output, err := cmd.CombinedOutput()
 	klog.Infof("Creating disk snapshot finished with: %q\nError is: %v", string(output), err)
 	return true, err
+}
+
+func (pc *PrometheusController) initializeCortexTemplateMappings() {
+	if *cortexTenantId != "" {
+		pc.templateMapping["CortexEnabled"] = true
+		pc.templateMapping["CortexTenantId"] = *cortexTenantId
+	}
 }

--- a/clusterloader2/pkg/prometheus/manifests/prometheus-prometheus.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/prometheus-prometheus.yaml
@@ -32,6 +32,14 @@ spec:
   serviceMonitorSelector: {}
   version: v2.9.2
   retention: 7d
+  {{if .CortexEnabled}}
+  remoteWrite:
+    - url: http://35.237.38.211:9090/cortex/{{.CortexTenantId}}/api/prom/push
+      queueConfig:
+        # The default is 1 shard which is not enough in our set-up, causing initial samples to be
+        # dropped until more shards are added. We avoid that by starting with 5 shards.
+        minShards: 5
+  {{end}}
   storage:
     volumeClaimTemplate:
       spec:

--- a/clusterloader2/pkg/prometheus/prometheus.go
+++ b/clusterloader2/pkg/prometheus/prometheus.go
@@ -71,10 +71,13 @@ func NewPrometheusController(clusterLoaderConfig *config.ClusterLoaderConfig) (p
 		return nil, errList
 	}
 	mapping["MasterIp"], err = getMasterIp(clusterLoaderConfig.ClusterConfig)
+	mapping["CortexEnabled"] = false
 	if err != nil {
 		return nil, err
 	}
 	pc.templateMapping = mapping
+
+	pc.initializeCortexTemplateMappings()
 
 	return pc, nil
 }

--- a/verify/verify-flags/known-flags.txt
+++ b/verify/verify-flags/known-flags.txt
@@ -1,5 +1,6 @@
 comparison-scheme
 enable-output-coloring
+experimental-cortex-tenant-id
 experimental-gcp-snapshot-prometheus-disk
 kubernetes-url
 left-build-number


### PR DESCRIPTION
Inspired by the Cortex talks on KubeCon, I allowed myself to setup an experimental [Cortex](https://github.com/cortexproject/cortex) cluster.
The cluster is hosted in my dev project, the grafana for it is available at http://35.237.38.211:3000.

The advantages of using Cortex in addition to Prometheus are:
  * It supports multi-tenancy (we can have a separate tenant per test)
  * Horizontally scalable / highly available - it should be easily able to support the load from our tests (if what authors of Cortex are promising is true)
  * Faster / better query enging - we wouldn't run into prometheus "too many samples" limitations anymore
  * Long term storage - we should be able to store metrics from all our place in single place
  * We'll able to have live dashboards for currently running tests
  * And many more :)

I'd like to experiment with it in our scalability tests.
If anything goes wrong it shouldn't break anything, given how the remote write is implemented in prometheus.

Ref. https://github.com/kubernetes/perf-tests/issues/523