### PR TITLE
failing-test: remove duplicate ports and endpoints

### DIFF
--- a/clusterloader2/pkg/prometheus/manifests/kubemark/kubemark-master-endpoints.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/kubemark/kubemark-master-endpoints.yaml
@@ -20,5 +20,3 @@ subsets:
         port: 10251
       - name: kube-controller-manager
         port: 10252
-      - name: etcd
-        port: 2379

--- a/clusterloader2/pkg/prometheus/manifests/kubemark/kubemark-master-service.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/kubemark/kubemark-master-service.yaml
@@ -22,5 +22,3 @@ spec:
       port: 10251
     - name: kube-controller-manager
       port: 10252
-    - name: etcd
-      port: 2379

--- a/clusterloader2/pkg/prometheus/manifests/kubemark/kubemark-master-serviceMonitor.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/kubemark/kubemark-master-serviceMonitor.yaml
@@ -36,5 +36,3 @@ spec:
     port: kube-scheduler
   - interval: 5s
     port: kube-controller-manager
-  - interval: 5s
-    port: etcd


### PR DESCRIPTION
duplicate `ServicePort` names make `Service` object fail validation during e2e test. The other two APIs (`Endpoints` and `ServiceMonitor`) might tolerate duplication, but de-duped here for clarity.

ref: https://github.com/kubernetes/kubernetes/issues/78401, https://github.com/kubernetes/perf-tests/pull/538#discussion_r287891512

/cc @mm4tt @wojtek-t