### PR TITLE
Print config on startup

### DIFF
--- a/clusterloader2/cmd/clusterloader.go
+++ b/clusterloader2/cmd/clusterloader.go
@@ -202,6 +202,8 @@ func main() {
 		klog.Exitf("Config completing error: %v", err)
 	}
 
+	klog.Infof("Using config: %+v", clusterLoaderConfig)
+
 	if err = createReportDir(); err != nil {
 		klog.Exitf("Cannot create report directory: %v", err)
 	}


### PR DESCRIPTION
Given that some config parts are based on env, some on flags, some autoguessed I think it's better to log all of them to make debugging easier.