### PR TITLE
Update travis go version to 1.12.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ language: go
 
 matrix:
     include:
-        - go: 1.11
+        - go: 1.12
 
 install:
 # Create and move build under the go path


### PR DESCRIPTION
This should fix cl2 build broken by https://github.com/kubernetes/perf-tests/pull/534