### PR TITLE
Use strings.Replace instead strings.ReplaceAll to keep compatibility with go1.11.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ language: go
 
 matrix:
     include:
-        - go: 1.12
+        - go: 1.11
 
 install:
 # Create and move build under the go path

--- a/clusterloader2/pkg/config/template_functions.go
+++ b/clusterloader2/pkg/config/template_functions.go
@@ -222,5 +222,7 @@ func yamlQuote(strInt interface{}, tabsInt interface{}) (string, error) {
 	}
 	tabsStr := strings.Repeat("  ", tabs)
 	b, err := yaml.Marshal(&str)
-	return strings.ReplaceAll(string(b), "\n", "\n"+tabsStr), err
+	// TODO(oxddr): change back to strings.ReplaceAll once we figure out how to compile clusterloader2
+	// with newer versions of go for tests against stable version of K8s
+	return strings.Replace(string(b), "\n", "\n"+tabsStr, -1), err
 }


### PR DESCRIPTION
ReplaceAll function has been added in go1.12. We still compile clusterloader2 against go1.11 to run tests against stable Kubernetes versions.

Until we figure out how to compile clusterloader2 with newer version of go and Kubernetes with the older one, we should test against go1.11.

/assign @mborsz 
/fixes #554 