### PR TITLE
Exclude _logviewer from tests

### DIFF
--- a/verify/test.sh
+++ b/verify/test.sh
@@ -33,6 +33,7 @@ find_test_dirs() {
         -o -path './network/vendor/*' \
         -o -path './perfdash/vendor/*' \
         -o -path './slo-monitor/vendor/*' \
+        -o -path './_logviewer/*' \
       \) -prune \
     \) -name '*_test.go' -print0 | xargs -0n1 dirname | sed "s|^\./|${KUBE_GO_PACKAGE}/|" | LC_ALL=C sort -u
   )


### PR DESCRIPTION
It's using bazel setup, so 'go test' won't work on it.