### PR TITLE
Perfdash - Merging component versions

### DIFF
--- a/perfdash/Makefile
+++ b/perfdash/Makefile
@@ -1,7 +1,7 @@
 all: push
 
 # See pod.yaml for the version currently running-- bump this ahead before rebuilding!
-TAG = 2.0
+TAG = 2.1
 
 REPO = gcr.io/k8s-testimages
 

--- a/perfdash/config.go
+++ b/perfdash/config.go
@@ -82,20 +82,10 @@ var (
 				OutputFilePrefix: "PodStartupLatency_SaturationPodStartupLatency",
 				Parser:           parseResponsivenessData,
 			}},
-			"DensityTestPhaseTimer": []TestDescription{{
-				Name:             "density",
-				OutputFilePrefix: "TestPhaseTimer",
-				Parser:           parseResponsivenessData,
-			}},
 			"LoadResources": []TestDescription{{
 				Name:             "load",
 				OutputFilePrefix: "ResourceUsageSummary",
 				Parser:           parseResourceUsageData,
-			}},
-			"LoadTestPhaseTimer": []TestDescription{{
-				Name:             "load",
-				OutputFilePrefix: "TestPhaseTimer",
-				Parser:           parseResponsivenessData,
 			}},
 		},
 		"APIServer": {

--- a/perfdash/deployment.yaml
+++ b/perfdash/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: default
   labels:
     app: perfdash
-    version: "2.0"
+    version: "2.1"
 spec:
   selector:
     matchLabels:
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: perfdash
-        image: gcr.io/k8s-testimages/perfdash:2.0
+        image: gcr.io/k8s-testimages/perfdash:2.1
         command:
           - /perfdash
           -   --www=true

--- a/perfdash/www/script.js
+++ b/perfdash/www/script.js
@@ -28,6 +28,7 @@ var PerfDashApp = function(http, scope, route) {
     this.cap = 0;
     this.currentCall = 0;
     this.scope.$on('$routeChangeSuccess', this.routeChanged.bind(this));
+    this.lastCall = {jobname: "", metriccategoryname: "", metricname: "", time: Date.now()};
 };
 
 
@@ -139,7 +140,17 @@ PerfDashApp.prototype.metricCategoryNameChanged = function() {
 // Update the data to graph, using the selected metricName
 PerfDashApp.prototype.metricNameChanged = function() {
     this.setURLParameters();
+    if (
+        this.lastCall.jobname == this.jobName &&
+        this.lastCall.metriccategoryname == this.metricCategoryName &&
+        this.lastCall.metricname == this.metricName &&
+        Date.now() < this.lastCall.time
+    ) {
+        // Preventing initialization calls spamming.
+        return;
+    }
     var callId = ++this.currentCall;
+    this.lastCall = {jobname: this.jobName, metriccategoryname: this.metricCategoryName, metricname: this.metricName, time: Date.now() + 1000};
     this.http.get("buildsdata", {params: {jobname: this.jobName, metriccategoryname: this.metricCategoryName, metricname: this.metricName}})
             .success(function(data) {
                     if (this.currentCall != callId) {

--- a/perfdash/www/script.js
+++ b/perfdash/www/script.js
@@ -164,21 +164,21 @@ PerfDashApp.prototype.labelChanged = function() {
     this.series = [];
     result = this.getData(this.selectedLabels);
     this.options = null;
-    var seriesLabels = null;
-    var a = result.length-1;
-    for (; a >= 0; a--) {
+    var seriesLabels = new Array();
+    var a = 0;
+    for (; a < result.length; a++) {
         if ("unit" in result[a] && "data" in result[a] && result[a].data != {}) {
             // All the unit should be the same
             this.options = {scaleLabel: "<%=value%> "+result[a].unit, animation: false};
             // Start with higher percentiles, since their values are usually strictly higher
             // than lower percentiles, which avoids obscuring graph data. It also orders data
             // in the onHover labels more naturally.
-            seriesLabels = Object.keys(result[a].data);
-            seriesLabels.sort();
-            seriesLabels.reverse();
-            break;
+            seriesLabels = seriesLabels.concat(Object.keys(result[a].data));
         }
     }
+    seriesLabels = [...new Set(seriesLabels)]
+    seriesLabels.sort();
+    seriesLabels.reverse();
     if(this.options == null) {
         return;
     }


### PR DESCRIPTION
- DensityRequestCountByClient and LoadRequestCountByClient will have separate plot for each component (instead of component + version). Each version will be displayed as separate plot line.
- Removing parser for phase time. We aren't collecting this data anymore.
- Preventing triple calls during the initialization (one for each label). 