### PR TITLE
Show Network programming latency in perf-dash

### DIFF
--- a/perfdash/config.go
+++ b/perfdash/config.go
@@ -69,18 +69,18 @@ var (
 				{
 					Name:             "density",
 					OutputFilePrefix: "PodStartupLatency",
-					Parser:           parseResponsivenessData,
+					Parser:           parsePerfData,
 				},
 				{
 					Name:             "density",
 					OutputFilePrefix: "PodStartupLatency_PodStartupLatency",
-					Parser:           parseResponsivenessData,
+					Parser:           parsePerfData,
 				},
 			},
 			"DensitySaturationPodStartup": []TestDescription{{
 				Name:             "density",
 				OutputFilePrefix: "PodStartupLatency_SaturationPodStartupLatency",
-				Parser:           parseResponsivenessData,
+				Parser:           parsePerfData,
 			}},
 			"LoadResources": []TestDescription{{
 				Name:             "load",
@@ -92,7 +92,7 @@ var (
 			"DensityResponsiveness": []TestDescription{{
 				Name:             "density",
 				OutputFilePrefix: "APIResponsiveness",
-				Parser:           parseResponsivenessData,
+				Parser:           parsePerfData,
 			}},
 			"DensityRequestCount": []TestDescription{{
 				Name:             "density",
@@ -107,7 +107,7 @@ var (
 			"LoadResponsiveness": []TestDescription{{
 				Name:             "load",
 				OutputFilePrefix: "APIResponsiveness",
-				Parser:           parseResponsivenessData,
+				Parser:           parsePerfData,
 			}},
 			"LoadRequestCount": []TestDescription{{
 				Name:             "load",
@@ -161,6 +161,13 @@ var (
 				Parser:           parseHistogramMetric("walFsyncDuration"),
 			}},
 		},
+		"KubeProxy": {
+			"NetworkProgrammingLatency": []TestDescription{{
+				Name:             "load",
+				OutputFilePrefix: "NetworkProgrammingLatency",
+				Parser:           parsePerfData,
+			}},
+		},
 	}
 
 	// benchmarkDescriptions contains metrics exported by test/integration/scheduler_perf
@@ -169,7 +176,7 @@ var (
 			"BenchmarkResults": []TestDescription{{
 				Name:             "benchmark",
 				OutputFilePrefix: "BenchmarkResults",
-				Parser:           parseResponsivenessData,
+				Parser:           parsePerfData,
 			}},
 		},
 	}
@@ -179,22 +186,22 @@ var (
 			"Latency": []TestDescription{{
 				Name:             "dns",
 				OutputFilePrefix: "Latency",
-				Parser:           parseResponsivenessData,
+				Parser:           parsePerfData,
 			}},
 			"LatencyPerc": []TestDescription{{
 				Name:             "dns",
 				OutputFilePrefix: "LatencyPerc",
-				Parser:           parseResponsivenessData,
+				Parser:           parsePerfData,
 			}},
 			"Queries": []TestDescription{{
 				Name:             "dns",
 				OutputFilePrefix: "Queries",
-				Parser:           parseResponsivenessData,
+				Parser:           parsePerfData,
 			}},
 			"Qps": []TestDescription{{
 				Name:             "dns",
 				OutputFilePrefix: "Qps",
-				Parser:           parseResponsivenessData,
+				Parser:           parsePerfData,
 			}},
 		},
 	}

--- a/perfdash/parser.go
+++ b/perfdash/parser.go
@@ -19,8 +19,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"k8s.io/kubernetes/test/e2e/framework/metrics"
-	"k8s.io/kubernetes/test/e2e/perftype"
 	"math"
 	"os"
 	"regexp"
@@ -28,6 +26,9 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"k8s.io/kubernetes/test/e2e/framework/metrics"
+	"k8s.io/kubernetes/test/e2e/perftype"
 )
 
 func stripCount(data *perftype.DataItem) {
@@ -49,7 +50,7 @@ func createRequestCountData(data *perftype.DataItem) error {
 	return nil
 }
 
-func parseResponsivenessData(data []byte, buildNumber int, testResult *BuildData) {
+func parsePerfData(data []byte, buildNumber int, testResult *BuildData) {
 	build := fmt.Sprintf("%d", buildNumber)
 	obj := perftype.PerfData{}
 	if err := json.Unmarshal(data, &obj); err != nil {


### PR DESCRIPTION
Rename parsing function more clearly (it's actually not specific to responsiveness data).

fixes: https://github.com/kubernetes/perf-tests/issues/575

Tested locally: ![b9a2U3ZYNEd](https://user-images.githubusercontent.com/30298753/60447793-7e1b8800-9c24-11e9-9f75-4f1dc94d7fcd.png)

/assign @mm4tt
