### PR TITLE
Add node-exporter to our tests

### DIFF
--- a/clusterloader2/pkg/prometheus/manifests/default/master-ip/master-endpoints.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/default/master-ip/master-endpoints.yaml
@@ -16,3 +16,5 @@ subsets:
         port: 2379
       - name: kubelet
         port: 10250
+      - name: node-exporter
+        port: 9100

--- a/clusterloader2/pkg/prometheus/manifests/default/master-ip/master-service.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/default/master-ip/master-service.yaml
@@ -14,3 +14,5 @@ spec:
       port: 2379
     - name: kubelet
       port: 10250
+    - name: node-exporter
+      port: 9100

--- a/clusterloader2/pkg/prometheus/manifests/default/master-ip/master-serviceMonitor.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/default/master-ip/master-serviceMonitor.yaml
@@ -1,4 +1,5 @@
 {{$PROMETHEUS_SCRAPE_ETCD := DefaultParam .PROMETHEUS_SCRAPE_ETCD false}}
+{{$PROMETHEUS_SCRAPE_NODE_EXPORTER := DefaultParam .PROMETHEUS_SCRAPE_NODE_EXPORTER false}}
 
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
@@ -12,6 +13,10 @@ spec:
   {{if $PROMETHEUS_SCRAPE_ETCD}}
   - interval: 5s
     port: etcd
+  {{end}}
+  {{if $PROMETHEUS_SCRAPE_NODE_EXPORTER}}
+  - interval: 5s
+    port: node-exporter
   {{end}}
   - interval: 5s
     port: kubelet

--- a/clusterloader2/pkg/prometheus/manifests/exporters/node-exporter.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/exporters/node-exporter.yaml
@@ -1,0 +1,44 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: node-exporter
+  namespace: kube-system
+  labels:
+    k8s-app: node-exporter
+spec:
+  containers:
+    - name: prometheus-node-exporter
+      image: quay.io/prometheus/node-exporter:v0.18.1
+      imagePullPolicy: "IfNotPresent"
+      args:
+        - --path.procfs=/host/proc
+        - --path.sysfs=/host/sys
+        - --collector.netstat.fields=^.*$
+        - --collector.qdisc
+      ports:
+        - name: metrics
+          containerPort: 9100
+          hostPort: 9100
+      volumeMounts:
+        - name: proc
+          mountPath: /host/proc
+          readOnly:  true
+        - name: sys
+          mountPath: /host/sys
+          readOnly: true
+      resources:
+        limits:
+          cpu: 10m
+          memory: 50Mi
+        requests:
+          cpu: 10m
+          memory: 50Mi
+  hostNetwork: true
+  hostPID: true
+  volumes:
+    - name: proc
+      hostPath:
+        path: /proc
+    - name: sys
+      hostPath:
+        path: /sys

--- a/clusterloader2/pkg/prometheus/manifests/kubemark/kubemark-master-endpoints.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/kubemark/kubemark-master-endpoints.yaml
@@ -1,3 +1,5 @@
+{{$PROMETHEUS_SCRAPE_NODE_EXPORTER := DefaultParam .PROMETHEUS_SCRAPE_NODE_EXPORTER false}}
+
 # Endpoints object for the kubemark/kube-apiserver service. For details, see the service object yaml
 apiVersion: v1
 kind: Endpoints
@@ -22,3 +24,7 @@ subsets:
         port: 10251
       - name: kube-controller-manager
         port: 10252
+      {{if $PROMETHEUS_SCRAPE_NODE_EXPORTER}}
+      - name: node-exporter
+        port: 9100
+      {{end}}

--- a/clusterloader2/pkg/prometheus/manifests/kubemark/kubemark-master-service.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/kubemark/kubemark-master-service.yaml
@@ -1,3 +1,5 @@
+{{$PROMETHEUS_SCRAPE_NODE_EXPORTER := DefaultParam .PROMETHEUS_SCRAPE_NODE_EXPORTER false}}
+
 # This service points to the Kubemark ApiServer, which runs on separate VM, outside of the main
 # cluster.The service is needed for Prometheus (discovery and monitoring in Prometheus server is
 # based on k8s services and endpoints) in order to collect metrics from the Kubemark ApiServer.
@@ -22,3 +24,7 @@ spec:
       port: 10251
     - name: kube-controller-manager
       port: 10252
+    {{if $PROMETHEUS_SCRAPE_NODE_EXPORTER}}
+    - name: node-exporter
+      port: 9100
+    {{end}}

--- a/clusterloader2/pkg/prometheus/manifests/kubemark/kubemark-master-serviceMonitor.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/kubemark/kubemark-master-serviceMonitor.yaml
@@ -1,3 +1,5 @@
+{{$PROMETHEUS_SCRAPE_NODE_EXPORTER := DefaultParam .PROMETHEUS_SCRAPE_NODE_EXPORTER false}}
+
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -36,3 +38,7 @@ spec:
     port: kube-scheduler
   - interval: 5s
     port: kube-controller-manager
+  {{if $PROMETHEUS_SCRAPE_NODE_EXPORTER}}
+  - interval: 5s
+    port: node-exporter
+  {{end}}

--- a/clusterloader2/pkg/util/ssh.go
+++ b/clusterloader2/pkg/util/ssh.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"fmt"
+	"io"
+	"os/exec"
+
+	"k8s.io/api/core/v1"
+	"k8s.io/klog"
+)
+
+// SSH executes command on a given node with stdin provided.
+// If stdin is nil, the process reads from null device.
+func SSH(command string, node *v1.Node, stdin io.Reader) error {
+	zone, ok := node.Labels["failure-domain.beta.kubernetes.io/zone"]
+	if !ok {
+		return fmt.Errorf("unknown zone for %q node: no failure-domain.beta.kubernetes.io/zone label", node.Name)
+	}
+	cmd := exec.Command("gcloud", "compute", "ssh", "--zone", zone, "--command", command, node.Name)
+	cmd.Stdin = stdin
+	output, err := cmd.CombinedOutput()
+	klog.Infof("ssh to %q finished with %q: %v", node.Name, string(output), err)
+	return err
+}

--- a/clusterloader2/vendor/golang.org/x/sync/errgroup/errgroup.go
+++ b/clusterloader2/vendor/golang.org/x/sync/errgroup/errgroup.go
@@ -1,0 +1,66 @@
+// Copyright 2016 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package errgroup provides synchronization, error propagation, and Context
+// cancelation for groups of goroutines working on subtasks of a common task.
+package errgroup
+
+import (
+	"context"
+	"sync"
+)
+
+// A Group is a collection of goroutines working on subtasks that are part of
+// the same overall task.
+//
+// A zero Group is valid and does not cancel on error.
+type Group struct {
+	cancel func()
+
+	wg sync.WaitGroup
+
+	errOnce sync.Once
+	err     error
+}
+
+// WithContext returns a new Group and an associated Context derived from ctx.
+//
+// The derived Context is canceled the first time a function passed to Go
+// returns a non-nil error or the first time Wait returns, whichever occurs
+// first.
+func WithContext(ctx context.Context) (*Group, context.Context) {
+	ctx, cancel := context.WithCancel(ctx)
+	return &Group{cancel: cancel}, ctx
+}
+
+// Wait blocks until all function calls from the Go method have returned, then
+// returns the first non-nil error (if any) from them.
+func (g *Group) Wait() error {
+	g.wg.Wait()
+	if g.cancel != nil {
+		g.cancel()
+	}
+	return g.err
+}
+
+// Go calls the given function in a new goroutine.
+//
+// The first call to return a non-nil error cancels the group; its error will be
+// returned by Wait.
+func (g *Group) Go(f func() error) {
+	g.wg.Add(1)
+
+	go func() {
+		defer g.wg.Done()
+
+		if err := f(); err != nil {
+			g.errOnce.Do(func() {
+				g.err = err
+				if g.cancel != nil {
+					g.cancel()
+				}
+			})
+		}
+	}()
+}

--- a/clusterloader2/vendor/vendor.json
+++ b/clusterloader2/vendor/vendor.json
@@ -414,8 +414,8 @@
 			"revision": "0646ccaebea1ed1539efcab30cae44019090093f",
 			"revisionTime": "2018-03-12T05:41:25Z"
 		},
-	        {
-		    "checksumSHA1": "LuFv4/jlrmFNnDb/5SCSEPAM9vU=",
+		{
+			"checksumSHA1": "LuFv4/jlrmFNnDb/5SCSEPAM9vU=",
 			"path": "github.com/pmezard/go-difflib/difflib",
 			"revision": "5d4384ee4fb2527b0a1256a821ebfc92f91efefc",
 			"revisionTime": "2018-12-26T10:54:42Z"
@@ -749,6 +749,12 @@
 			"path": "golang.org/x/oauth2/jwt",
 			"revision": "99b60b757ec124ebb7d6b7e97f153b19c10ce163",
 			"revisionTime": "2019-01-29T22:49:30Z"
+		},
+		{
+			"checksumSHA1": "iEK5hCRfrkdc1JOJsaiWuymHmeQ=",
+			"path": "golang.org/x/sync/errgroup",
+			"revision": "112230192c580c3556b8cee6403af37a4fc5f28c",
+			"revisionTime": "2019-04-22T22:11:18Z"
 		},
 		{
 			"checksumSHA1": "tI1YsCNEjyDW/aGNtunZDyjN9MA=",


### PR DESCRIPTION
Add support for node-exporter in our tests.

It will run only on registered nodes with kubernetes.io/node-exporter=true label (none right now, it will be possible to add this when https://github.com/kubernetes/kubernetes/pull/79703 is merged.

* It does work for both kubemark and regular tests *
/assign @mm4tt 