### PR TITLE
Clarify documentation of query used to measure network programming latency

### DIFF
--- a/clusterloader2/pkg/measurement/common/slos/network_programming.go
+++ b/clusterloader2/pkg/measurement/common/slos/network_programming.go
@@ -32,7 +32,7 @@ const (
 
 	metricVersion = "v1"
 
-	// Query measuring 99th percentaile of network programming latency.
+	// Query measuring 99th percentile of Xth percentiles (where X=50,90,99) of network programming latency over last 5min.
 	// %v should be replaced with query window size (duration of the test).
 	// This measurement assumes, that there is no data points for the rest of the cluster-day.
 	// Definition: https://github.com/kubernetes/community/blob/master/sig-scalability/slos/network_programming_latency.md
@@ -84,7 +84,7 @@ func (n *netProgGatherer) query(executor QueryExecutor, startTime time.Time) ([]
 }
 
 func (n *netProgGatherer) createSummary(p []float64) (measurement.Summary, error) {
-	content, err := util.PrettyPrintJSON(n.createPerfData(p))
+	content, err := util.PrettyPrintJSON(createPerfData(p))
 	if err != nil {
 		return nil, err
 	}
@@ -92,7 +92,7 @@ func (n *netProgGatherer) createSummary(p []float64) (measurement.Summary, error
 	return summary, nil
 }
 
-func (n *netProgGatherer) createPerfData(p []float64) *measurementutil.PerfData {
+func createPerfData(p []float64) *measurementutil.PerfData {
 	return &measurementutil.PerfData{
 		Version: metricVersion,
 		DataItems: []measurementutil.DataItem{{

--- a/clusterloader2/pkg/measurement/common/slos/network_programming_test.go
+++ b/clusterloader2/pkg/measurement/common/slos/network_programming_test.go
@@ -83,16 +83,3 @@ func (f *fakeExecutor) Query(query string, queryTime time.Time) ([]*model.Sample
 	}
 	return f.samples, nil
 }
-
-func createPerfData(p []float64) *measurementutil.PerfData {
-	return &measurementutil.PerfData{
-		Version: "v1",
-		DataItems: []measurementutil.DataItem{{
-			Data: map[string]float64{
-				"Perc50": p[0],
-				"Perc90": p[1],
-				"Perc99": p[2]},
-			Unit: "ms",
-		}},
-	}
-}


### PR DESCRIPTION
Clarify documentation of query used to measure network programming latency. 
Also remove redundant method.

ref https://github.com/kubernetes/perf-tests/issues/575

/assign @mm4tt 