### PR TITLE
Display in-cluster network latency in perf-dash.

### DIFF
--- a/perfdash/Makefile
+++ b/perfdash/Makefile
@@ -1,7 +1,7 @@
 all: push
 
 # See pod.yaml for the version currently running-- bump this ahead before rebuilding!
-TAG = 2.5
+TAG = 2.6
 
 REPO = gcr.io/k8s-testimages
 

--- a/perfdash/config.go
+++ b/perfdash/config.go
@@ -191,10 +191,20 @@ var (
 				Parser:           parseHistogramMetric("walFsyncDuration"),
 			}},
 		},
-		"KubeProxy": {
-			"NetworkProgrammingLatency": []TestDescription{{
+		"Network": {
+			"Load_NetworkProgrammingLatency": []TestDescription{{
 				Name:             "load",
 				OutputFilePrefix: "NetworkProgrammingLatency",
+				Parser:           parsePerfData,
+			}},
+			"Load_NetworkLatency": []TestDescription{{
+				Name:             "load",
+				OutputFilePrefix: "in_cluster_network_latency",
+				Parser:           parsePerfData,
+			}},
+			"Density_NetworkLatency": []TestDescription{{
+				Name:             "density",
+				OutputFilePrefix: "in_cluster_network_latency",
 				Parser:           parsePerfData,
 			}},
 		},

--- a/perfdash/deployment.yaml
+++ b/perfdash/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: default
   labels:
     app: perfdash
-    version: "2.5"
+    version: "2.6"
 spec:
   selector:
     matchLabels:
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: perfdash
-        image: gcr.io/k8s-testimages/perfdash:2.5
+        image: gcr.io/k8s-testimages/perfdash:2.6
         command:
           - /perfdash
           -   --www=true


### PR DESCRIPTION
ref https://github.com/kubernetes/perf-tests/issues/579

Also rename "KubeProxy" section to "Network".

/hold 
wait until metrics is enable in gce100 and we have some results to display and test this upon