### PR TITLE
ClusterLoader2: switch RCs to Deployments

### DIFF
--- a/clusterloader2/testing/density/config.yaml
+++ b/clusterloader2/testing/density/config.yaml
@@ -72,8 +72,8 @@ steps:
     Method: WaitForControlledPodsRunning
     Params:
       action: start
-      apiVersion: v1
-      kind: ReplicationController
+      apiVersion: apps/v1
+      kind: Deployment
       labelSelector: group = saturation
       operationTimeout: {{$saturationRCHardTimeout}}s
 - phases:
@@ -84,7 +84,7 @@ steps:
     tuningSet: Uniform5qps
     objectBundle:
     - basename: saturation-rc
-      objectTemplatePath: rc.yaml
+      objectTemplatePath: deployment.yaml
       templateFillMap:
         Replicas: {{$podsPerNamespace}}
         Group: saturation
@@ -124,8 +124,8 @@ steps:
     Method: WaitForControlledPodsRunning
     Params:
       action: start
-      apiVersion: v1
-      kind: ReplicationController
+      apiVersion: apps/v1
+      kind: Deployment
       labelSelector: group = latency
       operationTimeout: 15m
 - phases:
@@ -136,7 +136,7 @@ steps:
     tuningSet: Uniform5qps
     objectBundle:
     - basename: latency-pod-rc
-      objectTemplatePath: rc.yaml
+      objectTemplatePath: deployment.yaml
       templateFillMap:
         Replicas: 1
         Group: latency
@@ -157,7 +157,7 @@ steps:
     tuningSet: Uniform5qps
     objectBundle:
     - basename: latency-pod-rc
-      objectTemplatePath: rc.yaml
+      objectTemplatePath: deployment.yaml
 - measurements:
   - Identifier: WaitForRunningLatencyRCs
     Method: WaitForControlledPodsRunning
@@ -178,7 +178,7 @@ steps:
     tuningSet: Uniform5qps
     objectBundle:
     - basename: saturation-rc
-      objectTemplatePath: rc.yaml
+      objectTemplatePath: deployment.yaml
 - measurements:
   - Identifier: WaitForRunningSaturationRCs
     Method: WaitForControlledPodsRunning

--- a/clusterloader2/testing/density/deployment.yaml
+++ b/clusterloader2/testing/density/deployment.yaml
@@ -1,0 +1,37 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{.Name}}
+  labels:
+    group: {{.Group}}
+spec:
+  replicas: {{.Replicas}}
+  selector:
+    matchLabels:
+      name: {{.Name}}
+  template:
+    metadata:
+      labels:
+        name: {{.Name}}
+        group: {{.Group}}
+    spec:
+      containers:
+      - image: k8s.gcr.io/pause:3.1
+        imagePullPolicy: IfNotPresent
+        name: {{.Name}}
+        ports:
+        resources:
+          requests:
+            cpu: {{.CpuRequest}}
+            memory: {{.MemoryRequest}}
+      # Add not-ready/unreachable tolerations for 15 minutes so that node
+      # failure doesn't trigger pod deletion.
+      tolerations:
+      - key: "node.kubernetes.io/not-ready"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 900
+      - key: "node.kubernetes.io/unreachable"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 900

--- a/clusterloader2/testing/load/config.yaml
+++ b/clusterloader2/testing/load/config.yaml
@@ -104,8 +104,8 @@ steps:
     Method: WaitForControlledPodsRunning
     Params:
       action: start
-      apiVersion: v1
-      kind: ReplicationController
+      apiVersion: apps/v1
+      kind: Deployment
       labelSelector: group = load
       operationTimeout: 15m
 - phases:
@@ -116,7 +116,7 @@ steps:
     tuningSet: RandomizedSaturationTimeLimited
     objectBundle:
     - basename: big-rc
-      objectTemplatePath: rc.yaml
+      objectTemplatePath: deployment.yaml
       templateFillMap:
         ReplicasMin: {{$BIG_GROUP_SIZE}}
         ReplicasMax: {{$BIG_GROUP_SIZE}}
@@ -128,7 +128,7 @@ steps:
     tuningSet: RandomizedSaturationTimeLimited
     objectBundle:
     - basename: medium-rc
-      objectTemplatePath: rc.yaml
+      objectTemplatePath: deployment.yaml
       templateFillMap:
         ReplicasMin: {{$MEDIUM_GROUP_SIZE}}
         ReplicasMax: {{$MEDIUM_GROUP_SIZE}}
@@ -140,7 +140,7 @@ steps:
     tuningSet: RandomizedSaturationTimeLimited
     objectBundle:
     - basename: small-rc
-      objectTemplatePath: rc.yaml
+      objectTemplatePath: deployment.yaml
       templateFillMap:
         ReplicasMin: {{$SMALL_GROUP_SIZE}}
         ReplicasMax: {{$SMALL_GROUP_SIZE}}
@@ -160,7 +160,7 @@ steps:
     tuningSet: RandomizedScalingTimeLimited
     objectBundle:
     - basename: big-rc
-      objectTemplatePath: rc.yaml
+      objectTemplatePath: deployment.yaml
       templateFillMap:
         ReplicasMin: {{MultiplyInt $BIG_GROUP_SIZE 0.5}}
         ReplicasMax: {{MultiplyInt $BIG_GROUP_SIZE 1.5}}
@@ -172,7 +172,7 @@ steps:
     tuningSet: RandomizedScalingTimeLimited
     objectBundle:
     - basename: medium-rc
-      objectTemplatePath: rc.yaml
+      objectTemplatePath: deployment.yaml
       templateFillMap:
         ReplicasMin: {{MultiplyInt $MEDIUM_GROUP_SIZE 0.5}}
         ReplicasMax: {{MultiplyInt $MEDIUM_GROUP_SIZE 1.5}}
@@ -184,7 +184,7 @@ steps:
     tuningSet: RandomizedScalingTimeLimited
     objectBundle:
     - basename: small-rc
-      objectTemplatePath: rc.yaml
+      objectTemplatePath: deployment.yaml
       templateFillMap:
         ReplicasMin: {{MultiplyInt $SMALL_GROUP_SIZE 0.5}}
         ReplicasMax: {{MultiplyInt $SMALL_GROUP_SIZE 1.5}}
@@ -204,7 +204,7 @@ steps:
     tuningSet: RandomizedSaturationTimeLimited
     objectBundle:
     - basename: big-rc
-      objectTemplatePath: rc.yaml
+      objectTemplatePath: deployment.yaml
   - namespaceRange:
       min: 1
       max: {{$namespaces}}
@@ -212,7 +212,7 @@ steps:
     tuningSet: RandomizedSaturationTimeLimited
     objectBundle:
     - basename: medium-rc
-      objectTemplatePath: rc.yaml
+      objectTemplatePath: deployment.yaml
   - namespaceRange:
       min: 1
       max: {{$namespaces}}
@@ -220,7 +220,7 @@ steps:
     tuningSet: RandomizedSaturationTimeLimited
     objectBundle:
     - basename: small-rc
-      objectTemplatePath: rc.yaml
+      objectTemplatePath: deployment.yaml
 - name: Deleting RCs
 - measurements:
   - Identifier: WaitForRunningRCs

--- a/clusterloader2/testing/load/deployment.yaml
+++ b/clusterloader2/testing/load/deployment.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{.Name}}
+  labels:
+    group: load
+    svc: {{.SvcName}}-{{.Index}}
+spec:
+  replicas: {{RandIntRange .ReplicasMin .ReplicasMax}}
+  selector:
+    matchLabels:
+      name: {{.Name}}
+  template:
+    metadata:
+      labels:
+        name: {{.Name}}
+        svc: {{.SvcName}}-{{.Index}}
+    spec:
+      containers:
+      - image: k8s.gcr.io/pause:3.1
+        name: {{.Name}}
+        resources:
+          requests:
+            cpu: 10m
+            memory: "10M"
+      dnsPolicy: Default
+      terminationGracePeriodSeconds: 1
+      # Add not-ready/unreachable tolerations for 15 minutes so that node
+      # failure doesn't trigger pod deletion.
+      tolerations:
+      - key: "node.kubernetes.io/not-ready"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 900
+      - key: "node.kubernetes.io/unreachable"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 900


### PR DESCRIPTION
Experimental change to switch deprecated ReplicationControllers to Deployments. 
We'll see if the today's CI/CD scale test passes with this change. If no we'll revert, if yes we'll cleanup and continue using Deployments. 