### PR TITLE
Temporarily increase the controller-manager CPU constraint

### DIFF
--- a/clusterloader2/testing/density/100_nodes/constraints.yaml
+++ b/clusterloader2/testing/density/100_nodes/constraints.yaml
@@ -18,7 +18,7 @@ kube-apiserver:
   cpuConstraint: 2.2
   memoryConstraint: 1258291200 #1200 * (1024 * 1024)
 kube-controller-manager:
-  cpuConstraint: 1.1
+  cpuConstraint: 2 # TODO(https://github.com/kubernetes/kubernetes/issues/79898): Lower when issue is investigated.
   memoryConstraint: 314572800 #300 * (1024 * 1024)
 kube-proxy:
   cpuConstraint: 0.1


### PR DESCRIPTION
This is to deflake the test for the time of investigation.

Ref. https://github.com/kubernetes/kubernetes/issues/79898