### PR TITLE
ClusterLaoder - Adding group label to load test pods

### DIFF
--- a/clusterloader2/testing/load/deployment.yaml
+++ b/clusterloader2/testing/load/deployment.yaml
@@ -13,6 +13,7 @@ spec:
   template:
     metadata:
       labels:
+        group: load
         name: {{.Name}}
         svc: {{.SvcName}}-{{.Index}}
     spec:

--- a/clusterloader2/testing/load/rc.yaml
+++ b/clusterloader2/testing/load/rc.yaml
@@ -12,6 +12,7 @@ spec:
   template:
     metadata:
       labels:
+        group: load
         name: {{.Name}}
         svc: {{.SvcName}}-{{.Index}}
     spec:


### PR DESCRIPTION
Adding group label to pods, so they can be observed by pod startup latency measurement.