### PR TITLE
Enable probes measuring in-cluster network latency.

### DIFF
--- a/clusterloader2/testing/density/config.yaml
+++ b/clusterloader2/testing/density/config.yaml
@@ -54,6 +54,14 @@ steps:
     Method: APIResponsivenessPrometheus
     Params:
       action: start
+  {{if $ENABLE_PROBES}}
+  # TODO(oxddr): figure out how many probers to run in function of cluster
+  - Identifier: Probes
+    Method: Probes
+    Params:
+      action: start
+      replicasPerProbe: {{DivideInt .Nodes 100}}
+  {{end}}
   - Identifier: TestMetrics
     Method: TestMetrics
     Params:
@@ -199,6 +207,12 @@ steps:
       {{if $ENABLE_PROMETHEUS_API_RESPONSIVENESS}}
       enableViolations: true
       {{end}}
+  {{if $ENABLE_PROBES}}
+  - Identifier: Probes
+    Method: Probes
+    Params:
+      action: gather
+  {{end}}
   - Identifier: TestMetrics
     Method: TestMetrics
     Params:

--- a/clusterloader2/testing/load/config.yaml
+++ b/clusterloader2/testing/load/config.yaml
@@ -67,6 +67,13 @@ steps:
       action: start
       labelSelector: group = load
       threshold: 1h
+  {{if $ENABLE_PROBES}}
+  - Identifier: Probes
+    Method: Probes
+    Params:
+      action: start
+      replicasPerProbe: {{DivideInt .Nodes 100}}
+  {{end}}
   {{if $PROMETHEUS_SCRAPE_KUBE_PROXY}}
   - Identifier: NetworkProgrammingLatency
     Method: NetworkProgrammingLatency
@@ -278,6 +285,12 @@ steps:
     Method: PodStartupLatency
     Params:
       action: gather
+  {{if $ENABLE_PROBES}}
+  - Identifier: Probes
+    Method: Probes
+    Params:
+      action: gather
+  {{end}}
   {{if $PROMETHEUS_SCRAPE_KUBE_PROXY}}
   - Identifier: NetworkProgrammingLatency
     Method: NetworkProgrammingLatency


### PR DESCRIPTION
ref https://github.com/kubernetes/perf-tests/issues/597

/hold