### PR TITLE
Old style exceptions -> new style for Python 3

### DIFF
--- a/dns/py/data.py
+++ b/dns/py/data.py
@@ -100,6 +100,7 @@ class Parser(object):
 
   def _compute_derived(self):
     # Note: not very efficient, but functional
+    from functools import reduce
     histogram = reduce(
         list.__add__,
         [[rtt]*count for rtt, count in self.histogram],

--- a/dns/py/runner.py
+++ b/dns/py/runner.py
@@ -271,7 +271,7 @@ class Runner(object):
         results['data']['max_kubedns_cpu'] = res_usage.get()
         results['data']['max_kubedns_memory'] = res_usage.get()
         results['data']['histogram'] = parser.histogram
-      except Exception, exc:
+      except Exception as exc:
         _log.error('Error parsing results: %s', exc)
         results['data']['ok'] = False
         results['data']['msg'] = 'parsing error:\n%s' % traceback.format_exc()

--- a/verify/verify-flags-underscore.py
+++ b/verify/verify-flags-underscore.py
@@ -199,7 +199,7 @@ def load_exceptions(rootdir):
     for exception in exception_file.read().splitlines():
         out = exception.split(":", 1)
         if len(out) != 2:
-            printf("Invalid line in exceptions file: %s" % exception)
+            print("Invalid line in exceptions file: %s" % exception)
             continue
         filename = out[0]
         line = out[1]


### PR DESCRIPTION
Old style exceptions are syntax errors in Python 3 but new style exceptions work as expected in both Python 2 and Python 3.

Also fix __reduce()__ and __printf()__ ;-)