### PR TITLE
ClusterLoader - Pod startup fix

### DIFF
--- a/clusterloader2/pkg/measurement/common/slos/pod_startup_latency.go
+++ b/clusterloader2/pkg/measurement/common/slos/pod_startup_latency.go
@@ -264,7 +264,11 @@ func (p *podStartupLatencyMeasurement) gatherScheduleTimes(c clientset.Interface
 	for _, event := range schedEvents.Items {
 		key := createMetaNamespaceKey(event.InvolvedObject.Namespace, event.InvolvedObject.Name)
 		if _, ok := p.createTimes[key]; ok {
-			p.scheduleTimes[key] = event.FirstTimestamp
+			if !event.EventTime.IsZero() {
+				p.scheduleTimes[key] = (metav1.Time)(event.EventTime)
+			} else {
+				p.scheduleTimes[key] = event.FirstTimestamp
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
Using `EventTime` as a default when checking scheduling time.