### PR TITLE
Add knob to enable DNS probe in clusterloader2.

### DIFF
--- a/clusterloader2/testing/experiments/enable_dns_probes.yaml
+++ b/clusterloader2/testing/experiments/enable_dns_probes.yaml
@@ -1,0 +1,1 @@
+ENABLE_DNS_PROBES: true


### PR DESCRIPTION
ref https://github.com/kubernetes/perf-tests/issues/612

/assing @mborsz 