### PR TITLE
Add flag to override the prometheus snapshot name

### DIFF
--- a/clusterloader2/pkg/prometheus/experimental.go
+++ b/clusterloader2/pkg/prometheus/experimental.go
@@ -30,6 +30,7 @@ import (
 
 var (
 	shouldSnapshotPrometheusDisk = pflag.Bool("experimental-gcp-snapshot-prometheus-disk", false, "(experimental, provider=gce|gke only) whether to snapshot Prometheus disk before Prometheus stack is torn down")
+	prometheusDiskSnapshotName   = pflag.String("experimental-prometheus-disk-snapshot-name", "", "Name of the prometheus disk snapshot that will be created if snapshots are enabled. If not set, the prometheus disk name will be used.")
 )
 
 func (pc *PrometheusController) snapshotPrometheusDiskIfEnabled() error {
@@ -75,6 +76,9 @@ func (pc *PrometheusController) trySnapshotPrometheusDisk() (bool, error) {
 		return true, nil
 	}
 	snapshotName := pdName
+	if *prometheusDiskSnapshotName != "" {
+		snapshotName = *prometheusDiskSnapshotName
+	}
 	klog.Infof("Snapshotting PD '%s' into snapshot '%s' in zone '%s'", pdName, snapshotName, zone)
 	cmd := exec.Command("gcloud", "compute", "disks", "snapshot", pdName, "--zone", zone, "--snapshot-names", snapshotName)
 	output, err := cmd.CombinedOutput()

--- a/verify/verify-flags/known-flags.txt
+++ b/verify/verify-flags/known-flags.txt
@@ -5,6 +5,7 @@ enable-exec-service
 enable-output-coloring
 enable-prometheus-server
 experimental-gcp-snapshot-prometheus-disk
+experimental-prometheus-disk-snapshot-name
 force-builds
 kubemark-root-kubeconfig
 kubernetes-url


### PR DESCRIPTION
This will be useful when running multiple similar tests locally to better organize the snaphots.
E.g. when running golang1.13 test we've already tried over 5 custom k8s versions, it'd be easier if I can give a snapshot a meaningful name (e.g. golang1.12.6-basline) rather than using the auto-generated pd name (e.g. golang-kubemark-dynami-pvc-1a775eaa-22bb-405a-81a5-eb2dd545168c)