### PR TITLE
add function to wait for bound PVCs

### DIFF
--- a/clusterloader2/pkg/measurement/common/wait_for_pvcs.go
+++ b/clusterloader2/pkg/measurement/common/wait_for_pvcs.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"time"
+
+	"k8s.io/klog"
+	"k8s.io/perf-tests/clusterloader2/pkg/measurement"
+	measurementutil "k8s.io/perf-tests/clusterloader2/pkg/measurement/util"
+	"k8s.io/perf-tests/clusterloader2/pkg/util"
+)
+
+const (
+	defaultWaitForPVCsTimeout       = 60 * time.Second
+	defaultWaitForPVCsInterval      = 5 * time.Second
+	waitForBoundPVCsMeasurementName = "WaitForBoundPVCs"
+)
+
+func init() {
+	if err := measurement.Register(waitForBoundPVCsMeasurementName, createWaitForBoundPVCsMeasurement); err != nil {
+		klog.Fatalf("Cannot register %s: %v", waitForBoundPVCsMeasurementName, err)
+	}
+}
+
+func createWaitForBoundPVCsMeasurement() measurement.Measurement {
+	return &waitForBoundPVCsMeasurement{}
+}
+
+type waitForBoundPVCsMeasurement struct{}
+
+// Execute waits until desired number of PVCs are bound or until timeout happens.
+// PVCs can be specified by field and/or label selectors.
+// If namespace is not passed by parameter, all-namespace scope is assumed.
+func (w *waitForBoundPVCsMeasurement) Execute(config *measurement.MeasurementConfig) ([]measurement.Summary, error) {
+	desiredPVCCount, err := util.GetInt(config.Params, "desiredPVCCount")
+	if err != nil {
+		return nil, err
+	}
+	selector := measurementutil.NewObjectSelector()
+	if err := selector.Parse(config.Params); err != nil {
+		return nil, err
+	}
+	timeout, err := util.GetDurationOrDefault(config.Params, "timeout", defaultWaitForPVCsTimeout)
+	if err != nil {
+		return nil, err
+	}
+
+	stopCh := make(chan struct{})
+	time.AfterFunc(timeout, func() {
+		close(stopCh)
+	})
+	options := &measurementutil.WaitForPVCOptions{
+		Selector:            selector,
+		DesiredPVCCount:     desiredPVCCount,
+		EnableLogging:       true,
+		CallerName:          w.String(),
+		WaitForPVCsInterval: defaultWaitForPVCsInterval,
+	}
+	return nil, measurementutil.WaitForPVCs(config.ClusterFramework.GetClientSets().GetClient(), stopCh, options)
+}
+
+// Dispose cleans up after the measurement.
+func (*waitForBoundPVCsMeasurement) Dispose() {}
+
+// String returns a string representation of the measurement.
+func (*waitForBoundPVCsMeasurement) String() string {
+	return waitForBoundPVCsMeasurementName
+}

--- a/clusterloader2/pkg/measurement/util/pvcs.go
+++ b/clusterloader2/pkg/measurement/util/pvcs.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+// PVCStartupStatus represents phase of a pvc group.
+type PVCStartupStatus struct {
+	Pending  int
+	Bound    int
+	Lost     int
+	Expected int
+	Created  int
+}
+
+// String returns string representation for PVCsStartupStatus.
+func (s *PVCStartupStatus) String() string {
+	return fmt.Sprintf("PVCs: %d out of %d created, %d bound, %d pending, %d lost", s.Created, s.Expected, s.Bound, s.Pending, s.Lost)
+}
+
+// ComputePVCStartupStatus computes PVCsStartupStatus for a group of PVCs.
+func ComputePVCStartupStatus(pvcs []*corev1.PersistentVolumeClaim, expected int) PVCStartupStatus {
+	startupStatus := PVCStartupStatus{
+		Expected: expected,
+	}
+	for _, p := range pvcs {
+		startupStatus.Created++
+		if p.Status.Phase == corev1.ClaimPending {
+			startupStatus.Pending++
+		} else if p.Status.Phase == corev1.ClaimBound {
+			startupStatus.Bound++
+		} else if p.Status.Phase == corev1.ClaimLost {
+			startupStatus.Lost++
+		}
+	}
+	return startupStatus
+}
+
+type pvcInfo struct {
+	oldPhase string
+	phase    string
+}
+
+// PVCDiff represets diff between old and new group of pvcs.
+type PVCDiff map[string]*pvcInfo
+
+// Print formats and prints the give PVCDiff.
+func (p PVCDiff) String(ignorePhases sets.String) string {
+	ret := ""
+	for name, info := range p {
+		if ignorePhases.Has(info.phase) {
+			continue
+		}
+		if info.phase == nonExist {
+			ret += fmt.Sprintf("PVC %v was deleted, had phase %v\n", name, info.oldPhase)
+			continue
+		}
+		msg := fmt.Sprintf("PVC %v ", name)
+		if info.oldPhase != info.phase {
+			if info.oldPhase == nonExist {
+				msg += fmt.Sprintf("in phase %v ", info.phase)
+			} else {
+				msg += fmt.Sprintf("went from phase: %v -> %v ", info.oldPhase, info.phase)
+			}
+			ret += msg + "\n"
+		}
+	}
+	return ret
+}
+
+// DeletedPVCs returns a slice of PVCs that were present at the beginning
+// and then disappeared.
+func (p PVCDiff) DeletedPVCs() []string {
+	var deletedPVCs []string
+	for pvcName, pvcInfo := range p {
+		if pvcInfo.phase == nonExist {
+			deletedPVCs = append(deletedPVCs, pvcName)
+		}
+	}
+	return deletedPVCs
+}
+
+// AddedPVCs returns a slice of PVCs that were added.
+func (p PVCDiff) AddedPVCs() []string {
+	var addedPVCs []string
+	for pvcName, pvcInfo := range p {
+		if pvcInfo.oldPhase == nonExist {
+			addedPVCs = append(addedPVCs, pvcName)
+		}
+	}
+	return addedPVCs
+}
+
+// DiffPVCs computes a PVCDiff given 2 lists of PVCs.
+func DiffPVCs(oldPVCs []*corev1.PersistentVolumeClaim, curPVCs []*corev1.PersistentVolumeClaim) PVCDiff {
+	pvcInfoMap := PVCDiff{}
+
+	// New PVCs will show up in the curPVCs list but not in oldPVCs. They have oldhostname/phase == nonexist.
+	for _, pvc := range curPVCs {
+		pvcInfoMap[pvc.Name] = &pvcInfo{phase: string(pvc.Status.Phase), oldPhase: nonExist}
+	}
+
+	// Deleted PVCs will show up in the oldPVCs list but not in curPVCs. They have a hostname/phase == nonexist.
+	for _, pvc := range oldPVCs {
+		if info, ok := pvcInfoMap[pvc.Name]; ok {
+			info.oldPhase = string(pvc.Status.Phase)
+		} else {
+			pvcInfoMap[pvc.Name] = &pvcInfo{phase: nonExist, oldPhase: string(pvc.Status.Phase)}
+		}
+	}
+	return pvcInfoMap
+}

--- a/clusterloader2/pkg/measurement/util/wait_for_pvcs.go
+++ b/clusterloader2/pkg/measurement/util/wait_for_pvcs.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/klog"
+)
+
+// WaitForPVCOptions is an options used by WaitForPVCs methods.
+type WaitForPVCOptions struct {
+	Selector            *ObjectSelector
+	DesiredPVCCount     int
+	EnableLogging       bool
+	CallerName          string
+	WaitForPVCsInterval time.Duration
+}
+
+// WaitForPVCs waits till disire nuber of PVCs is running.
+// PVCs are be specified by namespace, field and/or label selectors.
+// If stopCh is closed before all PVCs are running, the error will be returned.
+func WaitForPVCs(clientSet clientset.Interface, stopCh <-chan struct{}, options *WaitForPVCOptions) error {
+	ps, err := NewPVCStore(clientSet, options.Selector)
+	if err != nil {
+		return fmt.Errorf("PVC store creation error: %v", err)
+	}
+	defer ps.Stop()
+
+	pvcs := ps.List()
+	var oldPVCs []*corev1.PersistentVolumeClaim
+	pvcsStatus := ComputePVCStartupStatus(pvcs, options.DesiredPVCCount)
+	scaling := uninitialized
+
+	switch {
+	case len(pvcs) == options.DesiredPVCCount:
+		scaling = none
+	case len(pvcs) < options.DesiredPVCCount:
+		scaling = up
+	case len(pvcs) > options.DesiredPVCCount:
+		scaling = down
+	}
+
+	for {
+		select {
+		case <-stopCh:
+			return fmt.Errorf("timeout while waiting for %d PVCs to be running in namespace '%v' with labels '%v' and fields '%v' - only %d found bound",
+				options.DesiredPVCCount, options.Selector.Namespace, options.Selector.LabelSelector, options.Selector.FieldSelector, pvcsStatus.Bound)
+		case <-time.After(options.WaitForPVCsInterval):
+			diff := DiffPVCs(oldPVCs, pvcs)
+			deletedPVCs := diff.DeletedPVCs()
+			if scaling != down && len(deletedPVCs) > 0 {
+				klog.Errorf("%s: %s: %d PVCs disappeared: %v", options.CallerName, options.Selector.String(), len(deletedPVCs), strings.Join(deletedPVCs, ", "))
+				klog.Infof("%s: %v", options.CallerName, diff.String(sets.NewString()))
+			}
+			addedPVCs := diff.AddedPVCs()
+			if scaling != up && len(addedPVCs) > 0 {
+				klog.Errorf("%s: %s: %d PVCs appeared: %v", options.CallerName, options.Selector.String(), len(deletedPVCs), strings.Join(deletedPVCs, ", "))
+				klog.Infof("%s: %v", options.CallerName, diff.String(sets.NewString()))
+			}
+			if options.EnableLogging {
+				klog.Infof("%s: %s: %s", options.CallerName, options.Selector.String(), pvcsStatus.String())
+			}
+			// We wait until there is a desired number of PVCs bound and all other PVCs are pending.
+			if len(pvcs) == (pvcsStatus.Bound+pvcsStatus.Pending) && pvcsStatus.Bound == options.DesiredPVCCount {
+				return nil
+			}
+			oldPVCs = pvcs
+			pvcs = ps.List()
+			pvcsStatus = ComputePVCStartupStatus(pvcs, options.DesiredPVCCount)
+		}
+	}
+}


### PR DESCRIPTION
Adds a function `WaitForBoundPVCs` that works very similarly to `WaitForRunningPods` and waits until the desired number of PVCs becomes "Bound". 

The code is very similar to the code for `WaitForRunningPods` - I played with experimenting on a way to generalize the similar parts into a generic `WaitForResource` but I am not sure how easy or feasible it will be to actually complete it. In the mean time, this does it with just some repeated code and logic.