### PR TITLE
Fix error handling in pod startup time metric

### DIFF
--- a/clusterloader2/pkg/measurement/common/slos/pod_startup_latency.go
+++ b/clusterloader2/pkg/measurement/common/slos/pod_startup_latency.go
@@ -178,7 +178,7 @@ func (p *podStartupLatencyMeasurement) gather(c clientset.Interface, identifier 
 	}
 
 	content, jsonErr := util.PrettyPrintJSON(measurementutil.LatencyMapToPerfData(podStartupLatency))
-	if err != nil {
+	if jsonErr != nil {
 		return nil, jsonErr
 	}
 	summary := measurement.CreateSummary(fmt.Sprintf("%s_%s", podStartupLatencyMeasurementName, identifier), "json", content)


### PR DESCRIPTION
This basically means that our tests could never failing in pod-startup-latency SLO. !!!

Fix: https://github.com/kubernetes/perf-tests/issues/667

@kubernetes/sig-scalability-bugs 
@mm4tt @mborsz @oxddr @krzysied 