### PR TITLE
Use 30s as the threshold for cluster-scoped list calls.

### DIFF
--- a/clusterloader2/pkg/measurement/common/slos/api_responsiveness_prometheus.go
+++ b/clusterloader2/pkg/measurement/common/slos/api_responsiveness_prometheus.go
@@ -196,10 +196,10 @@ func getMetricKey(resource, subresource, verb, scope string) string {
 
 func getSLOThreshold(verb, scope string) time.Duration {
 	if verb != "LIST" {
-		return apiCallLatencyThreshold
+		return resourceThreshold
 	}
 	if scope == "cluster" {
-		return apiClusterScopeListCallThreshold
+		return clusterThreshold
 	}
-	return apiListCallLatencyThreshold
+	return namespaceThreshold
 }


### PR DESCRIPTION
Also remove logic for special handling of  big clusters in api_responsiveness measurement. 

/assign @wojtek-t 