### PR TITLE
Clean up steps in CL2 test configs.

### DIFF
--- a/clusterloader2/pkg/test/simple_test_executor.go
+++ b/clusterloader2/pkg/test/simple_test_executor.go
@@ -96,6 +96,9 @@ func (ste *simpleTestExecutor) ExecuteTest(ctx Context, conf *api.Config) *error
 
 // ExecuteStep executes single test step based on provided step configuration.
 func (ste *simpleTestExecutor) ExecuteStep(ctx Context, step *api.Step) *errors.ErrorList {
+	if step.Name != "" {
+		klog.Infof("Step %q started", step.Name)
+	}
 	var wg wait.Group
 	errList := errors.NewErrorList()
 	if len(step.Measurements) > 0 {
@@ -123,7 +126,7 @@ func (ste *simpleTestExecutor) ExecuteStep(ctx Context, step *api.Step) *errors.
 	}
 	wg.Wait()
 	if step.Name != "" {
-		klog.Infof("Step \"%s\" ended", step.Name)
+		klog.Infof("Step %q ended", step.Name)
 	}
 	return errList
 }

--- a/clusterloader2/testing/density/config.yaml
+++ b/clusterloader2/testing/density/config.yaml
@@ -45,7 +45,8 @@ chaosMonkey:
     simulatedDowntime: 10m
 {{end}}
 steps:
-- measurements:
+- name: Starting measurements
+  measurements:
   - Identifier: APIResponsiveness
     Method: APIResponsiveness
     Params:
@@ -68,15 +69,15 @@ steps:
       action: start
       nodeMode: {{$NODE_MODE}}
       resourceConstraints: {{$DENSITY_RESOURCE_CONSTRAINTS_FILE}}
-# Create saturation pods
-- measurements:
+
+- name: Starting saturation pod measurements
+  measurements:
   - Identifier: SaturationPodStartupLatency
     Method: PodStartupLatency
     Params:
       action: start
       labelSelector: group = saturation
       threshold: {{$saturationDeploymentTimeout}}s
-- measurements:
   - Identifier: WaitForRunningSaturationDeployments
     Method: WaitForControlledPodsRunning
     Params:
@@ -85,7 +86,14 @@ steps:
       kind: Deployment
       labelSelector: group = saturation
       operationTimeout: {{$saturationDeploymentHardTimeout}}s
-- phases:
+  - Identifier: SchedulingThroughput
+    Method: SchedulingThroughput
+    Params:
+      action: start
+      labelSelector: group = saturation
+
+- name: Creating saturation pods
+  phases:
   - namespaceRange:
       min: 1
       max: {{$namespaces}}
@@ -99,13 +107,9 @@ steps:
         Group: saturation
         CpuRequest: 1m
         MemoryRequest: 10M
-- measurements:
-  - Identifier: SchedulingThroughput
-    Method: SchedulingThroughput
-    Params:
-      action: start
-      labelSelector: group = saturation
-- measurements:
+
+- name: Collecting saturation pod measurements
+  measurements:
   - Identifier: WaitForRunningSaturationDeployments
     Method: WaitForControlledPodsRunning
     Params:
@@ -120,15 +124,14 @@ steps:
     Method: SchedulingThroughput
     Params:
       action: gather
-- name: Creating saturation pods
-# Create latency pods
-- measurements:
+
+- name: Starting latency pod measurements
+  measurements:
   - Identifier: PodStartupLatency
     Method: PodStartupLatency
     Params:
       action: start
       labelSelector: group = latency
-- measurements:
   - Identifier: WaitForRunningLatencyDeployments
     Method: WaitForControlledPodsRunning
     Params:
@@ -137,7 +140,9 @@ steps:
       kind: Deployment
       labelSelector: group = latency
       operationTimeout: 15m
-- phases:
+
+- name: Creating latency pods
+  phases:
   - namespaceRange:
       min: 1
       max: {{$namespaces}}
@@ -151,14 +156,16 @@ steps:
         Group: latency
         CpuRequest: {{$LATENCY_POD_CPU}}m
         MemoryRequest: {{$LATENCY_POD_MEMORY}}M
-- measurements:
+
+- name: Waiting for latency pods to be running
+  measurements:
   - Identifier: WaitForRunningLatencyDeployments
     Method: WaitForControlledPodsRunning
     Params:
       action: gather
-- name: Creating latency pods
-# Remove latency pods
-- phases:
+
+- name: Deleting latency pods
+  phases:
   - namespaceRange:
       min: 1
       max: {{$namespaces}}
@@ -167,19 +174,23 @@ steps:
     objectBundle:
     - basename: latency-deployment
       objectTemplatePath: deployment.yaml
-- measurements:
+
+- name: Waiting for latency pods to be deleted
+  measurements:
   - Identifier: WaitForRunningLatencyDeployments
     Method: WaitForControlledPodsRunning
     Params:
       action: gather
-- measurements:
+
+- name: Collecting pod startup latency
+  measurements:
   - Identifier: PodStartupLatency
     Method: PodStartupLatency
     Params:
       action: gather
-- name: Deleting latency pods
-# Delete pods
-- phases:
+
+- name: Deleting saturation pods
+  phases:
   - namespaceRange:
       min: 1
       max: {{$namespaces}}
@@ -188,14 +199,16 @@ steps:
     objectBundle:
     - basename: saturation-deployment
       objectTemplatePath: deployment.yaml
-- measurements:
+
+- name: Waiting for saturation pods to be deleted
+  measurements:
   - Identifier: WaitForRunningSaturationDeployments
     Method: WaitForControlledPodsRunning
     Params:
       action: gather
-- name: Deleting saturation pods
-# Collect measurements
-- measurements:
+
+- name: Collecting measurements
+  measurements:
   - Identifier: APIResponsiveness
     Method: APIResponsiveness
     Params:

--- a/clusterloader2/testing/load/config.yaml
+++ b/clusterloader2/testing/load/config.yaml
@@ -52,7 +52,8 @@ chaosMonkey:
     simulatedDowntime: 10m
 {{end}}
 steps:
-- measurements:
+- name: Starting measurements
+  measurements:
   - Identifier: APIResponsiveness
     Method: APIResponsiveness
     Params:
@@ -85,8 +86,9 @@ steps:
     Params:
       action: start
       nodeMode: {{$NODE_MODE}}
-# Create SVCs
-- phases:
+
+- name: Creating SVCs
+  phases:
   - namespaceRange:
       min: 1
       max: {{$namespaces}}
@@ -111,9 +113,9 @@ steps:
     objectBundle:
     - basename: small-service
       objectTemplatePath: service.yaml
-- name: Creating SVCs
-# Create Deployments
-- measurements:
+
+- name: Starting measurement for waiting for deployments
+  measurements:
   - Identifier: WaitForRunningDeployments
     Method: WaitForControlledPodsRunning
     Params:
@@ -122,7 +124,9 @@ steps:
       kind: Deployment
       labelSelector: group = load
       operationTimeout: 15m
-- phases:
+
+- name: Creating Deployments
+  phases:
   - namespaceRange:
       min: 1
       max: {{$namespaces}}
@@ -159,14 +163,16 @@ steps:
         ReplicasMin: {{$SMALL_GROUP_SIZE}}
         ReplicasMax: {{$SMALL_GROUP_SIZE}}
         SvcName: small-service
-- measurements:
+
+- name: Waiting for deployments to be running
+  measurements:
   - Identifier: WaitForRunningDeployments
     Method: WaitForControlledPodsRunning
     Params:
       action: gather
-- name: Creating Deployments
-# Scale Deployments
-- phases:
+
+- name: Scaling Deployments
+  phases:
   - namespaceRange:
       min: 1
       max: {{$namespaces}}
@@ -203,14 +209,16 @@ steps:
         ReplicasMin: {{MultiplyInt $SMALL_GROUP_SIZE 0.5}}
         ReplicasMax: {{MultiplyInt $SMALL_GROUP_SIZE 1.5}}
         SvcName: small-service
-- measurements:
+
+- name: Waiting for deployments to become scaled
+  measurements:
   - Identifier: WaitForRunningDeployments
     Method: WaitForControlledPodsRunning
     Params:
       action: gather
-- name: Scaling Deployments
-# Delete Deployments
-- phases:
+
+- name: Deleting Deployments
+  phases:
   - namespaceRange:
       min: 1
       max: {{$namespaces}}
@@ -235,14 +243,16 @@ steps:
     objectBundle:
     - basename: small-deployment
       objectTemplatePath: deployment.yaml
-- name: Deleting Deployments
+
+- name: Waiting for Deployments to be deleted
 - measurements:
   - Identifier: WaitForRunningDeployments
     Method: WaitForControlledPodsRunning
     Params:
       action: gather
-# Delete SVCs
-- phases:
+
+- name: Deleting SVCs
+  phases:
   - namespaceRange:
       min: 1
       max: {{$namespaces}}
@@ -267,9 +277,9 @@ steps:
     objectBundle:
     - basename: small-service
       objectTemplatePath: service.yaml
-- name: Deleting SVCs
-# Collect measurements
-- measurements:
+
+- name: Collecting measurements
+  measurements:
   - Identifier: APIResponsiveness
     Method: APIResponsiveness
     Params:


### PR DESCRIPTION
The change adds name for each steps describing what it does. I believe this will make the test configs easier to understand to people not familiar with clusterloader2.
In addition we'll be logging when step starts and ends, so it's easier to identify particular steps in the log.