### PR TITLE
Remove cpuInterval param from GetOneTimeResourceUsageOnNode()

### DIFF
--- a/clusterloader2/pkg/measurement/common/resource_usage.go
+++ b/clusterloader2/pkg/measurement/common/resource_usage.go
@@ -108,7 +108,6 @@ func (e *resourceUsageMetricMeasurement) Execute(config *measurement.Measurement
 			InKubemark:                  strings.ToLower(provider) == "kubemark",
 			Nodes:                       nodesSet,
 			ResourceDataGatheringPeriod: 60 * time.Second,
-			ProbeDuration:               15 * time.Second,
 			PrintVerboseLogs:            false,
 		}, nil)
 		if err != nil {

--- a/clusterloader2/pkg/measurement/util/gatherers/container_resource_gatherer.go
+++ b/clusterloader2/pkg/measurement/util/gatherers/container_resource_gatherer.go
@@ -67,7 +67,6 @@ type ResourceGathererOptions struct {
 	InKubemark                  bool
 	Nodes                       NodesSet
 	ResourceDataGatheringPeriod time.Duration
-	ProbeDuration               time.Duration
 	PrintVerboseLogs            bool
 }
 
@@ -89,7 +88,6 @@ func NewResourceUsageGatherer(c clientset.Interface, host, provider string, opti
 			wg:                          &g.workerWg,
 			finished:                    false,
 			resourceDataGatheringPeriod: options.ResourceDataGatheringPeriod,
-			probeDuration:               options.ProbeDuration,
 			printVerboseLogs:            options.PrintVerboseLogs,
 			host:                        host,
 			provider:                    provider,
@@ -138,7 +136,6 @@ func NewResourceUsageGatherer(c clientset.Interface, host, provider string, opti
 					finished:                    false,
 					inKubemark:                  false,
 					resourceDataGatheringPeriod: options.ResourceDataGatheringPeriod,
-					probeDuration:               options.ProbeDuration,
 					printVerboseLogs:            options.PrintVerboseLogs,
 				})
 				if options.Nodes == MasterNodes {

--- a/clusterloader2/pkg/measurement/util/gatherers/resource_gather_worker.go
+++ b/clusterloader2/pkg/measurement/util/gatherers/resource_gather_worker.go
@@ -38,7 +38,6 @@ type resourceGatherWorker struct {
 	finished                    bool
 	inKubemark                  bool
 	resourceDataGatheringPeriod time.Duration
-	probeDuration               time.Duration
 	printVerboseLogs            bool
 	host                        string
 	provider                    string
@@ -59,7 +58,7 @@ func (w *resourceGatherWorker) singleProbe() {
 			}
 		}
 	} else {
-		nodeUsage, err := kubelet.GetOneTimeResourceUsageOnNode(w.c, w.nodeName, w.probeDuration, func() []string { return w.containerIDs })
+		nodeUsage, err := kubelet.GetOneTimeResourceUsageOnNode(w.c, w.nodeName, func() []string { return w.containerIDs })
 		if err != nil {
 			klog.Errorf("error while reading data from %v: %v", w.nodeName, err)
 			return


### PR DESCRIPTION
It's not used anywhere other than to check that it's within some limits.
Also update the method doc, as it doesn't make sense comparing to what the method actually does and how cadvisor works.

From the tests I've run, the cadvisor endpoint gets updated every ~15s and scraping it takes on average ~110ms. It seems to be exactly the same data that we scrape via prometheus. 
Given that, we should be able to scrape it more often (in prometheus we scrape master every 5s) which should allow us to fix https://github.com/kubernetes/perf-tests/issues/694. 
This is a prework to that.