### PR TITLE
Gather resource usage on master every 10s

### DIFF
--- a/clusterloader2/pkg/measurement/common/resource_usage.go
+++ b/clusterloader2/pkg/measurement/common/resource_usage.go
@@ -105,10 +105,11 @@ func (e *resourceUsageMetricMeasurement) Execute(config *measurement.Measurement
 
 		klog.Infof("%s: starting resource usage collecting...", e)
 		e.gatherer, err = gatherers.NewResourceUsageGatherer(config.ClusterFramework.GetClientSets().GetClient(), host, provider, gatherers.ResourceGathererOptions{
-			InKubemark:                  strings.ToLower(provider) == "kubemark",
-			Nodes:                       nodesSet,
-			ResourceDataGatheringPeriod: 60 * time.Second,
-			PrintVerboseLogs:            false,
+			InKubemark:                        strings.ToLower(provider) == "kubemark",
+			Nodes:                             nodesSet,
+			ResourceDataGatheringPeriod:       60 * time.Second,
+			MasterResourceDataGatheringPeriod: 10 * time.Second,
+			PrintVerboseLogs:                  false,
 		}, nil)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
This is to address https://github.com/kubernetes/perf-tests/issues/694.

It's enough to scrape more often only on master as when it comes to nodes'components we scrape them much more often on average, e.g. for 100 node cluster we have 100 times more data for nodes components as each node is scrape separately every 60s.

In addition it should be safe to hit cadvisor every 10s on master due to two reasons:

1. We do it already via prometheus every 5s (and it doesn't seem to be impacting master's performance at all)
2. From the tests I run looks like cadvisor updates every ~10-16s and request are fast (~100ms), so it implements caching and requests are cheap and in addition there is no gain in scraping it often than 10s
