### PR TITLE
Bump probes to v0.0.2, so the image includes dns probe.

### DIFF
--- a/probes/Makefile
+++ b/probes/Makefile
@@ -1,6 +1,6 @@
 PROJECT = k8s-testimages
 IMG = gcr.io/$(PROJECT)/probes
-TAG = v0.0.1
+TAG = v0.0.2
 
 all: push
 


### PR DESCRIPTION
ref https://github.com/kubernetes/perf-tests/issues/612

/assign @mm4tt 