### PR TITLE
Run DNS probes in tests

### DIFF
--- a/clusterloader2/pkg/measurement/common/probes/manifests/dnsLookup/dns-prober-deployment.yaml
+++ b/clusterloader2/pkg/measurement/common/probes/manifests/dnsLookup/dns-prober-deployment.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: probes
+  name: dns
+  labels:
+    probe: dns
+spec:
+  selector:
+    matchLabels:
+      probe: dns
+  replicas: {{.Replicas}}
+  template:
+    metadata:
+      labels:
+        probe: dns
+    spec:
+      containers:
+        - name: dns
+          image: gcr.io/k8s-testimages/probes:v0.0.3
+          args:
+            - --metric-bind-address=0.0.0.0:8080
+            - --mode=dns
+            # Instead of creating dedicated "null-service" use one that's already exists
+            # TODO(oxddr): according to @wojtek-t there are differences between fully and not fully qualified domain names
+            # Investigate it and potentially measure latency for both
+            - --dns-probe-url=ping-server.probes
+          resources:
+            limits:
+              cpu: 100m
+              memory: 100Mi
+          ports:
+            - containerPort: 8080
+              name: metrics

--- a/clusterloader2/pkg/measurement/common/probes/manifests/dnsLookup/dns-prober-service.yaml
+++ b/clusterloader2/pkg/measurement/common/probes/manifests/dnsLookup/dns-prober-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: probes
+  name: dns
+  labels:
+    probe: dns
+spec:
+  ports:
+    - name: metrics
+      port: 8080
+  selector:
+    probe: dns

--- a/clusterloader2/pkg/measurement/common/probes/manifests/dnsLookup/dns-prober-serviceMonitor.yaml
+++ b/clusterloader2/pkg/measurement/common/probes/manifests/dnsLookup/dns-prober-serviceMonitor.yaml
@@ -1,0 +1,15 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  namespace: probes
+  name: dns
+spec:
+  endpoints:
+    - interval: 30s
+      port: metrics
+  namespaceSelector:
+    matchNames:
+      - probes
+  selector:
+    matchLabels:
+      probe: dns

--- a/clusterloader2/pkg/prometheus/manifests/prometheus-rules.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/prometheus-rules.yaml
@@ -42,6 +42,21 @@ spec:
       record: probes:in_cluster_network_latency:histogram_quantile
       labels:
         quantile: "0.50"
+    - expr: |
+        histogram_quantile(0.99, sum(rate(probes_in_cluster_dns_latency_seconds_bucket[5m])) by (le))
+      record: probes:dns_lookup_latency:histogram_quantile
+      labels:
+        quantile: "0.99"
+    - expr: |
+        histogram_quantile(0.90, sum(rate(probes_in_cluster_dns_latency_seconds_bucket[5m])) by (le))
+      record: probes:dns_lookup_latency:histogram_quantile
+      labels:
+        quantile: "0.90"
+    - expr: |
+        histogram_quantile(0.50, sum(rate(probes_in_cluster_dns_latency_seconds_bucket[5m])) by (le))
+      record: probes:dns_lookup_latency:histogram_quantile
+      labels:
+        quantile: "0.50"
   - name: kube-proxy.rules
     rules:
     - expr: |

--- a/clusterloader2/testing/density/config.yaml
+++ b/clusterloader2/testing/density/config.yaml
@@ -19,6 +19,7 @@
 {{$ENABLE_CHAOSMONKEY := DefaultParam .ENABLE_CHAOSMONKEY false}}
 {{$ENABLE_PROMETHEUS_API_RESPONSIVENESS := DefaultParam .ENABLE_PROMETHEUS_API_RESPONSIVENESS false}}
 {{$ENABLE_PROBES := DefaultParam .ENABLE_PROBES false}}
+{{$ENABLE_DNS_PROBES := DefaultParam .ENABLE_DNS_PROBES false}}
 #Variables
 {{$namespaces := DivideInt .Nodes $NODES_PER_NAMESPACE}}
 {{$podsPerNamespace := MultiplyInt $PODS_PER_NODE $NODES_PER_NAMESPACE}}
@@ -61,6 +62,13 @@ steps:
     Params:
       action: start
       replicasPerProbe: {{DivideInt .Nodes 100}}
+  {{if $ENABLE_DNS_PROBES}}
+  - Identifier: DnsLookupLatency
+    Method: DnsLookupLatency
+    Params:
+      action: start
+      replicasPerProbe: {{DivideInt .Nodes 100}}
+  {{end}}
   - Identifier: TestMetrics
     Method: TestMetrics
     Params:
@@ -222,6 +230,12 @@ steps:
     Method: InClusterNetworkLatency
     Params:
       action: gather
+  {{if $ENABLE_DNS_PROBES}}
+  - Identifier: DnsLookupLatency
+    Method: DnsLookupLatency
+    Params:
+      action: gather
+  {{end}}
   - Identifier: TestMetrics
     Method: TestMetrics
     Params:

--- a/clusterloader2/testing/load/config.yaml
+++ b/clusterloader2/testing/load/config.yaml
@@ -14,6 +14,7 @@
 {{$SMALL_GROUP_SIZE := 5}}
 {{$ENABLE_CHAOSMONKEY := DefaultParam .ENABLE_CHAOSMONKEY false}}
 {{$ENABLE_PROMETHEUS_API_RESPONSIVENESS := DefaultParam .ENABLE_PROMETHEUS_API_RESPONSIVENESS false}}
+{{$ENABLE_DNS_PROBES := DefaultParam .ENABLE_DNS_PROBES false}}
 #Variables
 {{$namespaces := DivideInt .Nodes $NODES_PER_NAMESPACE}}
 {{$totalPods := MultiplyInt $namespaces $NODES_PER_NAMESPACE $PODS_PER_NODE}}
@@ -71,6 +72,13 @@ steps:
     Params:
       action: start
       replicasPerProbe: {{DivideInt .Nodes 100}}
+  {{if $ENABLE_DNS_PROBES}}
+  - Identifier: DnsLookupLatency
+    Method: DnsLookupLatency
+    Params:
+      action: start
+      replicasPerProbe: {{DivideInt .Nodes 100}}
+  {{end}}
   - Identifier: NetworkProgrammingLatency
     Method: NetworkProgrammingLatency
     Params:
@@ -293,6 +301,12 @@ steps:
     Method: InClusterNetworkLatency
     Params:
       action: gather
+  {{if $ENABLE_DNS_PROBES}}
+  - Identifier: DnsLookupLatency
+    Method: DnsLookupLatency
+    Params:
+      action: gather
+  {{end}}
   - Identifier: NetworkProgrammingLatency
     Method: NetworkProgrammingLatency
     Params:

--- a/clusterloader2/testing/load/experimental/bundled_services_and_deployments.yaml
+++ b/clusterloader2/testing/load/experimental/bundled_services_and_deployments.yaml
@@ -16,6 +16,7 @@
 {{$SMALL_GROUP_SIZE := 5}}
 {{$ENABLE_CHAOSMONKEY := DefaultParam .ENABLE_CHAOSMONKEY false}}
 {{$ENABLE_PROMETHEUS_API_RESPONSIVENESS := DefaultParam .ENABLE_PROMETHEUS_API_RESPONSIVENESS false}}
+{{$ENABLE_DNS_PROBES := DefaultParam .ENABLE_DNS_PROBES false}}
 #Variables
 {{$namespaces := DivideInt .Nodes $NODES_PER_NAMESPACE}}
 {{$totalPods := MultiplyInt $namespaces $NODES_PER_NAMESPACE $PODS_PER_NODE}}
@@ -70,6 +71,13 @@ steps:
     Params:
       action: start
       replicasPerProbe: {{DivideInt .Nodes 100}}
+  {{if $ENABLE_DNS_PROBES}}
+  - Identifier: DnsLookupLatency
+    Method: DnsLookupLatency
+    Params:
+      action: start
+      replicasPerProbe: {{DivideInt .Nodes 100}}
+  {{end}}
   - Identifier: NetworkProgrammingLatency
     Method: NetworkProgrammingLatency
     Params:
@@ -263,6 +271,12 @@ steps:
     Method: InClusterNetworkLatency
     Params:
       action: gather
+  {{if $ENABLE_DNS_PROBES}}
+  - Identifier: DnsLookupLatency
+    Method: DnsLookupLatency
+    Params:
+      action: gather
+  {{end}}
   - Identifier: NetworkProgrammingLatency
     Method: NetworkProgrammingLatency
     Params:

--- a/clusterloader2/testing/load/experimental/extended_config.yaml
+++ b/clusterloader2/testing/load/experimental/extended_config.yaml
@@ -16,6 +16,7 @@
 {{$ENABLE_PROMETHEUS_API_RESPONSIVENESS := DefaultParam .ENABLE_PROMETHEUS_API_RESPONSIVENESS false}}
 {{$ENABLE_CONFIGMAPS := DefaultParam .ENABLE_CONFIGMAPS false}}
 {{$ENABLE_SECRETS := DefaultParam .ENABLE_SECRETS false}}
+{{$ENABLE_DNS_PROBES := DefaultParam .ENABLE_DNS_PROBES false}}
 #Variables
 {{$namespaces := DivideInt .Nodes $NODES_PER_NAMESPACE}}
 {{$totalPods := MultiplyInt $namespaces $NODES_PER_NAMESPACE $PODS_PER_NODE}}
@@ -73,6 +74,13 @@ steps:
     Params:
       action: start
       replicasPerProbe: {{DivideInt .Nodes 100}}
+  {{if $ENABLE_DNS_PROBES}}
+  - Identifier: DnsLookupLatency
+    Method: DnsLookupLatency
+    Params:
+      action: start
+      replicasPerProbe: {{DivideInt .Nodes 100}}
+  {{end}}
   - Identifier: NetworkProgrammingLatency
     Method: NetworkProgrammingLatency
     Params:
@@ -343,6 +351,12 @@ steps:
     Method: InClusterNetworkLatency
     Params:
       action: gather
+  {{if $ENABLE_DNS_PROBES}}
+  - Identifier: DnsLookupLatency
+    Method: DnsLookupLatency
+    Params:
+      action: gather
+  {{end}}
   - Identifier: NetworkProgrammingLatency
     Method: NetworkProgrammingLatency
     Params:


### PR DESCRIPTION
ref https://github.com/kubernetes/perf-tests/issues/612

This PR also adds parsed overrides as an argument to Measurements. This is needed, so the probes can be started from inside measurement and still benefit from knobs passed via testoverrides to clusterloader2. I think the approach is not ideal, but I am struggling to come up with something better. I am open to other ideas. 

/assign @wojtek-t @mm4tt 