### PR TITLE
ClusterLoader2 cleanups and improvements

### DIFF
--- a/clusterloader2/pkg/config/template_functions.go
+++ b/clusterloader2/pkg/config/template_functions.go
@@ -53,8 +53,6 @@ func GetFuncs() template.FuncMap {
 		"MaxFloat":      maxFloat,
 		"MinFloat":      minFloat,
 		"Mod":           mod,
-		"IsEven":        isEven,
-		"IsOdd":         isOdd,
 		"DefaultParam":  defaultParam,
 		"IncludeFile":   includeFile,
 		"YamlQuote":     yamlQuote,
@@ -186,14 +184,6 @@ func minFloat(numbers ...interface{}) float64 {
 
 func mod(a interface{}, b interface{}) int {
 	return int(toFloat64(a)) % int(toFloat64(b))
-}
-
-func isEven(number interface{}) bool {
-	return int(toFloat64(number))%2 == 0
-}
-
-func isOdd(number interface{}) bool {
-	return !isEven(number)
 }
 
 func defaultParam(param, defaultValue interface{}) interface{} {

--- a/clusterloader2/pkg/test/interface.go
+++ b/clusterloader2/pkg/test/interface.go
@@ -50,6 +50,7 @@ type Context interface {
 	GetClusterFramework() *framework.Framework
 	GetPrometheusFramework() *framework.Framework
 	GetState() *state.State
+	GetTemplateMappingCopy() map[string]interface{}
 	GetTemplateProvider() *config.TemplateProvider
 	GetTuningSetFactory() tuningset.TuningSetFactory
 	GetMeasurementManager() *measurement.MeasurementManager

--- a/clusterloader2/pkg/test/simple_context.go
+++ b/clusterloader2/pkg/test/simple_context.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/perf-tests/clusterloader2/pkg/measurement"
 	"k8s.io/perf-tests/clusterloader2/pkg/state"
 	"k8s.io/perf-tests/clusterloader2/pkg/tuningset"
+	"k8s.io/perf-tests/clusterloader2/pkg/util"
 )
 
 type simpleContext struct {
@@ -32,19 +33,21 @@ type simpleContext struct {
 	clusterFramework    *framework.Framework
 	prometheusFramework *framework.Framework
 	state               *state.State
+	templateMapping     map[string]interface{}
 	templateProvider    *config.TemplateProvider
 	tuningSetFactory    tuningset.TuningSetFactory
 	measurementManager  *measurement.MeasurementManager
 	chaosMonkey         *chaos.Monkey
 }
 
-func createSimpleContext(c *config.ClusterLoaderConfig, f, p *framework.Framework, s *state.State) Context {
+func createSimpleContext(c *config.ClusterLoaderConfig, f, p *framework.Framework, s *state.State, templateMapping map[string]interface{}) Context {
 	templateProvider := config.NewTemplateProvider(filepath.Dir(c.TestConfigPath))
 	return &simpleContext{
 		clusterLoaderConfig: c,
 		clusterFramework:    f,
 		prometheusFramework: p,
 		state:               s,
+		templateMapping:     util.CloneMap(templateMapping),
 		templateProvider:    templateProvider,
 		tuningSetFactory:    tuningset.NewTuningSetFactory(),
 		measurementManager:  measurement.CreateMeasurementManager(f, p, templateProvider, c),
@@ -75,6 +78,11 @@ func (sc *simpleContext) GetState() *state.State {
 // GetTemplateProvider returns template provider.
 func (sc *simpleContext) GetTemplateProvider() *config.TemplateProvider {
 	return sc.templateProvider
+}
+
+// GetTemplateMappingCopy returns a copy of template mapping.
+func (sc *simpleContext) GetTemplateMappingCopy() map[string]interface{} {
+	return util.CloneMap(sc.templateMapping)
 }
 
 // GetTickerFactory returns tuning set factory.

--- a/clusterloader2/pkg/test/simple_test_executor.go
+++ b/clusterloader2/pkg/test/simple_test_executor.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/klog"
 
 	"k8s.io/perf-tests/clusterloader2/api"
+	"k8s.io/perf-tests/clusterloader2/pkg/config"
 	"k8s.io/perf-tests/clusterloader2/pkg/errors"
 	"k8s.io/perf-tests/clusterloader2/pkg/state"
 	"k8s.io/perf-tests/clusterloader2/pkg/util"
@@ -246,20 +247,22 @@ func (ste *simpleTestExecutor) ExecuteObject(ctx Context, object *api.Object, na
 		mapping[namePlaceholder] = objName
 		mapping[indexPlaceholder] = replicaIndex
 		obj, err = ctx.GetTemplateProvider().TemplateToObject(object.ObjectTemplatePath, mapping)
-		if err != nil {
+		if err != nil && err != config.ErrorEmptyFile {
 			return errors.NewErrorList(fmt.Errorf("reading template (%v) error: %v", object.ObjectTemplatePath, err))
 		}
 	case DELETE_OBJECT:
 		obj, err = ctx.GetTemplateProvider().RawToObject(object.ObjectTemplatePath)
-		if err != nil {
+		if err != nil && err != config.ErrorEmptyFile {
 			return errors.NewErrorList(fmt.Errorf("reading template (%v) for deletion error: %v", object.ObjectTemplatePath, err))
 		}
 	default:
 		return errors.NewErrorList(fmt.Errorf("unsupported operation %v for namespace %v object %v", operation, namespace, objName))
 	}
-	gvk := obj.GroupVersionKind()
-
 	errList := errors.NewErrorList()
+	if err == config.ErrorEmptyFile {
+		return errList
+	}
+	gvk := obj.GroupVersionKind()
 	switch operation {
 	case CREATE_OBJECT:
 		if err := ctx.GetClusterFramework().CreateObject(namespace, objName, obj); err != nil {

--- a/clusterloader2/pkg/test/simple_test_executor.go
+++ b/clusterloader2/pkg/test/simple_test_executor.go
@@ -238,7 +238,7 @@ func (ste *simpleTestExecutor) ExecuteObject(ctx Context, object *api.Object, na
 	var obj *unstructured.Unstructured
 	switch operation {
 	case CREATE_OBJECT, PATCH_OBJECT:
-		mapping := make(map[string]interface{})
+		mapping := ctx.GetTemplateMappingCopy()
 		if object.TemplateFillMap != nil {
 			util.CopyMap(object.TemplateFillMap, mapping)
 		}

--- a/clusterloader2/pkg/test/test.go
+++ b/clusterloader2/pkg/test/test.go
@@ -51,13 +51,12 @@ func RunTest(clusterFramework, prometheusFramework *framework.Framework, cluster
 		return errors.NewErrorList(fmt.Errorf("no Test installed"))
 	}
 
-	ctx := CreateContext(clusterLoaderConfig, clusterFramework, prometheusFramework, state.NewState())
-	testConfigFilename := filepath.Base(clusterLoaderConfig.TestConfigPath)
-
 	mapping, errList := config.GetMapping(clusterLoaderConfig)
 	if errList != nil {
 		return errList
 	}
+	ctx := CreateContext(clusterLoaderConfig, clusterFramework, prometheusFramework, state.NewState(), mapping)
+	testConfigFilename := filepath.Base(clusterLoaderConfig.TestConfigPath)
 	testConfig, err := ctx.GetTemplateProvider().TemplateToConfig(testConfigFilename, mapping)
 	if err != nil {
 		return errors.NewErrorList(fmt.Errorf("config reading error: %v", err))

--- a/clusterloader2/pkg/util/util.go
+++ b/clusterloader2/pkg/util/util.go
@@ -219,6 +219,13 @@ func CopyMap(src, dest map[string]interface{}) {
 	}
 }
 
+// CloneMap returns clone of the provided map.
+func CloneMap(src map[string]interface{}) map[string]interface{} {
+	m := make(map[string]interface{})
+	CopyMap(src, m)
+	return m
+}
+
 // RandomDNS1123String generates random string of a given length.
 func RandomDNS1123String(length int) string {
 	characters := []rune("abcdefghijklmnopqrstuvwxyz0123456789")

--- a/clusterloader2/testing/load/deployment.yaml
+++ b/clusterloader2/testing/load/deployment.yaml
@@ -1,6 +1,5 @@
-# TODO(mm4tt): Allow using global overrides in object templates.
-{{$EnableConfigMaps := DefaultParam .EnableConfigMaps false}}
-{{$EnableSecrets := DefaultParam .EnableSecrets false}}
+{{$EnableConfigMaps := DefaultParam .ENABLE_CONFIGMAPS false}}
+{{$EnableSecrets := DefaultParam .ENABLE_SECRETS false}}
 
 apiVersion: apps/v1
 kind: Deployment

--- a/clusterloader2/testing/load/experimental/extended_config.yaml
+++ b/clusterloader2/testing/load/experimental/extended_config.yaml
@@ -146,8 +146,6 @@ steps:
     - basename: big-deployment
       objectTemplatePath: deployment.yaml
       templateFillMap:
-        EnableConfigMaps: {{$ENABLE_CONFIGMAPS}}
-        EnableSecrets: {{$ENABLE_SECRETS}}
         ReplicasMin: {{$BIG_GROUP_SIZE}}
         ReplicasMax: {{$BIG_GROUP_SIZE}}
         SvcName: big-service
@@ -168,8 +166,6 @@ steps:
     - basename: medium-deployment
       objectTemplatePath: deployment.yaml
       templateFillMap:
-        EnableConfigMaps: {{$ENABLE_CONFIGMAPS}}
-        EnableSecrets: {{$ENABLE_SECRETS}}
         ReplicasMin: {{$MEDIUM_GROUP_SIZE}}
         ReplicasMax: {{$MEDIUM_GROUP_SIZE}}
         SvcName: medium-service
@@ -190,8 +186,6 @@ steps:
     - basename: small-deployment
       objectTemplatePath: deployment.yaml
       templateFillMap:
-        EnableConfigMaps: {{$ENABLE_CONFIGMAPS}}
-        EnableSecrets: {{$ENABLE_SECRETS}}
         ReplicasMin: {{$SMALL_GROUP_SIZE}}
         ReplicasMax: {{$SMALL_GROUP_SIZE}}
         SvcName: small-service
@@ -214,8 +208,6 @@ steps:
     - basename: big-deployment
       objectTemplatePath: deployment.yaml
       templateFillMap:
-        EnableConfigMaps: {{$ENABLE_CONFIGMAPS}}
-        EnableSecrets: {{$ENABLE_SECRETS}}
         ReplicasMin: {{MultiplyInt $BIG_GROUP_SIZE 0.5}}
         ReplicasMax: {{MultiplyInt $BIG_GROUP_SIZE 1.5}}
         SvcName: big-service
@@ -228,8 +220,6 @@ steps:
     - basename: medium-deployment
       objectTemplatePath: deployment.yaml
       templateFillMap:
-        EnableConfigMaps: {{$ENABLE_CONFIGMAPS}}
-        EnableSecrets: {{$ENABLE_SECRETS}}
         ReplicasMin: {{MultiplyInt $MEDIUM_GROUP_SIZE 0.5}}
         ReplicasMax: {{MultiplyInt $MEDIUM_GROUP_SIZE 1.5}}
         SvcName: medium-service
@@ -242,8 +232,6 @@ steps:
     - basename: small-deployment
       objectTemplatePath: deployment.yaml
       templateFillMap:
-        EnableConfigMaps: {{$ENABLE_CONFIGMAPS}}
-        EnableSecrets: {{$ENABLE_SECRETS}}
         ReplicasMin: {{MultiplyInt $SMALL_GROUP_SIZE 0.5}}
         ReplicasMax: {{MultiplyInt $SMALL_GROUP_SIZE 1.5}}
         SvcName: small-service

--- a/clusterloader2/testing/load/service.yaml
+++ b/clusterloader2/testing/load/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{.Name}}
-{{if and $SetServiceProxyLabel (IsEven .Index)}}
+{{if and $SetServiceProxyLabel (eq (Mod .Index 2) 0)}}
   labels:
     service.kubernetes.io/service-proxy-name: foo
 {{end}}


### PR DESCRIPTION
*  Remove IsEven / IsOdd template functions: replaced with eq (Mod a 2) 0/1
* Make overrides available in object templates - we don't have to pipe overrides to object templates anymore
* Don't apply empty object template files - this adds ability to easily create an object (e.g. NetworkPolicy) only for X% of deployments
