### PR TITLE
Storage tests: Remove app name from pod and volume object template

### DIFF
--- a/clusterloader2/testing/experimental/storage/pod-startup/config.yaml
+++ b/clusterloader2/testing/experimental/storage/pod-startup/config.yaml
@@ -65,7 +65,7 @@ steps:
     replicasPerNamespace: {{$volumesPerNamespace}}
     tuningSet: Sequence
     objectBundle:
-    - basename: vol-{{$TEST_NAME}}
+    - basename: vol
       objectTemplatePath: {{$VOLUME_TEMPLATE_PATH}}
       templateFillMap:
         Group: volume-test
@@ -89,7 +89,7 @@ steps:
     replicasPerNamespace: {{$podsPerNamespace}}
     tuningSet: Sequence
     objectBundle:
-    - basename: pod-{{$TEST_NAME}}
+    - basename: pod
       objectTemplatePath: {{$POD_TEMPLATE_PATH}}
       templateFillMap:
         Group: volume-test
@@ -109,7 +109,7 @@ steps:
     replicasPerNamespace: 0
     tuningSet: Sequence
     objectBundle:
-    - basename: pod-{{$TEST_NAME}}
+    - basename: pod
       objectTemplatePath: {{$POD_TEMPLATE_PATH}}
 {{ if $PROVISION_VOLUME }}
 # Delete volumes
@@ -120,7 +120,7 @@ steps:
     replicasPerNamespace: 0
     tuningSet: Sequence
     objectBundle:
-      - basename: vol-{{$TEST_NAME}}
+      - basename: vol
         objectTemplatePath: {{$VOLUME_TEMPLATE_PATH}}
 {{ end }}
 # Collect measurements

--- a/clusterloader2/testing/experimental/storage/pod-startup/volume-types/configmap/pod_with_configmap.yaml
+++ b/clusterloader2/testing/experimental/storage/pod-startup/volume-types/configmap/pod_with_configmap.yaml
@@ -1,5 +1,4 @@
 {{$index := .Index}}
-{{$appName := .AppName}}
 {{$volumesPerPod := .VolumesPerPod}}
 apiVersion: v1
 kind: Pod
@@ -22,5 +21,5 @@ spec:
   {{ range $volumeIndex, $vol := Seq .VolumesPerPod }}
   - name: vol-{{$volumeIndex}}
     configMap:
-      name: vol-{{$appName}}-{{AddInt $volumeIndex (MultiplyInt $index $volumesPerPod)}}
+      name: vol-{{AddInt $volumeIndex (MultiplyInt $index $volumesPerPod)}}
   {{ end }}

--- a/clusterloader2/testing/experimental/storage/pod-startup/volume-types/downwardapi/pod_with_downwardapi.yaml
+++ b/clusterloader2/testing/experimental/storage/pod-startup/volume-types/downwardapi/pod_with_downwardapi.yaml
@@ -1,5 +1,4 @@
 {{$index := .Index}}
-{{$appName := .AppName}}
 {{$volumesPerPod := .VolumesPerPod}}
 apiVersion: v1
 kind: Pod

--- a/clusterloader2/testing/experimental/storage/pod-startup/volume-types/emptydir/pod_with_emptydir.yaml
+++ b/clusterloader2/testing/experimental/storage/pod-startup/volume-types/emptydir/pod_with_emptydir.yaml
@@ -1,5 +1,4 @@
 {{$index := .Index}}
-{{$appName := .AppName}}
 {{$volumesPerPod := .VolumesPerPod}}
 apiVersion: v1
 kind: Pod

--- a/clusterloader2/testing/experimental/storage/pod-startup/volume-types/persistentvolume/pod_with_pvc.yaml
+++ b/clusterloader2/testing/experimental/storage/pod-startup/volume-types/persistentvolume/pod_with_pvc.yaml
@@ -1,5 +1,4 @@
 {{$index := .Index}}
-{{$appName := .AppName}}
 {{$volumesPerPod := .VolumesPerPod}}
 apiVersion: v1
 kind: Pod
@@ -22,6 +21,6 @@ spec:
     {{ range $volumeIndex, $vol := Seq .VolumesPerPod }}
     - name: vol-{{$volumeIndex}}
       persistentVolumeClaim:
-        claimName: vol-{{$appName}}-{{AddInt $volumeIndex (MultiplyInt $index $volumesPerPod)}}
+        claimName: vol-{{AddInt $volumeIndex (MultiplyInt $index $volumesPerPod)}}
         readOnly: false
     {{ end }}

--- a/clusterloader2/testing/experimental/storage/pod-startup/volume-types/secret/pod_with_secret.yaml
+++ b/clusterloader2/testing/experimental/storage/pod-startup/volume-types/secret/pod_with_secret.yaml
@@ -1,5 +1,4 @@
 {{$index := .Index}}
-{{$appName := .AppName}}
 {{$volumesPerPod := .VolumesPerPod}}
 apiVersion: v1
 kind: Pod
@@ -22,5 +21,5 @@ spec:
   {{ range $volumeIndex, $vol := Seq .VolumesPerPod }}
   - name: vol-{{$volumeIndex}}
     secret:
-      secretName: vol-{{$appName}}-{{AddInt $volumeIndex (MultiplyInt $index $volumesPerPod)}}
+      secretName: vol-{{AddInt $volumeIndex (MultiplyInt $index $volumesPerPod)}}
   {{ end }}


### PR DESCRIPTION
remove app name parameter from pod and volume object template

Fix: https://github.com/kubernetes/perf-tests/issues/710

/sig storage

/assign @wojtek-t 
cc @hantaowang @msau42 