### PR TITLE
Update cpuConstraints for scheduler and apiserver

### DIFF
--- a/clusterloader2/testing/density/100_nodes/constraints.yaml
+++ b/clusterloader2/testing/density/100_nodes/constraints.yaml
@@ -15,7 +15,7 @@ heapster:
   cpuConstraint: 0.15
   nemoryConstraint: 367001600 #350 * (1024 * 1024)
 kube-apiserver:
-  cpuConstraint: 2.5 # TODO(https://github.com/kubernetes/kubernetes/issues/80212): Change back to 2.2 once investigated.
+  cpuConstraint: 2.8
   memoryConstraint: 1258291200 #1200 * (1024 * 1024)
 kube-controller-manager:
   cpuConstraint: 1.5
@@ -24,7 +24,7 @@ kube-proxy:
   cpuConstraint: 0.1
   memoryConstraint: 31457280 #30 * (1024 * 1024)
 kube-scheduler:
-  cpuConstraint: 0.7 # TODO(https://github.com/kubernetes/kubernetes/issues/80212): Change back to 0.35 once investigated.
+  cpuConstraint: 0.75
   memoryConstraint: 125829120 #120 * (1024 * 1024)
 l7-lb-controller:
   cpuConstraint: 0.20


### PR DESCRIPTION
Now, the https://github.com/kubernetes/perf-tests/pull/697 has merged, the CPU usage is much less flaky. On the other hand it went up which is expected as now we more accurately measure the actual 99th percentile (see https://github.com/kubernetes/kubernetes/issues/80212#issuecomment-515010726 as an example of how bad we used to did it).

Given that we should increase some constraints and remove the old TODOs.

Justification for the values of cpuConstraints used in this PR:

* **scheduler** - since https://github.com/kubernetes/perf-tests/pull/697 the max observed value was 0.61 CPU, setting the limit to ~20% more which is ~0.75 
![eQkPyVj1a5C](https://user-images.githubusercontent.com/2604887/62209385-c4861300-b399-11e9-9c5f-78ba98e0782c.png)
* **api-server** - since https://github.com/kubernetes/perf-tests/pull/697 the max observed value was 2.3 CPU, setting the limit to ~20% more which is ~2.8
![L5SJnLFFSwY](https://user-images.githubusercontent.com/2604887/62209467-f7300b80-b399-11e9-8433-455c0749fe7e.png)



Fixes https://github.com/kubernetes/perf-tests/issues/694