### PR TITLE
ClusterLoader - Disk snapshot name verify

### DIFF
--- a/clusterloader2/pkg/prometheus/experimental.go
+++ b/clusterloader2/pkg/prometheus/experimental.go
@@ -77,7 +77,11 @@ func (pc *PrometheusController) trySnapshotPrometheusDisk() (bool, error) {
 	}
 	snapshotName := pdName
 	if *prometheusDiskSnapshotName != "" {
-		snapshotName = *prometheusDiskSnapshotName
+		if err := VerifySnapshotName(*prometheusDiskSnapshotName); err == nil {
+			snapshotName = *prometheusDiskSnapshotName
+		} else {
+			klog.Warningf("Incorrect disk name %v: %v. Using default name: %v", *prometheusDiskSnapshotName, err, pdName)
+		}
 	}
 	klog.Infof("Snapshotting PD '%s' into snapshot '%s' in zone '%s'", pdName, snapshotName, zone)
 	cmd := exec.Command("gcloud", "compute", "disks", "snapshot", pdName, "--zone", zone, "--snapshot-names", snapshotName)

--- a/clusterloader2/pkg/prometheus/util.go
+++ b/clusterloader2/pkg/prometheus/util.go
@@ -18,6 +18,9 @@ package prometheus
 
 import (
 	"encoding/json"
+	"fmt"
+	"regexp"
+
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog"
 )
@@ -84,4 +87,16 @@ func CheckTargetsReady(k8sClient kubernetes.Interface, selector func(Target) boo
 	}
 	klog.Infof("All %d expected targets are ready", minReadyTargets)
 	return true, nil
+}
+
+const snapshotNamePattern = `^(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?)$`
+
+var re = regexp.MustCompile(snapshotNamePattern)
+
+// VerifySnapshotName verifies if snapshot name statisfies snapshot name regex.
+func VerifySnapshotName(name string) error {
+	if re.MatchString(name) {
+		return nil
+	}
+	return fmt.Errorf("disk name doesn't match %v", snapshotNamePattern)
 }

--- a/clusterloader2/pkg/prometheus/util_test.go
+++ b/clusterloader2/pkg/prometheus/util_test.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package prometheus
+
+import (
+	"testing"
+)
+
+func TestVerifySnapshotName(t *testing.T) {
+	tests := []struct {
+		name    string
+		isValid bool
+	}{
+		{"disk-name", true},
+		{"disk_name", false},
+		{"disk12345", true},
+		{"123242345", false},
+	}
+
+	for _, test := range tests {
+		err := VerifySnapshotName(test.name)
+		if test.isValid != (err == nil) {
+			t.Errorf("Incorrect validation result of %s, got: %v, want: %v",
+				test.name, (err == nil), test.isValid)
+		}
+	}
+}


### PR DESCRIPTION
This change prevents losing prometheus disk snapshot when snapshot name is invalid.