### PR TITLE
Refactor probes.go so that there is a single prober enabled per instance

### DIFF
--- a/clusterloader2/pkg/measurement/common/slos/pod_startup_latency.go
+++ b/clusterloader2/pkg/measurement/common/slos/pod_startup_latency.go
@@ -162,14 +162,8 @@ func (p *podStartupLatencyMeasurement) gather(c clientset.Interface, identifier 
 		},
 	})
 
-	podStartupLatencyThreshold := &measurementutil.LatencyMetric{
-		Perc50: p.threshold,
-		Perc90: p.threshold,
-		Perc99: p.threshold,
-	}
-
 	var err error
-	if slosErr := podStartupLatency["pod_startup"].VerifyThreshold(podStartupLatencyThreshold); slosErr != nil {
+	if slosErr := podStartupLatency["pod_startup"].VerifyThreshold(p.threshold); slosErr != nil {
 		err = errors.NewMetricViolationError("pod startup", slosErr.Error())
 		klog.Errorf("%s: %v", p, err)
 	}

--- a/clusterloader2/pkg/measurement/util/latency_metric.go
+++ b/clusterloader2/pkg/measurement/util/latency_metric.go
@@ -46,15 +46,15 @@ func (metric *LatencyMetric) SetQuantile(quantile float64, latency time.Duration
 }
 
 // VerifyThreshold verifies latency metric against given percentile thresholds.
-func (metric *LatencyMetric) VerifyThreshold(threshold *LatencyMetric) error {
-	if metric.Perc50 > threshold.Perc50 {
-		return fmt.Errorf("too high latency 50th percentile: %v", metric.Perc50)
+func (metric *LatencyMetric) VerifyThreshold(threshold time.Duration) error {
+	if metric.Perc50 > threshold {
+		return fmt.Errorf("too high latency 50th percentile: got %v expected: %v", metric.Perc50, threshold)
 	}
-	if metric.Perc90 > threshold.Perc90 {
-		return fmt.Errorf("too high latency 90th percentile: %v", metric.Perc90)
+	if metric.Perc90 > threshold {
+		return fmt.Errorf("too high latency 90th percentile: got %v expected: %v", metric.Perc90, threshold)
 	}
-	if metric.Perc99 > threshold.Perc99 {
-		return fmt.Errorf("too high latency 99th percentile: %v", metric.Perc99)
+	if metric.Perc99 > threshold {
+		return fmt.Errorf("too high latency 99th percentile: got %v expected: %v", metric.Perc99, threshold)
 	}
 	return nil
 }

--- a/clusterloader2/testing/density/config.yaml
+++ b/clusterloader2/testing/density/config.yaml
@@ -56,8 +56,8 @@ steps:
     Params:
       action: start
   # TODO(oxddr): figure out how many probers to run in function of cluster
-  - Identifier: Probes
-    Method: Probes
+  - Identifier: InClusterNetworkLatency
+    Method: InClusterNetworkLatency
     Params:
       action: start
       replicasPerProbe: {{DivideInt .Nodes 100}}
@@ -218,8 +218,8 @@ steps:
       {{if $ENABLE_PROMETHEUS_API_RESPONSIVENESS}}
       enableViolations: true
       {{end}}
-  - Identifier: Probes
-    Method: Probes
+  - Identifier: InClusterNetworkLatency
+    Method: InClusterNetworkLatency
     Params:
       action: gather
   - Identifier: TestMetrics

--- a/clusterloader2/testing/load/config.yaml
+++ b/clusterloader2/testing/load/config.yaml
@@ -66,8 +66,8 @@ steps:
       action: start
       labelSelector: group = load
       threshold: 1h
-  - Identifier: Probes
-    Method: Probes
+  - Identifier: InClusterNetworkLatency
+    Method: InClusterNetworkLatency
     Params:
       action: start
       replicasPerProbe: {{DivideInt .Nodes 100}}
@@ -289,8 +289,8 @@ steps:
     Method: PodStartupLatency
     Params:
       action: gather
-  - Identifier: Probes
-    Method: Probes
+  - Identifier: InClusterNetworkLatency
+    Method: InClusterNetworkLatency
     Params:
       action: gather
   - Identifier: NetworkProgrammingLatency

--- a/clusterloader2/testing/load/experimental/bundled_services_and_deployments.yaml
+++ b/clusterloader2/testing/load/experimental/bundled_services_and_deployments.yaml
@@ -65,8 +65,8 @@ steps:
       action: start
       labelSelector: group = load
       threshold: 1h
-  - Identifier: Probes
-    Method: Probes
+  - Identifier: InClusterNetworkLatency
+    Method: InClusterNetworkLatency
     Params:
       action: start
       replicasPerProbe: {{DivideInt .Nodes 100}}
@@ -259,8 +259,8 @@ steps:
     Method: PodStartupLatency
     Params:
       action: gather
-  - Identifier: Probes
-    Method: Probes
+  - Identifier: InClusterNetworkLatency
+    Method: InClusterNetworkLatency
     Params:
       action: gather
   - Identifier: NetworkProgrammingLatency

--- a/clusterloader2/testing/load/experimental/extended_config.yaml
+++ b/clusterloader2/testing/load/experimental/extended_config.yaml
@@ -68,8 +68,8 @@ steps:
       action: start
       labelSelector: group = load
       threshold: 1h
-  - Identifier: Probes
-    Method: Probes
+  - Identifier: InClusterNetworkLatency
+    Method: InClusterNetworkLatency
     Params:
       action: start
       replicasPerProbe: {{DivideInt .Nodes 100}}
@@ -339,8 +339,8 @@ steps:
     Method: PodStartupLatency
     Params:
       action: gather
-  - Identifier: Probes
-    Method: Probes
+  - Identifier: InClusterNetworkLatency
+    Method: InClusterNetworkLatency
     Params:
       action: gather
   - Identifier: NetworkProgrammingLatency


### PR DESCRIPTION
This allows to enable probes using overrides, so they can be rolled out gradually or rolled back if needed. The previous version was optimized for minimizing code changes needed to enable a new prober. However in light of https://github.com/kubernetes/perf-tests/blob/master/clusterloader2/docs/experiments.md this make gradual rollout impossible without changes to probes.go.