### PR TITLE
Show DNS lookup latency in PerfDash.

### DIFF
--- a/perfdash/Makefile
+++ b/perfdash/Makefile
@@ -1,7 +1,7 @@
 all: push
 
 # See pod.yaml for the version currently running-- bump this ahead before rebuilding!
-TAG = 2.10
+TAG = 2.11
 
 REPO = gcr.io/k8s-testimages
 

--- a/perfdash/config.go
+++ b/perfdash/config.go
@@ -203,14 +203,40 @@ var (
 				OutputFilePrefix: "NetworkProgrammingLatency",
 				Parser:           parsePerfData,
 			}},
-			"Load_NetworkLatency": []TestDescription{{
+
+			"Load_NetworkLatency": []TestDescription{
+				{
+					// TODO(oxddr): remove this around Sep '19 when we stop showing old data
+					Name:             "load",
+					OutputFilePrefix: "in_cluster_network_latency",
+					Parser:           parsePerfData,
+				}, {
+					Name:             "load",
+					OutputFilePrefix: "InClusterNetworkLatency",
+					Parser:           parsePerfData,
+				}},
+
+			"Density_NetworkLatency": []TestDescription{
+				{
+					// TODO(oxddr): remove this around Sep '19 when we stop showing old data
+					Name:             "density",
+					OutputFilePrefix: "in_cluster_network_latency",
+					Parser:           parsePerfData,
+				}, {
+					Name:             "density",
+					OutputFilePrefix: "InClusterNetworkLatency",
+					Parser:           parsePerfData,
+				}},
+		},
+		"DNS": {
+			"Load_DNSLookupLatency": []TestDescription{{
 				Name:             "load",
-				OutputFilePrefix: "in_cluster_network_latency",
+				OutputFilePrefix: "DnsLookupLatency",
 				Parser:           parsePerfData,
 			}},
-			"Density_NetworkLatency": []TestDescription{{
+			"Density_DNSLookupLatency": []TestDescription{{
 				Name:             "density",
-				OutputFilePrefix: "in_cluster_network_latency",
+				OutputFilePrefix: "DnsLookupLatency",
 				Parser:           parsePerfData,
 			}},
 		},

--- a/perfdash/deployment.yaml
+++ b/perfdash/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: default
   labels:
     app: perfdash
-    version: "2.10"
+    version: "2.11"
 spec:
   selector:
     matchLabels:
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: perfdash
-        image: gcr.io/k8s-testimages/perfdash:2.10
+        image: gcr.io/k8s-testimages/perfdash:2.11
         command:
           - /perfdash
           -   --www=true


### PR DESCRIPTION
Also reintroduce Network latency as the metric format has changed.

ref https://github.com/kubernetes/perf-tests/issues/612
ref https://github.com/kubernetes/perf-tests/issues/597

/hold