### PR TITLE
Remove enable_dns_probes experiment.

### DIFF
--- a/clusterloader2/testing/experiments/enable_dns_probes.yaml
+++ b/clusterloader2/testing/experiments/enable_dns_probes.yaml
@@ -1,1 +1,0 @@
-ENABLE_DNS_PROBES: true


### PR DESCRIPTION
Fixes https://github.com/kubernetes/perf-tests/issues/612
/hold