### PR TITLE
 Use a threshold of 1000ms in in-cluster network latency SLI.

### DIFF
--- a/clusterloader2/testing/density/config.yaml
+++ b/clusterloader2/testing/density/config.yaml
@@ -61,6 +61,7 @@ steps:
     Params:
       action: start
       replicasPerProbe: {{DivideInt .Nodes 100}}
+      threshold: 1000ms
   - Identifier: DnsLookupLatency
     Method: DnsLookupLatency
     Params:

--- a/clusterloader2/testing/load/config.yaml
+++ b/clusterloader2/testing/load/config.yaml
@@ -71,6 +71,7 @@ steps:
     Params:
       action: start
       replicasPerProbe: {{DivideInt .Nodes 100}}
+      threshold: 1000ms
   - Identifier: DnsLookupLatency
     Method: DnsLookupLatency
     Params:


### PR DESCRIPTION
Test will fail if the latency exceeds the threshold.