### PR TITLE
Fix memory leaks in probes.

### DIFF
--- a/probes/Makefile
+++ b/probes/Makefile
@@ -1,6 +1,6 @@
 PROJECT = k8s-testimages
 IMG = gcr.io/$(PROJECT)/probes
-TAG = v0.0.3
+TAG = v0.0.4
 
 all: push
 

--- a/probes/cmd/main.go
+++ b/probes/cmd/main.go
@@ -20,6 +20,8 @@ import (
 	"flag"
 	"net/http"
 
+	_ "net/http/pprof"
+
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"k8s.io/klog"
 	"k8s.io/perf-tests/probes/pkg/dns"

--- a/probes/pkg/ping/client/client.go
+++ b/probes/pkg/ping/client/client.go
@@ -65,7 +65,10 @@ func Run(config *Config) {
 }
 
 func ping(serverAddress string) error {
-	_, err := http.Get("http://" + serverAddress)
+	resp, err := http.Get("http://" + serverAddress)
+	if resp != nil {
+		resp.Body.Close()
+	}
 	return err
 }
 


### PR DESCRIPTION
 Close response body to fix memory leak in ping-client.

Also:
 * bump probes to v0.0.4
 * add pprof handlers to probes binary for ease of debugging

ref https://github.com/kubernetes/perf-tests/issues/755
/assign @mm4tt 