### PR TITLE
Make deployment.yaml ignore .ENABLE_CONFIGMAPS|SECRETS vars

### DIFF
--- a/clusterloader2/testing/load/deployment.yaml
+++ b/clusterloader2/testing/load/deployment.yaml
@@ -1,5 +1,6 @@
-{{$EnableConfigMaps := DefaultParam .ENABLE_CONFIGMAPS false}}
-{{$EnableSecrets := DefaultParam .ENABLE_SECRETS false}}
+# TODO(mm4tt): Change to read from .ENABLE_CONFIGMAPS and .ENABLE_SECRETS vars.
+{{$EnableConfigMaps := false}}
+{{$EnableSecrets := false}}
 
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
This is to fix presubmits. It will be switched back in https://github.com/kubernetes/perf-tests/pull/767