### PR TITLE
Increase number of probes running in tests

### DIFF
--- a/clusterloader2/testing/density/config.yaml
+++ b/clusterloader2/testing/density/config.yaml
@@ -60,12 +60,12 @@ steps:
     Method: InClusterNetworkLatency
     Params:
       action: start
-      replicasPerProbe: {{DivideInt .Nodes 100}}
+      replicasPerProbe: {{AddInt 2 (DivideInt .Nodes 100)}}
   - Identifier: DnsLookupLatency
     Method: DnsLookupLatency
     Params:
       action: start
-      replicasPerProbe: {{DivideInt .Nodes 100}}
+      replicasPerProbe: {{AddInt 2 (DivideInt .Nodes 100)}}
   - Identifier: TestMetrics
     Method: TestMetrics
     Params:

--- a/clusterloader2/testing/load/config.yaml
+++ b/clusterloader2/testing/load/config.yaml
@@ -79,12 +79,12 @@ steps:
     Method: InClusterNetworkLatency
     Params:
       action: start
-      replicasPerProbe: {{DivideInt .Nodes 100}}
+      replicasPerProbe: {{AddInt 2 (DivideInt .Nodes 100)}}
   - Identifier: DnsLookupLatency
     Method: DnsLookupLatency
     Params:
       action: start
-      replicasPerProbe: {{DivideInt .Nodes 100}}
+      replicasPerProbe: {{AddInt 2 (DivideInt .Nodes 100)}}
   - Identifier: NetworkProgrammingLatency
     Method: NetworkProgrammingLatency
     Params:


### PR DESCRIPTION
Change number of probes to 2 + #nodes / 100. 

This gives more data points and decreases chances that of single restarted pod to burn SLO (which IMO is unintended).

/assign @mm4tt 
