### PR TITLE
Fix logic for checking if at least one etcd target is available

### DIFF
--- a/clusterloader2/pkg/prometheus/prometheus.go
+++ b/clusterloader2/pkg/prometheus/prometheus.go
@@ -291,7 +291,7 @@ func (pc *PrometheusController) isPrometheusReady() (bool, error) {
 		}
 		return CheckTargetsReady( // 1 out of 2 etcd targets should be ready.
 			pc.framework.GetClientSets().GetClient(),
-			func(t Target) bool { return !isEtcdEndpoint(t.Labels["endpoint"]) },
+			func(t Target) bool { return isEtcdEndpoint(t.Labels["endpoint"]) },
 			2, // expected targets: etcd-2379 and etcd-2382
 			1) // one of them should be healthy
 	}


### PR DESCRIPTION
This will fail until https://github.com/kubernetes/kubernetes/pull/82579 gets in.

Ref. https://github.com/kubernetes/perf-tests/issues/786