### PR TITLE
ClusterLoader: Log step's errors

### DIFF
--- a/clusterloader2/pkg/test/simple_test_executor.go
+++ b/clusterloader2/pkg/test/simple_test_executor.go
@@ -137,6 +137,9 @@ func (ste *simpleTestExecutor) ExecuteStep(ctx Context, step *api.Step) *errors.
 	if step.Name != "" {
 		klog.Infof("Step %q ended", step.Name)
 	}
+	if !errList.IsEmpty() {
+		klog.Warningf("Got errors during step execution: %v", errList)
+	}
 	return errList
 }
 


### PR DESCRIPTION
Our load config recently exceeded 500 lines. If you modify a few places in the config and you get an error is super hard to find it in the yaml as errors are only logged after the whole test, without information where it occurred. This logging will let user know if there were any errors for a given step, which in most cases is enough to easily locate the error it in the yaml file.