### PR TITLE
Extend load test to cover PersistentVolumes

### DIFF
--- a/clusterloader2/api/types.go
+++ b/clusterloader2/api/types.go
@@ -18,6 +18,8 @@ package api
 
 import (
 	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // TestSuite defines list of test scenarios to be run.
@@ -90,6 +92,18 @@ type Object struct {
 	ObjectTemplatePath string `json: objectTemplatePath`
 	// TemplateFillMap specifies for each placeholder what value should it be replaced with.
 	TemplateFillMap map[string]interface{} `json: templateFillMap`
+	// ListUnknownObjectOptions, if set, will result in listing objects that were
+	// not created directly via ClusterLoader2 before executing Phase. The main
+	// use case for that is deleting unknown objects using the Phase mechanism,
+	// e.g. deleting PVs that were created via StatefulSets leveraging all Phase
+	// functionalities, e.g. respecting given QPS, doing it in parallel with other
+	// Phases, etc.
+	ListUnknownObjectOptions *ListUnknownObjectOptions `json: listUnknownObjectOptions`
+}
+
+// ListUnknownObjectOptions struct specifies options for listing unknown objects.
+type ListUnknownObjectOptions struct {
+	LabelSelector *metav1.LabelSelector `json: labelSelector`
 }
 
 // NamespaceRange specifies the range of namespaces [Min, Max].

--- a/clusterloader2/pkg/test/simple_test_executor.go
+++ b/clusterloader2/pkg/test/simple_test_executor.go
@@ -23,13 +23,15 @@ import (
 	"strings"
 	"time"
 
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog"
-
 	"k8s.io/perf-tests/clusterloader2/api"
 	"k8s.io/perf-tests/clusterloader2/pkg/config"
 	"k8s.io/perf-tests/clusterloader2/pkg/errors"
+	"k8s.io/perf-tests/clusterloader2/pkg/measurement/util/runtimeobjects"
 	"k8s.io/perf-tests/clusterloader2/pkg/state"
 	"k8s.io/perf-tests/clusterloader2/pkg/util"
 )
@@ -166,9 +168,14 @@ func (ste *simpleTestExecutor) ExecutePhase(ctx Context, phase *api.Phase) *erro
 			}
 			instances, exists := ctx.GetState().GetNamespacesState().Get(nsName, id)
 			if !exists {
+				currentReplicaCount, err := getReplicaCountOfNewObject(ctx, nsName, &phase.ObjectBundle[j])
+				if err != nil {
+					errList.Append(err)
+					return errList
+				}
 				instances = &state.InstancesState{
 					DesiredReplicaCount: 0,
-					CurrentReplicaCount: 0,
+					CurrentReplicaCount: currentReplicaCount,
 					Object:              phase.ObjectBundle[j],
 				}
 			}
@@ -350,4 +357,31 @@ func cleanupResources(ctx Context) {
 		return
 	}
 	klog.Infof("Resources cleanup time: %v", time.Since(cleanupStartTime))
+}
+
+func getReplicaCountOfNewObject(ctx Context, namespace string, object *api.Object) (int32, error) {
+	if object.ListUnknownObjectOptions == nil {
+		return 0, nil
+	}
+	klog.V(4).Infof("%s: new object detected, will list objects in order to find num replicas", object.Basename)
+	selector, err := metav1.LabelSelectorAsSelector(object.ListUnknownObjectOptions.LabelSelector)
+	if err != nil {
+		return 0, err
+	}
+	obj, err := ctx.GetTemplateProvider().RawToObject(object.ObjectTemplatePath)
+	if err != nil {
+		return 0, err
+	}
+	gvk := obj.GroupVersionKind()
+	gvr, _ := meta.UnsafeGuessKindToResource(gvk)
+	replicaCount, err := runtimeobjects.GetNumObjectsMatchingSelector(
+		ctx.GetClusterFramework().GetDynamicClients().GetClient(),
+		namespace,
+		gvr,
+		selector)
+	if err != nil {
+		return 0, nil
+	}
+	klog.V(4).Infof("%s: found %d replicas", object.Basename, replicaCount)
+	return int32(replicaCount), nil
 }

--- a/clusterloader2/testing/load/config.yaml
+++ b/clusterloader2/testing/load/config.yaml
@@ -19,6 +19,7 @@
 {{$ENABLE_CONFIGMAPS := DefaultParam .ENABLE_CONFIGMAPS false}}
 {{$ENABLE_DAEMONSETS := DefaultParam .ENABLE_DAEMONSETS false}}
 {{$ENABLE_JOBS := DefaultParam .ENABLE_JOBS false}}
+{{$ENABLE_PVS := DefaultParam .ENABLE_PVS false}}
 {{$ENABLE_SECRETS := DefaultParam .ENABLE_SECRETS false}}
 {{$ENABLE_STATEFULSETS := DefaultParam .ENABLE_STATEFULSETS false}}
 {{$USE_SIMPLE_LATENCY_QUERY := DefaultParam .USE_SIMPLE_LATENCY_QUERY false}}
@@ -576,6 +577,37 @@ steps:
       - basename: big-job
         objectTemplatePath: job.yaml
   {{end}}
+  # If both StatefulSets and PVs were enabled we need to delete PVs manually.
+  {{if and $ENABLE_STATEFULSETS $ENABLE_PVS}}
+  - namespaceRange:
+      min: 1
+      max: {{$namespaces}}
+    replicasPerNamespace: 0
+    tuningSet: RandomizedSaturationTimeLimited
+    objectBundle:
+      {{range $ssIndex := Seq $SMALL_STATEFUL_SETS_PER_NAMESPACE}}
+      - basename: pv-small-statefulset-{{$ssIndex}}
+        objectTemplatePath: pvc.yaml
+        listUnknownObjectOptions:
+          labelSelector:
+            matchLabels:
+              name: small-statefulset-{{$ssIndex}}
+      {{end}}
+  - namespaceRange:
+      min: 1
+      max: {{$namespaces}}
+    replicasPerNamespace: 0
+    tuningSet: RandomizedSaturationTimeLimited
+    objectBundle:
+      {{range $ssIndex := Seq $MEDIUM_STATEFUL_SETS_PER_NAMESPACE}}
+      - basename: pv-medium-statefulset-{{$ssIndex}}
+        objectTemplatePath: pvc.yaml
+        listUnknownObjectOptions:
+          labelSelector:
+            matchLabels:
+              name: medium-statefulset-{{$ssIndex}}
+      {{end}}
+  {{end}}
 
 - name: Waiting for pods to be deleted
   measurements:
@@ -600,6 +632,14 @@ steps:
     Method: WaitForControlledPodsRunning
     Params:
       action: gather
+  {{end}}
+  {{if and $ENABLE_STATEFULSETS $ENABLE_PVS}}
+  - Identifier: WaitForPVCsToBeDeleted
+    Method: WaitForBoundPVCs
+    Params:
+      desiredPVCCount: 0
+      labelSelector: group = load
+      timeout: 15m
   {{end}}
 
 - name: Deleting SVCs

--- a/clusterloader2/testing/load/pvc.yaml
+++ b/clusterloader2/testing/load/pvc.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{.Name}}

--- a/clusterloader2/testing/load/statefulset.yaml
+++ b/clusterloader2/testing/load/statefulset.yaml
@@ -1,3 +1,5 @@
+{{$EnablePVs := DefaultParam .ENABLE_PVS false}}
+
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -8,6 +10,7 @@ spec:
   podManagementPolicy: Parallel
   selector:
     matchLabels:
+      group: load
       name: {{.Name}}
   serviceName: {{.Name}}
   replicas: {{RandIntRange .ReplicasMin .ReplicasMax}}
@@ -27,6 +30,11 @@ spec:
           requests:
             cpu: 10m
             memory: "10M"
+        {{if $EnablePVs}}
+        volumeMounts:
+          - name: pv
+            mountPath: /var/pv
+        {{end}}
       terminationGracePeriodSeconds: 1
       # Add not-ready/unreachable tolerations for 15 minutes so that node
       # failure doesn't trigger pod deletion.
@@ -39,3 +47,15 @@ spec:
         operator: "Exists"
         effect: "NoExecute"
         tolerationSeconds: 900
+  {{if $EnablePVs}}
+  # NOTE: PVs created this way should be cleaned-up manually, as deleting the StatefulSet doesn't automatically delete PVs.
+  # To avoid deleting all the PVs at once during namespace deletion, they should be deleted explicitly via Phase.
+  volumeClaimTemplates:
+    - metadata:
+        name: pv
+      spec:
+        accessModes: [ "ReadWriteOnce" ]
+        resources:
+          requests:
+            storage: 100Mi
+  {{end}}


### PR DESCRIPTION
The only tricky part here is deleting PVs that are created via StatefulSets. Theses PVs are not automatically deleted when StatefulSets are deleted. 
Because of that I extended the ClusterLoader2 Phase api to allow deleting objects that weren't created directly via CL2. 
The way it works is that once we detect a new object, and if certain option is set, we issue a List request to find number of replicas for that object.

Ref. https://github.com/kubernetes/perf-tests/issues/704