### PR TITLE
ClusterLoader2:  NetworkProgrammingLatency disable on scraping kube-proxy disabled

### DIFF
--- a/clusterloader2/pkg/measurement/common/slos/network_programming.go
+++ b/clusterloader2/pkg/measurement/common/slos/network_programming.go
@@ -48,6 +48,10 @@ func init() {
 type netProgGatherer struct{}
 
 func (n *netProgGatherer) IsEnabled(config *measurement.MeasurementConfig) bool {
+	// Disable NetworkProgrammingLatency measurement if scraping kube-proxy is disabled.
+	if !config.ClusterLoaderConfig.PrometheusConfig.ScrapeKubeProxy {
+		return false
+	}
 	return config.CloudProvider != "kubemark"
 }
 

--- a/clusterloader2/pkg/measurement/interface.go
+++ b/clusterloader2/pkg/measurement/interface.go
@@ -33,7 +33,9 @@ type MeasurementConfig struct {
 	// into the Execute method.
 	Params map[string]interface{}
 	// TemplateProvider provides templated objects.
-	TemplateProvider *config.TemplateProvider
+	TemplateProvider    *config.TemplateProvider
+	ClusterLoaderConfig *config.ClusterLoaderConfig
+
 	// Identifier identifies this instance of measurement.
 	Identifier    string
 	CloudProvider string

--- a/clusterloader2/pkg/measurement/manager.go
+++ b/clusterloader2/pkg/measurement/manager.go
@@ -62,6 +62,7 @@ func (mm *MeasurementManager) Execute(methodName string, identifier string, para
 		TemplateProvider:    mm.templateProvider,
 		Identifier:          identifier,
 		CloudProvider:       mm.clusterLoaderConfig.ClusterConfig.Provider,
+		ClusterLoaderConfig: mm.clusterLoaderConfig,
 	}
 	summaries, err := measurementInstance.Execute(config)
 	mm.summaries = append(mm.summaries, summaries...)


### PR DESCRIPTION
Fix for 
https://github.com/kubernetes/perf-tests/issues/807