### PR TITLE
Add storage experimental test suite

### DIFF
--- a/clusterloader2/testing/experimental/storage/pod-startup/config.yaml
+++ b/clusterloader2/testing/experimental/storage/pod-startup/config.yaml
@@ -29,7 +29,8 @@
   {{$PVCBoundTime := MultiplyInt $totalVols 2 | MaxInt 60}}
 
 
-name: storage-{{$TEST_NAME}}
+# TODO(pierewoj): Remove this condition once all storage tests are migrated to a single suite.
+name: {{ if eq $TEST_NAME "" }} storage {{ else }} storage-{{$TEST_NAME}} {{ end }}
 automanagedNamespaces: {{$namespaces}}
 tuningSets:
 - name: UniformQPS

--- a/clusterloader2/testing/experimental/storage/pod-startup/empty_test_name/override.yaml
+++ b/clusterloader2/testing/experimental/storage/pod-startup/empty_test_name/override.yaml
@@ -1,0 +1,7 @@
+# TODO(pierewoj): Remove this file once all storage tests are migrated to a single suite.
+# This is used for the storage tests migration from separate jobs to a single suite.
+# Old storage tests won't have this override applied, so metric file names will
+# remain the same.
+# New tests will use this override, so the metric file name will be only parametrized
+# by the suite test identifier.
+TEST_NAME: ''

--- a/clusterloader2/testing/experimental/storage/pod-startup/suite.yaml
+++ b/clusterloader2/testing/experimental/storage/pod-startup/suite.yaml
@@ -1,0 +1,55 @@
+- identifier: emptydir-vol-per-pod
+  configPath: testing/experimental/storage/pod-startup/config.yaml
+  overridePaths:
+    - testing/experimental/storage/pod-startup/volume-types/emptydir/override.yaml
+    - testing/experimental/storage/pod-startup/max_volumes_per_pod/override.yaml
+    - testing/experimental/storage/pod-startup/empty_test_name/override.yaml
+
+- identifier: configmap-vol-per-pod
+  configPath: testing/experimental/storage/pod-startup/config.yaml
+  overridePaths:
+    - testing/experimental/storage/pod-startup/volume-types/configmap/override.yaml
+    - testing/experimental/storage/pod-startup/max_volumes_per_pod/override.yaml
+    - testing/experimental/storage/pod-startup/empty_test_name/override.yaml
+
+- identifier: downwardapi-vol-per-pod
+  configPath: testing/experimental/storage/pod-startup/config.yaml
+  overridePaths:
+    - testing/experimental/storage/pod-startup/volume-types/downwardapi/override.yaml
+    - testing/experimental/storage/pod-startup/max_volumes_per_pod/override.yaml
+    - testing/experimental/storage/pod-startup/empty_test_name/override.yaml
+
+- identifier: secret-vol-per-pod
+  configPath: testing/experimental/storage/pod-startup/config.yaml
+  overridePaths:
+    - testing/experimental/storage/pod-startup/volume-types/secret/override.yaml
+    - testing/experimental/storage/pod-startup/max_volumes_per_pod/override.yaml
+    - testing/experimental/storage/pod-startup/empty_test_name/override.yaml
+
+- identifier: emptydir-vol-per-node
+  configPath: testing/experimental/storage/pod-startup/config.yaml
+  overridePaths:
+    - testing/experimental/storage/pod-startup/volume-types/emptydir/override.yaml
+    - testing/experimental/storage/pod-startup/max_volumes_per_node/override.yaml
+    - testing/experimental/storage/pod-startup/empty_test_name/override.yaml
+
+- identifier: configmap-vol-per-node
+  configPath: testing/experimental/storage/pod-startup/config.yaml
+  overridePaths:
+    - testing/experimental/storage/pod-startup/volume-types/configmap/override.yaml
+    - testing/experimental/storage/pod-startup/max_volumes_per_node/override.yaml
+    - testing/experimental/storage/pod-startup/empty_test_name/override.yaml
+
+- identifier: downwardapi-vol-per-node
+  configPath: testing/experimental/storage/pod-startup/config.yaml
+  overridePaths:
+    - testing/experimental/storage/pod-startup/volume-types/downwardapi/override.yaml
+    - testing/experimental/storage/pod-startup/max_volumes_per_node/override.yaml
+    - testing/experimental/storage/pod-startup/empty_test_name/override.yaml
+
+- identifier: secret-vol-per-node
+  configPath: testing/experimental/storage/pod-startup/config.yaml
+  overridePaths:
+    - testing/experimental/storage/pod-startup/volume-types/secret/override.yaml
+    - testing/experimental/storage/pod-startup/max_volumes_per_node/override.yaml
+    - testing/experimental/storage/pod-startup/empty_test_name/override.yaml


### PR DESCRIPTION
This adds a test suite for running storage tests. In the next commit (to
test-infra), a prow job that runs this suite will be defined in
sig-scalability-experimental-periodic-jobs.

The goal of running a suite instead of duplicated jobs is to minimize
config duplication.

There is some redundancy in the suite definition. To be investigated if
it can be reduced using go templates. If it is feasible, it will be done
as a follow-up change once the suite job is working.

Tesing:
* ran clusterloader with
testsuite=testing/experimental/storage/pod-startup/suite.yaml and
verified that tests passed