### PR TITLE
Add support for displaying test suite results in perfdash

### DIFF
--- a/perfdash/config.go
+++ b/perfdash/config.go
@@ -282,24 +282,14 @@ var (
 		"APIServer": {
 			"Responsiveness": []TestDescription{
 				{
-					Name:             "pod-with-ephemeral-volume-startup-latency",
-					OutputFilePrefix: "APIResponsiveness",
-					Parser:           parsePerfData,
-				},
-				{
-					Name:             "storage-",
+					Name:             "storage",
 					OutputFilePrefix: "APIResponsiveness",
 					Parser:           parsePerfData,
 				},
 			},
 			"RequestCount": []TestDescription{
 				{
-					Name:             "pod-with-ephemeral-volume-startup-latency",
-					OutputFilePrefix: "APIResponsiveness",
-					Parser:           parseRequestCountData,
-				},
-				{
-					Name:             "storage-",
+					Name:             "storage",
 					OutputFilePrefix: "APIResponsiveness",
 					Parser:           parseRequestCountData,
 				},
@@ -308,12 +298,7 @@ var (
 		"E2E": {
 			"PodStartup": []TestDescription{
 				{
-					Name:             "pod-with-ephemeral-volume-startup-latency",
-					OutputFilePrefix: "PodStartupLatency_PodWithMultiVolumeStartupLatency",
-					Parser:           parsePerfData,
-				},
-				{
-					Name:             "storage-",
+					Name:             "storage",
 					OutputFilePrefix: "PodStartupLatency_PodWithVolumesStartupLatency",
 					Parser:           parsePerfData,
 				},

--- a/perfdash/google-gcs-downloader.go
+++ b/perfdash/google-gcs-downloader.go
@@ -22,6 +22,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
@@ -78,28 +79,22 @@ func (g *GoogleGCSDownloader) getData() (JobToCategoryData, error) {
 		if tests.Prefix == "" {
 			return nil, fmt.Errorf("Invalid empty Prefix for job %s", job)
 		}
-		for categoryLabel, categoryMap := range tests.Descriptions {
-			for testLabel := range categoryMap {
-				resultLock.Lock()
-				if _, found := result[tests.Prefix]; !found {
-					result[tests.Prefix] = make(CategoryToMetricData)
-				}
-				if _, found := result[tests.Prefix][categoryLabel]; !found {
-					result[tests.Prefix][categoryLabel] = make(MetricToBuildData)
-				}
-				if _, found := result[tests.Prefix][categoryLabel][testLabel]; found {
-					return result, fmt.Errorf("Duplicate name %s for %s", testLabel, tests.Prefix)
-				}
-				result[tests.Prefix][categoryLabel][testLabel] = &BuildData{Job: job, Version: "", Builds: map[string][]perftype.DataItem{}}
-				resultLock.Unlock()
-			}
-		}
 		go g.getJobData(&wg, result, &resultLock, job, tests)
 	}
 	wg.Wait()
 	return result, nil
 }
 
+/*
+getJobData fetches build numbers, reads metrics data from GCS and
+updates result with parsed metrics for a given prow job. Assumptions:
+- metric files are in /artifacts directory
+- metric file names have following prefix: {{OutputFilePrefix}}_{{Name}},
+  where OutputFilePrefix and Name are parts of test description (specified in prefdash config)
+- if there are multiple files with a given prefix, then expected format is
+  {{OutputFilePrefix}}_{{Name}}_{{SuiteId}}. SuiteId is appended to the category label,
+  which allows comparing metrics across several runs in a given suite
+*/
 func (g *GoogleGCSDownloader) getJobData(wg *sync.WaitGroup, result JobToCategoryData, resultLock *sync.Mutex, job string, tests Tests) {
 	defer wg.Done()
 	buildNumbers, err := g.GoogleGCSBucketUtils.getBuildNumbersFromJenkinsGoogleBucket(job)
@@ -120,31 +115,55 @@ func (g *GoogleGCSDownloader) getJobData(wg *sync.WaitGroup, result JobToCategor
 		for categoryLabel, categoryMap := range tests.Descriptions {
 			for testLabel, testDescriptions := range categoryMap {
 				for _, testDescription := range testDescriptions {
-					fileStem := fmt.Sprintf("artifacts/%v_%v", testDescription.OutputFilePrefix, testDescription.Name)
-					artifacts, err := g.GoogleGCSBucketUtils.listFilesInBuild(job, buildNumber, fileStem)
+					filePrefix := fmt.Sprintf("%v_%v", testDescription.OutputFilePrefix, testDescription.Name)
+					searchPrefix := fmt.Sprintf("artifacts/%v", filePrefix)
+					artifacts, err := g.GoogleGCSBucketUtils.listFilesInBuild(job, buildNumber, searchPrefix)
 					if err != nil || len(artifacts) == 0 {
-						fmt.Printf("Error while looking for %s* in %s build %v: %v\n", fileStem, job, buildNumber, err)
+						fmt.Printf("Error while looking for %s* in %s build %v: %v\n", searchPrefix, job, buildNumber, err)
 						continue
 					}
-					metricsFilename := artifacts[0][strings.LastIndex(artifacts[0], "/")+1:]
-					if len(artifacts) > 1 {
-						fmt.Printf("WARNING: found multiple %s files with data, reading only one: %s\n", fileStem, metricsFilename)
+					for _, artifact := range artifacts {
+						metricsFileName := filepath.Base(artifact)
+						resultCategory := getResultCategory(metricsFileName, filePrefix, categoryLabel, artifacts)
+						testDataResponse, err := g.GoogleGCSBucketUtils.getFileFromJenkinsGoogleBucket(job, buildNumber,
+							fmt.Sprintf("artifacts/%v", metricsFileName))
+						if err != nil {
+							fmt.Fprintf(os.Stderr, "Error when reading response Body: %v\n", err)
+							continue
+						}
+						buildData := getBuildData(result, tests.Prefix, resultCategory, testLabel, job, resultLock)
+						testDescription.Parser(testDataResponse, buildNumber, buildData)
 					}
-
-					testDataResponse, err := g.GoogleGCSBucketUtils.getFileFromJenkinsGoogleBucket(job, buildNumber, fmt.Sprintf("artifacts/%v", metricsFilename))
-					if err != nil {
-						fmt.Fprintf(os.Stderr, "Error when reading response Body: %v\n", err)
-						continue
-					}
-					resultLock.Lock()
-					buildData := result[tests.Prefix][categoryLabel][testLabel]
-					resultLock.Unlock()
-					testDescription.Parser(testDataResponse, buildNumber, buildData)
 					break
 				}
 			}
 		}
 	}
+}
+
+func getResultCategory(metricsFileName string, filePrefix string, category string, artifacts []string) string {
+	if len(artifacts) <= 1 {
+		return category
+	}
+	// If there are more artifacts, assume that this is a test suite run.
+	trimmed := strings.TrimPrefix(metricsFileName, filePrefix+"_")
+	suiteId := strings.Split(trimmed, "_")[0]
+	return fmt.Sprintf("%v_%v", category, suiteId)
+}
+
+func getBuildData(result JobToCategoryData, prefix string, category string, label string, job string, resultLock *sync.Mutex) *BuildData {
+	resultLock.Lock()
+	defer resultLock.Unlock()
+	if _, found := result[prefix]; !found {
+		result[prefix] = make(CategoryToMetricData)
+	}
+	if _, found := result[prefix][category]; !found {
+		result[prefix][category] = make(MetricToBuildData)
+	}
+	if _, found := result[prefix][category][label]; !found {
+		result[prefix][category][label] = &BuildData{Job: job, Version: "", Builds: map[string][]perftype.DataItem{}}
+	}
+	return result[prefix][category][label]
 }
 
 type bucketUtil struct {

--- a/perfdash/www/index.html
+++ b/perfdash/www/index.html
@@ -21,7 +21,7 @@
             </md-select>
           </md-input-container>
         </div>
-        <div style="width: 200px; display: inline-block;">
+        <div style="width: 300px; display: inline-block;">
           <md-input-container>
             <md-select placeholder="MetricCategoryName" ng-model="controller.metricCategoryName"  ng-change="controller.metricCategoryNameChanged()">
               <md-option ng-value="metricCategoryName" ng-repeat="metricCategoryName in controller.metricCategoryNames">


### PR DESCRIPTION
This commit enables perfdash to view metrics recorded by clusterloader
test suite runs.

Before this change, it was not possible to do so, because test suite run
puts measurement results in separate files, for example:
-  APIResponsiveness_storage_configmap-vol-per-node_2019-10-01T06:08:05Z.json
-  APIResponsiveness_storage_downwardapi-vol-per-node_2019-10-01T06:10:00Z.json
In such case, perfdash read metrics data from the first file that
matched the prefix APIResponsiveness_storage (prefix is specified in
config.go file), meaning that other results were ignored.

To solve this issue, support for handling multiple files that match
given prefix is added. For each of the matched files, perfdash extracts
the "suiteId" from the file name and appends it to the result category.
This means that results from different test cases in a given suite will
land in different categories in the web UI, for example:
- APIServer_configmap-vol-per-node
- APIServer_downwardapi-vol-per-node

Alternatively, same effect could be achieved by generating separate test
descriptions in the perfdash config. It was not chosen, because it would
mean that perfdash config needs to be changed every time some test case
is added or removed.

This commit also includes other minor, but related changes like:
- increasing with of category field in the web UI
- removing 'pod-with-ephemeral-volume' configs

Testing:
- run perfdash locally, verify that data for both storage-suite and
separate storage jobs is displayed as expected