### PR TITLE
ClusterLoader - Latency pod memory update - 100 nodes

### DIFF
--- a/clusterloader2/testing/density/config.yaml
+++ b/clusterloader2/testing/density/config.yaml
@@ -13,7 +13,7 @@
 # decreases the value of priority function in scheduler by one point.
 # This results in decreased probability of choosing the same node again.
 {{$LATENCY_POD_CPU := DefaultParam .LATENCY_POD_CPU 100}}
-{{$LATENCY_POD_MEMORY := DefaultParam .LATENCY_POD_MEMORY 400}}
+{{$LATENCY_POD_MEMORY := DefaultParam .LATENCY_POD_MEMORY 350}}
 {{$MIN_LATENCY_PODS := 500}}
 {{$MIN_SATURATION_PODS_TIMEOUT := 180}}
 {{$ENABLE_CHAOSMONKEY := DefaultParam .ENABLE_CHAOSMONKEY false}}


### PR DESCRIPTION
Using better memory estimation for latency pods in gce 100 test. This will save ~200MB for potential probe pods.

Scheduler uses allocatable memory to evaluate node score. Nodes have < 3500MB memory available. Therefore 350MB should be a good choice.
