### PR TITLE
Extended Load: NetworkPolicies

### DIFF
--- a/clusterloader2/testing/load/config.yaml
+++ b/clusterloader2/testing/load/config.yaml
@@ -23,6 +23,7 @@
 {{$ENABLE_PVS := DefaultParam .ENABLE_PVS false}}
 {{$ENABLE_SECRETS := DefaultParam .ENABLE_SECRETS false}}
 {{$ENABLE_STATEFULSETS := DefaultParam .ENABLE_STATEFULSETS false}}
+{{$ENABLE_NETWORKPOLICIES := DefaultParam .ENABLE_NETWORKPOLICIES false}}
 {{$USE_SIMPLE_LATENCY_QUERY := DefaultParam .USE_SIMPLE_LATENCY_QUERY false}}
 #Variables
 {{$namespaces := DivideInt .Nodes $NODES_PER_NAMESPACE}}
@@ -212,6 +213,10 @@ steps:
     - basename: big-deployment
       objectTemplatePath: secret.yaml
     {{end}}
+    {{if $ENABLE_NETWORKPOLICIES}}
+    - basename: big-deployment
+      objectTemplatePath: networkpolicy.yaml
+    {{end}}
     - basename: big-deployment
       objectTemplatePath: deployment.yaml
       templateFillMap:
@@ -232,6 +237,10 @@ steps:
     - basename: medium-deployment
       objectTemplatePath: secret.yaml
     {{end}}
+    {{if $ENABLE_NETWORKPOLICIES}}
+    - basename: medium-deployment
+      objectTemplatePath: networkpolicy.yaml
+    {{end}}
     - basename: medium-deployment
       objectTemplatePath: deployment.yaml
       templateFillMap:
@@ -251,6 +260,10 @@ steps:
     {{if $ENABLE_SECRETS}}
     - basename: small-deployment
       objectTemplatePath: secret.yaml
+    {{end}}
+    {{if $ENABLE_NETWORKPOLICIES}}
+    - basename: small-deployment
+      objectTemplatePath: networkpolicy.yaml
     {{end}}
     - basename: small-deployment
       objectTemplatePath: deployment.yaml
@@ -500,6 +513,10 @@ steps:
     - basename: big-deployment
       objectTemplatePath: secret.yaml
     {{end}}
+    {{if $ENABLE_NETWORKPOLICIES}}
+    - basename: big-deployment
+      objectTemplatePath: networkpolicy.yaml
+    {{end}}
   - namespaceRange:
       min: 1
       max: {{$namespaces}}
@@ -516,6 +533,10 @@ steps:
     - basename: medium-deployment
       objectTemplatePath: secret.yaml
     {{end}}
+    {{if $ENABLE_NETWORKPOLICIES}}
+    - basename: medium-deployment
+      objectTemplatePath: networkpolicy.yaml
+    {{end}}
   - namespaceRange:
       min: 1
       max: {{$namespaces}}
@@ -531,6 +552,10 @@ steps:
     {{if $ENABLE_SECRETS}}
     - basename: small-deployment
       objectTemplatePath: secret.yaml
+    {{end}}
+    {{if $ENABLE_NETWORKPOLICIES}}
+    - basename: small-deployment
+      objectTemplatePath: networkpolicy.yaml
     {{end}}
   {{if $ENABLE_STATEFULSETS}}
   - namespaceRange:

--- a/clusterloader2/testing/load/networkpolicy.yaml
+++ b/clusterloader2/testing/load/networkpolicy.yaml
@@ -1,0 +1,19 @@
+{{if eq (Mod .Index 10) 0}} # Create for only 10% of deployments
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{.Name}}
+spec:
+  podSelector:
+    matchLabels:
+      name: {{.BaseName}}-{{.Index}}
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - ipBlock:
+            cidr: 10.0.0.0/24
+      ports:
+        - protocol: TCP
+          port: 8080
+{{end}}


### PR DESCRIPTION
Copy of: https://github.com/kubernetes/perf-tests/pull/719 with fixed paths

This is most likely no-op until we turn on some Network Policy Provider that will start enfocring these network policies.

It should be pretty straightforward to turn on Calico both in GKE and in GCE.
This should be done separately to isolate any potential performance
impact of tuning it just on.

Ref. https://github.com/kubernetes/perf-tests/issues/704

/cc oxddr
/cc mm4tt