### PR TITLE
Add a measurement for DNS programming latency

### DIFF
--- a/clusterloader2/pkg/measurement/common/slos/dns_programming.go
+++ b/clusterloader2/pkg/measurement/common/slos/dns_programming.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package slos
+
+import (
+	"fmt"
+	"time"
+
+	"k8s.io/klog"
+	"k8s.io/perf-tests/clusterloader2/pkg/measurement"
+	measurementutil "k8s.io/perf-tests/clusterloader2/pkg/measurement/util"
+)
+
+const (
+	dnsProgLat = "DNSProgrammingLatency"
+
+	dnsProgQuery = "quantile_over_time(0.99, dns:coredns_programming_duration:histogram_quantile{}[%v])"
+)
+
+func init() {
+	create := func() measurement.Measurement { return createPrometheusMeasurement(&dnsProgGatherer{}) }
+	if err := measurement.Register(dnsProgLat, create); err != nil {
+		klog.Fatalf("Cannot register %s: %v", dnsProgLat, err)
+	}
+}
+
+type dnsProgGatherer struct{}
+
+func (d *dnsProgGatherer) IsEnabled(config *measurement.MeasurementConfig) bool {
+	return true
+}
+
+func (d *dnsProgGatherer) String() string {
+	return dnsProgLat
+}
+
+func (d *dnsProgGatherer) Gather(executor QueryExecutor, startTime time.Time, config *measurement.MeasurementConfig) (measurement.Summary, error) {
+	latency, err := d.query(executor, startTime)
+	if err != nil {
+		return nil, err
+	}
+
+	klog.Infof("%s: got %v", dnsProgLat, latency)
+	return createLatencySummary(latency, dnsProgLat)
+}
+
+func (d *dnsProgGatherer) query(executor QueryExecutor, startTime time.Time) (*measurementutil.LatencyMetric, error) {
+	end := time.Now()
+	duration := end.Sub(startTime)
+
+	boundedQuery := fmt.Sprintf(dnsProgQuery, measurementutil.ToPrometheusTime(duration))
+
+	samples, err := executor.Query(boundedQuery, end)
+	if err != nil {
+		return nil, err
+	}
+	if len(samples) != 3 {
+		return nil, fmt.Errorf("got unexpected number of samples: %d", len(samples))
+	}
+	return measurementutil.NewLatencyMetricPrometheus(samples)
+}

--- a/clusterloader2/pkg/measurement/common/slos/network_programming.go
+++ b/clusterloader2/pkg/measurement/common/slos/network_programming.go
@@ -23,7 +23,6 @@ import (
 	"k8s.io/klog"
 	"k8s.io/perf-tests/clusterloader2/pkg/measurement"
 	measurementutil "k8s.io/perf-tests/clusterloader2/pkg/measurement/util"
-	"k8s.io/perf-tests/clusterloader2/pkg/util"
 )
 
 const (
@@ -58,7 +57,7 @@ func (n *netProgGatherer) Gather(executor QueryExecutor, startTime time.Time, co
 	}
 
 	klog.Infof("%s: got %v", netProg, latency)
-	return n.createSummary(latency)
+	return createLatencySummary(latency, netProg)
 }
 
 func (n *netProgGatherer) String() string {
@@ -79,15 +78,4 @@ func (n *netProgGatherer) query(executor QueryExecutor, startTime time.Time) (*m
 		return nil, fmt.Errorf("got unexpected number of samples: %d", len(samples))
 	}
 	return measurementutil.NewLatencyMetricPrometheus(samples)
-}
-
-func (n *netProgGatherer) createSummary(latency *measurementutil.LatencyMetric) (measurement.Summary, error) {
-	content, err := util.PrettyPrintJSON(&measurementutil.PerfData{
-		Version:   metricVersion,
-		DataItems: []measurementutil.DataItem{latency.ToPerfData(netProg)},
-	})
-	if err != nil {
-		return nil, err
-	}
-	return measurement.CreateSummary(netProg, "json", content), nil
 }

--- a/clusterloader2/pkg/measurement/common/slos/prometheus_measurement.go
+++ b/clusterloader2/pkg/measurement/common/slos/prometheus_measurement.go
@@ -34,6 +34,17 @@ func createPrometheusMeasurement(gatherer Gatherer) measurement.Measurement {
 	}
 }
 
+func createLatencySummary(latency *measurementutil.LatencyMetric, metricName string) (measurement.Summary, error) {
+	content, err := util.PrettyPrintJSON(&measurementutil.PerfData{
+		Version:   metricVersion,
+		DataItems: []measurementutil.DataItem{latency.ToPerfData(metricName)},
+	})
+	if err != nil {
+		return nil, err
+	}
+	return measurement.CreateSummary(metricName, "json", content), nil
+}
+
 // QueryExecutor is an interface for queryning Prometheus server.
 type QueryExecutor interface {
 	Query(query string, queryTime time.Time) ([]*model.Sample, error)


### PR DESCRIPTION
This needs to be tested, once coredns version including https://github.com/coredns/coredns/pull/3171 is released. 

/hold
/ref https://github.com/kubernetes/perf-tests/issues/617