### PR TITLE
Switch Prometheus API responsiveness to use 1m windows.

### DIFF
--- a/clusterloader2/pkg/measurement/common/slos/api_responsiveness_prometheus.go
+++ b/clusterloader2/pkg/measurement/common/slos/api_responsiveness_prometheus.go
@@ -45,7 +45,7 @@ const (
 	// latencyQuery matches description of the API call latency SLI and measure 99th percentaile over 5m windows
 	//
 	// latencyQuery: %v should be replaced with (1) filters and (2) query window size..
-	latencyQuery = "quantile_over_time(0.99, apiserver:apiserver_request_latency:histogram_quantile{ %v}[%v])"
+	latencyQuery = "quantile_over_time(0.99, apiserver:apiserver_request_latency_1m:histogram_quantile{%v}[%v])"
 
 	// simpleLatencyQuery measures 99th percentile of API call latency  over given period of time
 	// it doesn't match SLI, but is useful in shorter tests, where we don't have enough number of windows to use latencyQuery meaningfully.

--- a/clusterloader2/pkg/prometheus/manifests/prometheus-rules.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/prometheus-rules.yaml
@@ -74,23 +74,6 @@ spec:
       record: kubeproxy:kubeproxy_network_programming_duration:histogram_quantile
       labels:
         quantile: "0.50"
-  - name: apiserver.30s.rules
-    rules:
-    - expr: |
-        histogram_quantile(0.99, sum(rate(apiserver_request_duration_seconds_bucket[30s])) by (resource,  subresource, verb, scope, le))
-      record: apiserver:apiserver_request_latency_30s:histogram_quantile
-      labels:
-        quantile: "0.99"
-    - expr: |
-        histogram_quantile(0.9, sum(rate(apiserver_request_duration_seconds_bucket[30s])) by (resource,  subresource, verb, scope, le))
-      record: apiserver:apiserver_request_latency_30s:histogram_quantile
-      labels:
-        quantile: "0.90"
-    - expr: |
-        histogram_quantile(0.5, sum(rate(apiserver_request_duration_seconds_bucket[30s])) by (resource,  subresource, verb, scope, le))
-      record: apiserver:apiserver_request_latency_30s:histogram_quantile
-      labels:
-        quantile: "0.50"
   - name: apiserver.1m.rules
     rules:
     - expr: |


### PR DESCRIPTION
Default so far was 5m as in SLI definition. We're changing this to 1m, so we
have we calculate the the SLI over more data points. In the past, we were
suffering from having not enough of them, which was causing 99th percentaile to
be actually max over the series.

Minor: remove recording rules with 30s window.

/ref https://github.com/kubernetes/perf-tests/issues/498
/assign @mm4tt 