### PR TITLE
Enable simple Promethues API responsiveness measurement.

### DIFF
--- a/clusterloader2/pkg/measurement/common/slos/api_responsiveness_prometheus.go
+++ b/clusterloader2/pkg/measurement/common/slos/api_responsiveness_prometheus.go
@@ -103,7 +103,13 @@ func (a *apiResponsivenessGatherer) Gather(executor QueryExecutor, startTime tim
 	if err != nil {
 		return nil, err
 	}
-	summary := measurement.CreateSummary(apiResponsivenessPrometheusMeasurementName, "json", content)
+
+	summaryName, err := util.GetStringOrDefault(config.Params, "summaryName", apiResponsivenessPrometheusMeasurementName)
+	if err != nil {
+		return nil, err
+	}
+
+	summary := measurement.CreateSummary(summaryName, "json", content)
 	if len(badMetrics) > 0 {
 		return summary, errors.NewMetricViolationError("top latency metric", fmt.Sprintf("there should be no high-latency requests, but: %v", badMetrics))
 	}

--- a/clusterloader2/testing/density/config.yaml
+++ b/clusterloader2/testing/density/config.yaml
@@ -216,16 +216,21 @@ steps:
     Method: APIResponsiveness
     Params:
       action: gather
-  - Identifier: APIResponsivenessPrometheus
+  - Identifier: APIResponsivenessPrometheusSimple
     Method: APIResponsivenessPrometheus
     Params:
       action: gather
       {{if $ENABLE_PROMETHEUS_API_RESPONSIVENESS}}
       enableViolations: true
       {{end}}
-      {{if $USE_SIMPLE_LATENCY_QUERY}}
       useSimpleLatencyQuery: true
-      {{end}}
+      summaryName: APIResponsivenessPrometheus_simple
+  {{if not $USE_SIMPLE_LATENCY_QUERY}}
+  - Identifier: APIResponsivenessPrometheus
+    Method: APIResponsivenessPrometheus
+    Params:
+      action: gather
+  {{end}}
   - Identifier: InClusterNetworkLatency
     Method: InClusterNetworkLatency
     Params:

--- a/clusterloader2/testing/load/config.yaml
+++ b/clusterloader2/testing/load/config.yaml
@@ -723,16 +723,21 @@ steps:
     Method: APIResponsiveness
     Params:
       action: gather
-  - Identifier: APIResponsivenessPrometheus
+  - Identifier: APIResponsivenessPrometheusSimple
     Method: APIResponsivenessPrometheus
     Params:
       action: gather
       {{if $ENABLE_PROMETHEUS_API_RESPONSIVENESS}}
       enableViolations: true
       {{end}}
-      {{if $USE_SIMPLE_LATENCY_QUERY}}
       useSimpleLatencyQuery: true
-      {{end}}
+      summaryName: APIResponsivenessPrometheus_simple
+  {{if not $USE_SIMPLE_LATENCY_QUERY}}
+  - Identifier: APIResponsivenessPrometheus
+    Method: APIResponsivenessPrometheus
+    Params:
+      action: gather
+  {{end}}
   - Identifier: PodStartupLatency
     Method: PodStartupLatency
     Params:


### PR DESCRIPTION
Measure APIResponsivenessPrometheus twice (gather action):

1. First call mimics old APIResponsiveness, but uses new metric instead of the old summary. 
2. Second call uses the new two-level query. 

/ref https://github.com/kubernetes/perf-tests/issues/498