### PR TITLE
Add node-local-dns flag in e2e script.

### DIFF
--- a/run-e2e.sh
+++ b/run-e2e.sh
@@ -34,7 +34,7 @@ case "$1" in
     cd ${PERFTEST_ROOT}/network/benchmarks/netperf/ && go run ./launch.go  --kubeConfig="${HOME}/.kube/config" --hostnetworking --iterations 1
     exit
     ;;
-  kube-dns|core-dns )
+  kube-dns|core-dns|node-local-dns )
     cd ${PERFTEST_ROOT}/dns
     ./run $@
     exit
@@ -44,6 +44,7 @@ case "$1" in
     echo  " network-performance           Run Network Performance Test"
     echo  " kube-dns                      Run Kube-DNS test"
     echo  " core-dns                      Run Core-DNS test"
+    echo  " node-local-dns                Run NodeLocalDNS test"
     exit
     ;;
 esac


### PR DESCRIPTION
The previous PR https://github.com/kubernetes/perf-tests/pull/824 added support in run command, but not in e2e script.

/assign @krzysied @wojtek-t 