### PR TITLE
Subtract initial restart counts when calculating system pod metrics

### DIFF
--- a/clusterloader2/pkg/measurement/common/bundle/test_metrics.go
+++ b/clusterloader2/pkg/measurement/common/bundle/test_metrics.go
@@ -178,6 +178,8 @@ func (t *testMetrics) Execute(config *measurement.MeasurementConfig) ([]measurem
 		appendResults(&summaries, errList, summary, err)
 		summary, err = execute(t.controllerManagerMemoryProfile, kubeControllerManagerStartConfig)
 		appendResults(&summaries, errList, summary, err)
+		summary, err = execute(t.systemPodMetrics, config)
+		appendResults(&summaries, errList, summary, err)
 	case "gather":
 		summary, err := execute(t.etcdMetrics, actionGatherConfig)
 		appendResults(&summaries, errList, summary, err)

--- a/clusterloader2/pkg/measurement/common/system_pod_metrics_test.go
+++ b/clusterloader2/pkg/measurement/common/system_pod_metrics_test.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"reflect"
+	"testing"
+)
+
+func Test_subtractInitialRestartCounts(t *testing.T) {
+	tests := []struct {
+		name        string
+		metrics     *systemPodsMetrics
+		initMetrics *systemPodsMetrics
+		want        *systemPodsMetrics
+	}{
+		{
+			name:        "same-pods-and-containers",
+			metrics:     generatePodMetrics("p1", "c1", 5),
+			initMetrics: generatePodMetrics("p1", "c1", 4),
+			want:        generatePodMetrics("p1", "c1", 1),
+		},
+		{
+			name:        "different-container-names",
+			metrics:     generatePodMetrics("p1", "c1", 5),
+			initMetrics: generatePodMetrics("p1", "c2", 4),
+			want:        generatePodMetrics("p1", "c1", 5),
+		},
+		{
+			name:        "different-pod-names",
+			metrics:     generatePodMetrics("p1", "c1", 5),
+			initMetrics: generatePodMetrics("p2", "c1", 4),
+			want:        generatePodMetrics("p1", "c1", 5),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			subtractInitialRestartCounts(tt.metrics, tt.initMetrics)
+			if !reflect.DeepEqual(*tt.metrics, *tt.want) {
+				t.Errorf("want %v, got %v", *tt.want, *tt.metrics)
+			}
+		})
+	}
+}
+
+func generatePodMetrics(podName string, contName string, restartCount int32) *systemPodsMetrics {
+	return &systemPodsMetrics{
+		Pods: []podMetrics{
+			{
+				Name: podName,
+				Containers: []containerMetrics{
+					{
+						Name:         contName,
+						RestartCount: restartCount,
+					},
+				}},
+		},
+	}
+}


### PR DESCRIPTION
Before this change, system pod measurement gathered metrics only at the
end of each test. This means that the restart count in the present in
the summary was equal to the restart count since each given container
was created (this is usually during cluster creation). This means that
we could have high restart count metric for some test even though no
restart happened during that test, which could be misleading.

To fix this, in this commit we add listing system pods before the test
(in measurement "start" action). Then in "gather" action, initial
restart counts are subtracted from the actual restart counts. In effect,
restart count present in the summary is the number of restarts that
occured during execution of this test.

Testing:
* ran storage suite locally
* verified SystemPodMetrics summary is being created
* verified that test fails if we execute gather without executing start
action first
* unit tests for the restart count subtraction logic