### PR TITLE
Add support for viewing system pod metrics in perfdash

### DIFF
--- a/perfdash/Makefile
+++ b/perfdash/Makefile
@@ -1,12 +1,16 @@
 all: push
 
 # See pod.yaml for the version currently running-- bump this ahead before rebuilding!
-TAG = 2.13
+TAG = 2.14
 
 REPO = gcr.io/k8s-testimages
+GODEP = CGO_ENABLED=0 GOOS=linux godep
 
-perfdash: perfdash.go parser.go config.go downloader.go google-gcs-downloader.go
-	CGO_ENABLED=0 GOOS=linux godep go build -a -installsuffix cgo -ldflags '-w' -o perfdash
+test: perfdash.go parser.go config.go downloader.go google-gcs-downloader.go
+	${GODEP} go test
+
+perfdash: test
+	${GODEP} go build -a -installsuffix cgo -ldflags '-w' -o perfdash
 
 run: perfdash
 	./perfdash \
@@ -17,7 +21,6 @@ run: perfdash
 		--configPath=https://raw.githubusercontent.com/kubernetes/test-infra/master/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml \
 		--configPath=https://raw.githubusercontent.com/kubernetes/test-infra/master/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml \
 		--configPath=https://raw.githubusercontent.com/kubernetes/test-infra/master/config/jobs/kubernetes/sig-scalability/sig-scalability-experimental-periodic-jobs.yaml
-
 
 container: perfdash
 	docker build --pull -t $(REPO)/perfdash:$(TAG) .

--- a/perfdash/config.go
+++ b/perfdash/config.go
@@ -240,6 +240,18 @@ var (
 				Parser:           parsePerfData,
 			}},
 		},
+		"SystemPodMetrics": {
+			"Load_SystemPodMetrics": []TestDescription{{
+				Name:             "load",
+				OutputFilePrefix: "SystemPodMetrics",
+				Parser:           parseSystemPodMetrics,
+			}},
+			"Density_SystemPodMetrics": []TestDescription{{
+				Name:             "density",
+				OutputFilePrefix: "SystemPodMetrics",
+				Parser:           parseSystemPodMetrics,
+			}},
+		},
 	}
 
 	// benchmarkDescriptions contains metrics exported by test/integration/scheduler_perf

--- a/perfdash/deployment.yaml
+++ b/perfdash/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: perfdash
-        image: gcr.io/k8s-testimages/perfdash:2.13
+        image: gcr.io/k8s-testimages/perfdash:2.14
         command:
           - /perfdash
           -   --www=true

--- a/perfdash/parser_test.go
+++ b/perfdash/parser_test.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"reflect"
+	"testing"
+
+	"k8s.io/kubernetes/test/e2e/perftype"
+)
+
+func Test_parseSystemPodMetrics(t *testing.T) {
+	tests := []struct {
+		name        string
+		data        []byte
+		buildNumber int
+		testResult  *BuildData
+		want        *BuildData
+	}{
+		{
+			name:        "same-container-in-two-pods",
+			buildNumber: 123,
+			data:        sameContainerInTwoPodsSummary(),
+			testResult:  &BuildData{Job: "", Version: "", Builds: map[string][]perftype.DataItem{}},
+			want: &BuildData{Job: "", Version: "", Builds: map[string][]perftype.DataItem{
+				"123": {
+					perftype.DataItem{
+						Data: map[string]float64{
+							"c1": 2,
+							"c2": 1,
+						},
+						Labels: map[string]string{
+							"RestartCount": "RestartCount",
+						},
+						Unit: "",
+					},
+				},
+			}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parseSystemPodMetrics(tt.data, tt.buildNumber, tt.testResult)
+			if !reflect.DeepEqual(*tt.testResult, *tt.want) {
+				t.Errorf("want %v, got %v", *tt.want, *tt.testResult)
+			}
+		})
+	}
+}
+
+func sameContainerInTwoPodsSummary() []byte {
+	json := `{
+		"pods": [
+			{
+				"name": "p1",
+				"containers": [
+					{
+						"name": "c1",
+						"restartCount": 2
+					},
+					{
+						"name": "c2",
+						"restartCount": 1
+					}
+				]
+			},
+			{
+				"name": "p2",
+				"containers": [
+					{
+						"name": "c1",
+						"restartCount": 0
+					}
+				]
+			}
+		]
+	}`
+	return []byte(json)
+}


### PR DESCRIPTION
For each build, perfdash will display maximum restart count per each
container name (for example metadata-proxy, kube-apiserver,
etcd-container etc).

In addition a test was added and makefile was changed to run tests
before run.

Testing:
- started perfdash locally