### PR TITLE
Add parsing for Prometheus_simple summaries

### DIFF
--- a/perfdash/Makefile
+++ b/perfdash/Makefile
@@ -1,7 +1,7 @@
 all: push
 
 # See pod.yaml for the version currently running-- bump this ahead before rebuilding!
-TAG = 2.14
+TAG = 2.15
 
 REPO = gcr.io/k8s-testimages
 GODEP = CGO_ENABLED=0 GOOS=linux godep

--- a/perfdash/config.go
+++ b/perfdash/config.go
@@ -102,6 +102,16 @@ var (
 				OutputFilePrefix: "APIResponsivenessPrometheus",
 				Parser:           parseRequestCountData,
 			}},
+			"DensityResponsiveness_PrometheusSimple": []TestDescription{{
+				Name:             "density",
+				OutputFilePrefix: "APIResponsivenessPrometheus_simple",
+				Parser:           parsePerfData,
+			}},
+			"DensityRequestCount_PrometheusSimple": []TestDescription{{
+				Name:             "density",
+				OutputFilePrefix: "APIResponsivenessPrometheus_simple",
+				Parser:           parseRequestCountData,
+			}},
 			"DensityRequestCountByClient": []TestDescription{{
 				Name:             "density",
 				OutputFilePrefix: "MetricsForE2E",
@@ -130,6 +140,16 @@ var (
 			"LoadRequestCount_Prometheus": []TestDescription{{
 				Name:             "load",
 				OutputFilePrefix: "APIResponsivenessPrometheus",
+				Parser:           parseRequestCountData,
+			}},
+			"LoadResponsiveness_PrometheusSimple": []TestDescription{{
+				Name:             "load",
+				OutputFilePrefix: "APIResponsivenessPrometheus_simple",
+				Parser:           parsePerfData,
+			}},
+			"LoadRequestCount_PrometheusSimple": []TestDescription{{
+				Name:             "load",
+				OutputFilePrefix: "APIResponsivenessPrometheus_simple",
 				Parser:           parseRequestCountData,
 			}},
 			"LoadRequestCountByClient": []TestDescription{{

--- a/perfdash/deployment.yaml
+++ b/perfdash/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: perfdash
-        image: gcr.io/k8s-testimages/perfdash:2.14
+        image: gcr.io/k8s-testimages/perfdash:2.15
         command:
           - /perfdash
           -   --www=true


### PR DESCRIPTION
New prometheus summary naming was introduces in pull #837. It resulted
in metrics not being visible for new runs in perfdash. This commit adds
handling of these summaries.

Testing:
- ran perfdash locally