### PR TITLE
Enable restart count validation in clusterloader

### DIFF
--- a/clusterloader2/pkg/measurement/common/system_pod_metrics_test.go
+++ b/clusterloader2/pkg/measurement/common/system_pod_metrics_test.go
@@ -19,6 +19,9 @@ package common
 import (
 	"reflect"
 	"testing"
+
+	"gopkg.in/yaml.v2"
+	"k8s.io/perf-tests/clusterloader2/pkg/measurement"
 )
 
 func Test_subtractInitialRestartCounts(t *testing.T) {
@@ -57,6 +60,63 @@ func Test_subtractInitialRestartCounts(t *testing.T) {
 	}
 }
 
+func Test_validateRestartCounts(t *testing.T) {
+	tests := []struct {
+		name    string
+		metrics *systemPodsMetrics
+		config  *measurement.MeasurementConfig
+		wantErr bool
+	}{
+		{
+			name:    "check-disabled",
+			metrics: generatePodMetrics("p", "c", 1),
+			config:  buildConfig(t, false, nil),
+			wantErr: false,
+		},
+		{
+			name:    "check-enabled-violation",
+			metrics: generatePodMetrics("p", "c", 1),
+			config:  buildConfig(t, true, nil),
+			wantErr: true,
+		},
+		{
+			name:    "check-enabled-ok",
+			metrics: generatePodMetrics("p", "c", 0),
+			config:  buildConfig(t, true, nil),
+			wantErr: false,
+		},
+		{
+			name:    "override-equal-to-actual-count",
+			metrics: generatePodMetrics("p", "c", 3),
+			config:  buildConfig(t, true, map[string]int{"c": 3}),
+			wantErr: false,
+		},
+		{
+			name:    "override-below-actual-count",
+			metrics: generatePodMetrics("p", "c", 3),
+			config:  buildConfig(t, true, map[string]int{"c": 2}),
+			wantErr: true,
+		},
+		{
+			name:    "override-for-different-container",
+			metrics: generatePodMetrics("p", "c1", 3),
+			config:  buildConfig(t, true, map[string]int{"c2": 4}),
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			overrides, err := getThresholdOverrides(tt.config)
+			if err != nil {
+				t.Fatalf("getThresholdOverrides() error = %v", err)
+			}
+			if err := validateRestartCounts(tt.metrics, tt.config, overrides); (err != nil) != tt.wantErr {
+				t.Errorf("verifyViolations() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
 func generatePodMetrics(podName string, contName string, restartCount int32) *systemPodsMetrics {
 	return &systemPodsMetrics{
 		Pods: []podMetrics{
@@ -68,6 +128,19 @@ func generatePodMetrics(podName string, contName string, restartCount int32) *sy
 						RestartCount: restartCount,
 					},
 				}},
+		},
+	}
+}
+
+func buildConfig(t *testing.T, checkEnabled bool, thresholdOverrides map[string]int) *measurement.MeasurementConfig {
+	serializedOverrides, err := yaml.Marshal(thresholdOverrides)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &measurement.MeasurementConfig{
+		Params: map[string]interface{}{
+			"enableRestartCountCheck":        checkEnabled,
+			"restartCountThresholdOverrides": string(serializedOverrides),
 		},
 	}
 }

--- a/clusterloader2/testing/density/config.yaml
+++ b/clusterloader2/testing/density/config.yaml
@@ -21,6 +21,7 @@
 {{$ENABLE_SYSTEM_POD_METRICS:= DefaultParam .ENABLE_SYSTEM_POD_METRICS true}}
 {{$USE_SIMPLE_LATENCY_QUERY := DefaultParam .USE_SIMPLE_LATENCY_QUERY false}}
 {{$ENABLE_RESTART_COUNT_CHECK := DefaultParam .ENABLE_RESTART_COUNT_CHECK false}}
+{{$RESTART_COUNT_THRESHOLD_OVERRIDES:= DefaultParam .RESTART_COUNT_THRESHOLD_OVERRIDES ""}}
 #Variables
 {{$namespaces := DivideInt .Nodes $NODES_PER_NAMESPACE}}
 {{$podsPerNamespace := MultiplyInt $PODS_PER_NODE $NODES_PER_NAMESPACE}}
@@ -75,6 +76,8 @@ steps:
       nodeMode: {{$NODE_MODE}}
       resourceConstraints: {{$DENSITY_RESOURCE_CONSTRAINTS_FILE}}
       systemPodMetricsEnabled: {{$ENABLE_SYSTEM_POD_METRICS}}
+      restartCountThresholdOverrides: {{YamlQuote $RESTART_COUNT_THRESHOLD_OVERRIDES 4}}
+      enableRestartCountCheck: {{$ENABLE_RESTART_COUNT_CHECK}}
 
 - name: Starting saturation pod measurements
   measurements:
@@ -247,3 +250,5 @@ steps:
     Params:
       action: gather
       systemPodMetricsEnabled: {{$ENABLE_SYSTEM_POD_METRICS}}
+      restartCountThresholdOverrides: {{YamlQuote $RESTART_COUNT_THRESHOLD_OVERRIDES 4}}
+      enableRestartCountCheck: {{$ENABLE_RESTART_COUNT_CHECK}}

--- a/clusterloader2/testing/experiments/ignore_known_gce_container_restarts.yaml
+++ b/clusterloader2/testing/experiments/ignore_known_gce_container_restarts.yaml
@@ -1,4 +1,4 @@
-RESTART_COUNT_THRESHOLD_OVERRIDES:
+RESTART_COUNT_THRESHOLD_OVERRIDES: |
   # To be investigated in https://github.com/kubernetes/perf-tests/issues/872.
   fluentd-gcp: 999
 

--- a/clusterloader2/testing/experiments/ignore_known_kubemark_container_restarts.yaml
+++ b/clusterloader2/testing/experiments/ignore_known_kubemark_container_restarts.yaml
@@ -1,4 +1,4 @@
-RESTART_COUNT_THRESHOLD_OVERRIDES:
+RESTART_COUNT_THRESHOLD_OVERRIDES: |
   # To be fixed by https://github.com/kubernetes/perf-tests/issues/871.
   kubernetes-dashboard: 999
 

--- a/clusterloader2/testing/load/config.yaml
+++ b/clusterloader2/testing/load/config.yaml
@@ -110,6 +110,8 @@ steps:
       action: start
       nodeMode: {{$NODE_MODE}}
       systemPodMetricsEnabled: {{$ENABLE_SYSTEM_POD_METRICS}}
+      restartCountThresholdOverrides: {{YamlQuote $RESTART_COUNT_THRESHOLD_OVERRIDES 4}}
+      enableRestartCountCheck: {{$ENABLE_RESTART_COUNT_CHECK}}
 
 - name: Creating SVCs
   phases:
@@ -765,3 +767,5 @@ steps:
     Params:
       action: gather
       systemPodMetricsEnabled: {{$ENABLE_SYSTEM_POD_METRICS}}
+      restartCountThresholdOverrides: {{YamlQuote $RESTART_COUNT_THRESHOLD_OVERRIDES 4}}
+      enableRestartCountCheck: {{$ENABLE_RESTART_COUNT_CHECK}}


### PR DESCRIPTION
In this change, restart count validation is implemented. Note that it
will only affect tests, which have this feature enabled (by using
enable_restart_count_check.yaml override).

Testing:
* ran kubemark test locally using clusterloader, cluster running on GCE

/hold 
need to finish testing locally