### PR TITLE
Check division by zero in template func

### DIFF
--- a/clusterloader2/pkg/config/template_functions.go
+++ b/clusterloader2/pkg/config/template_functions.go
@@ -150,6 +150,9 @@ func multiplyFloat(numbers ...interface{}) float64 {
 func divideFloat(i, j interface{}) float64 {
 	typedI := toFloat64(i)
 	typedJ := toFloat64(j)
+	if typedJ == 0 {
+		panic("division by zero")
+	}
 	return typedI / typedJ
 }
 


### PR DESCRIPTION
Adds an explicit check on division by zero for template functions. This way we get more precise errors like:

```
config reading error: replacing placeholders error: template: :34:23: executing "" at <DivideInt $totalPods $namespaces>: error calling DivideInt: division by zero
```

instead of weird ones like:

```
config reading error: decoding failed: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal number -4611686018427388 into Go struct field Phase.ReplicasPerNamespace of type int32
```

Part of #887