### PR TITLE
Add missing start for APIResponsivenessPrometheusSimple

### DIFF
--- a/clusterloader2/testing/density/config.yaml
+++ b/clusterloader2/testing/density/config.yaml
@@ -58,6 +58,10 @@ steps:
     Method: APIResponsivenessPrometheus
     Params:
       action: start
+  - Identifier: APIResponsivenessPrometheusSimple
+    Method: APIResponsivenessPrometheus
+    Params:
+      action: start
   # TODO(oxddr): figure out how many probers to run in function of cluster
   - Identifier: InClusterNetworkLatency
     Method: InClusterNetworkLatency

--- a/clusterloader2/testing/load/config.yaml
+++ b/clusterloader2/testing/load/config.yaml
@@ -82,6 +82,10 @@ steps:
     Method: APIResponsivenessPrometheus
     Params:
       action: start
+  - Identifier: APIResponsivenessPrometheusSimple
+    Method: APIResponsivenessPrometheus
+    Params:
+      action: start
   - Identifier: PodStartupLatency
     Method: PodStartupLatency
     Params:


### PR DESCRIPTION
Without it the `startTime` is set to `time.Zero` which results in querying metrics for the whole lifetime of a cluster while we should query only for the time of the test.