### PR TITLE
Add last restart reason to system pod metrics

### DIFF
--- a/clusterloader2/pkg/measurement/common/system_pod_metrics.go
+++ b/clusterloader2/pkg/measurement/common/system_pod_metrics.go
@@ -57,8 +57,9 @@ type systemPodMetricsMeasurement struct {
 }
 
 type containerMetrics struct {
-	Name         string `json:"name"`
-	RestartCount int32  `json:"restartCount"`
+	Name              string `json:"name"`
+	RestartCount      int32  `json:"restartCount"`
+	LastRestartReason string `json:"lastRestartReason"`
 }
 
 type podMetrics struct {
@@ -232,10 +233,14 @@ func extractMetrics(lst *v1.PodList) *systemPodsMetrics {
 			Name:       pod.Name,
 		}
 		for _, container := range pod.Status.ContainerStatuses {
-			podMetrics.Containers = append(podMetrics.Containers, containerMetrics{
+			metrics := containerMetrics{
 				Name:         container.Name,
 				RestartCount: container.RestartCount,
-			})
+			}
+			if container.LastTerminationState.Terminated != nil {
+				metrics.LastRestartReason = container.LastTerminationState.Terminated.String()
+			}
+			podMetrics.Containers = append(podMetrics.Containers, metrics)
 		}
 		metrics.Pods = append(metrics.Pods, podMetrics)
 	}


### PR DESCRIPTION
This is a change in clusterloader system pod metrics measurement. To
speed up rootcausing, in this change restart reason field is added to
the measurement output.

Testing:
- set up cluster with 1 node
- ran density test with enabled system_pod_metrics
- restarted one container manually
- verified that SystemPodMetrics artifact is generated properly