### PR TITLE
Revert "Start enforcing scheduler throughput to be 90+ in density test"

### DIFF
--- a/clusterloader2/testing/density/config.yaml
+++ b/clusterloader2/testing/density/config.yaml
@@ -137,9 +137,6 @@ steps:
     Method: SchedulingThroughput
     Params:
       action: gather
-      # Setting to 90 should allow us to catch regressions like
-      # https://github.com/kubernetes/kubernetes/pull/85030 while not making the tests flaky.
-      threshold: 90
 
 - name: Starting latency pod measurements
   measurements:


### PR DESCRIPTION
This reverts commit #904 

Caused:
Error: scheduler throughput: actual throughput 23 lower than threshold 90
https://gke-scalability-prow.corp.goog/view/gcs/gke-scalability-prow/logs/ci-kubernetes-e2e-gke-1.16-100-performance/1197481369819680772

/cc mm4tt oxddr

