### PR TITLE
Start enforcing scheduler throughput in density test

### DIFF
--- a/clusterloader2/testing/density/config.yaml
+++ b/clusterloader2/testing/density/config.yaml
@@ -8,6 +8,7 @@
 {{$NODES_PER_NAMESPACE := DefaultParam .NODES_PER_NAMESPACE 100}}
 {{$PODS_PER_NODE := DefaultParam .PODS_PER_NODE 30}}
 {{$DENSITY_TEST_THROUGHPUT := DefaultParam .DENSITY_TEST_THROUGHPUT 20}}
+{{$SCHEDULER_THROUGHPUT_THRESHOLD := DefaultParam .CL2_SCHEDULER_THROUGHPUT_THRESHOLD 0}}
 # LATENCY_POD_MEMORY and LATENCY_POD_CPU are calculated for 1-core 4GB node.
 # Increasing allocation of both memory and cpu by 10%
 # decreases the value of priority function in scheduler by one point.
@@ -137,6 +138,7 @@ steps:
     Method: SchedulingThroughput
     Params:
       action: gather
+      threshold: {{$SCHEDULER_THROUGHPUT_THRESHOLD}}
 
 - name: Starting latency pod measurements
   measurements:


### PR DESCRIPTION
This is to catch regressions like https://github.com/kubernetes/kubernetes/pull/85030.

This will affect only tests for 500+ node clusters as in smaller clusters the scheduler QPS setting may be less than 100 and hence to 100 throughput won't be achievable.