### PR TITLE
Allow changing default allowed restart count

### DIFF
--- a/clusterloader2/pkg/measurement/common/system_pod_metrics.go
+++ b/clusterloader2/pkg/measurement/common/system_pod_metrics.go
@@ -35,6 +35,7 @@ const (
 	systemPodMetricsEnabledFlagName   = "systemPodMetricsEnabled"
 	restartThresholdOverridesFlagName = "restartCountThresholdOverrides"
 	enableRestartCountCheckFlagName   = "enableRestartCountCheck"
+	defaultRestartCountThresholdKey   = "default"
 )
 
 func init() {
@@ -194,9 +195,14 @@ func validateRestartCounts(metrics *systemPodsMetrics, config *measurement.Measu
 
 func getMaxAllowedRestarts(containerName string, thresholdOverrides map[string]int) int {
 	if override, ok := thresholdOverrides[containerName]; ok {
-		return int(override)
+		return override
 	}
-	return 0 // default if no overrides specified
+	// This allows setting default threshold, which will be used for containers
+	// not present in the thresholdOverrides map.
+	if override, ok := thresholdOverrides[defaultRestartCountThresholdKey]; ok {
+		return override
+	}
+	return 0 // do not allow any restarts if no override and no default specified
 }
 
 /*

--- a/clusterloader2/pkg/measurement/common/system_pod_metrics_test.go
+++ b/clusterloader2/pkg/measurement/common/system_pod_metrics_test.go
@@ -92,6 +92,21 @@ func Test_validateRestartCounts(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name:    "override-default-used",
+			metrics: generatePodMetrics("p", "c", 3),
+			config:  buildConfig(t, true, map[string]int{"default": 3}),
+			wantErr: false,
+		},
+		{
+			name:    "override-default-not-used",
+			metrics: generatePodMetrics("p", "c", 3),
+			config: buildConfig(t, true, map[string]int{
+				"default": 5,
+				"c":       0,
+			}),
+			wantErr: true,
+		},
+		{
 			name:    "override-below-actual-count",
 			metrics: generatePodMetrics("p", "c", 3),
 			config:  buildConfig(t, true, map[string]int{"c": 2}),


### PR DESCRIPTION
This feature is mostly used for detecting crashlooping system
components. Single restart of any component may be ok, see discussion in
https://github.com/kubernetes/perf-tests/pull/908.

At this point, tests will fail if any container (which is not present in
overrides) has even one restart. To simplify this, in this change
support for 'default' max allowed restart count was added. Setting it
will be as simple as adding 'default: X' in the overrides map. Note that
this won't be applied for containers that have some threshold specified.