### PR TITLE
Add PriorityClass with a high priority value to Prometheus.

### DIFF
--- a/clusterloader2/pkg/prometheus/manifests/00monitoring-priorityclass.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/00monitoring-priorityclass.yaml
@@ -1,0 +1,7 @@
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: monitoring
+value: 1000000
+globalDefault: false
+description: "This priority class should be used for monitoring pods only."

--- a/clusterloader2/pkg/prometheus/manifests/prometheus-prometheus.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/prometheus-prometheus.yaml
@@ -16,6 +16,7 @@ spec:
   baseImage: gcr.io/k8s-testimages/quay.io/prometheus/prometheus
   nodeSelector:
     beta.kubernetes.io/os: linux
+  priorityClassName: monitoring
   replicas: 1
   resources:
     requests:


### PR DESCRIPTION
Running Promtheus is critical to even start tests, it should evict other
non-monitoring pod if needed.

/assign @wojtek-t 

ref https://github.com/kubernetes/kubernetes/issues/85683