### PR TITLE
Allow Prometheus to run on a tainted heapster node.

### DIFF
--- a/clusterloader2/pkg/prometheus/manifests/prometheus-prometheus.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/prometheus-prometheus.yaml
@@ -34,6 +34,10 @@ spec:
     fsGroup: 2000
     runAsNonRoot: true
     runAsUser: 1000
+  tolerations:
+  - key: "monitoring"
+    operator: "Exists"
+    effect: "NoSchedule"
   serviceAccountName: prometheus-k8s
   serviceMonitorNamespaceSelector: {}
   serviceMonitorSelector: {}


### PR DESCRIPTION
See https://github.com/kubernetes/kubernetes/issues/85683 and https://github.com/kubernetes/kubernetes/pull/85797 for context. 

/assign @wojtek-t 