### PR TITLE
Use APIResponsivenessPrometheusSimple instead of APIResponsiveness.

### DIFF
--- a/clusterloader2/testing/density/config.yaml
+++ b/clusterloader2/testing/density/config.yaml
@@ -50,10 +50,6 @@ chaosMonkey:
 steps:
 - name: Starting measurements
   measurements:
-  - Identifier: APIResponsiveness
-    Method: APIResponsiveness
-    Params:
-      action: reset
   - Identifier: APIResponsivenessPrometheus
     Method: APIResponsivenessPrometheus
     Params:
@@ -222,17 +218,11 @@ steps:
 
 - name: Collecting measurements
   measurements:
-  - Identifier: APIResponsiveness
-    Method: APIResponsiveness
-    Params:
-      action: gather
   - Identifier: APIResponsivenessPrometheusSimple
     Method: APIResponsivenessPrometheus
     Params:
       action: gather
-      {{if $ENABLE_PROMETHEUS_API_RESPONSIVENESS}}
       enableViolations: true
-      {{end}}
       useSimpleLatencyQuery: true
       summaryName: APIResponsivenessPrometheus_simple
   {{if not $USE_SIMPLE_LATENCY_QUERY}}

--- a/clusterloader2/testing/load/config.yaml
+++ b/clusterloader2/testing/load/config.yaml
@@ -74,10 +74,6 @@ chaosMonkey:
 steps:
 - name: Starting measurements
   measurements:
-  - Identifier: APIResponsiveness
-    Method: APIResponsiveness
-    Params:
-      action: reset
   - Identifier: APIResponsivenessPrometheus
     Method: APIResponsivenessPrometheus
     Params:
@@ -729,17 +725,11 @@ steps:
 
 - name: Collecting measurements
   measurements:
-  - Identifier: APIResponsiveness
-    Method: APIResponsiveness
-    Params:
-      action: gather
   - Identifier: APIResponsivenessPrometheusSimple
     Method: APIResponsivenessPrometheus
     Params:
       action: gather
-      {{if $ENABLE_PROMETHEUS_API_RESPONSIVENESS}}
       enableViolations: true
-      {{end}}
       useSimpleLatencyQuery: true
       summaryName: APIResponsivenessPrometheus_simple
   {{if not $USE_SIMPLE_LATENCY_QUERY}}


### PR DESCRIPTION
The latter is based on a deprecated metric. The former mimics the behavior using Prometheus and has been already enable in all tests. 

ref https://github.com/kubernetes/kubernetes/issues/73519

/assign @wojtek-t 