### PR TITLE
Cl2: Make CL2_* envs available in templates

### DIFF
--- a/clusterloader2/pkg/config/template_provider_test.go
+++ b/clusterloader2/pkg/config/template_provider_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package config
 
 import (
+	"os"
+	"reflect"
 	"testing"
 
 	"k8s.io/perf-tests/clusterloader2/api"
@@ -60,6 +62,115 @@ func TestValidateTestSuite(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if err := validateTestSuite(tt.suite); (err != nil) != tt.wantErr {
 				t.Errorf("validateTestSuite() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestLoadCL2Envs(t *testing.T) {
+	tests := []struct {
+		name          string
+		env           map[string]string
+		wantedMapping map[string]interface{}
+	}{
+		{
+			name: "One CL2 env, one non-CL2 env",
+			env: map[string]string{
+				"CL2_MY_PARAM": "100",
+				"NODE_SIZE":    "n1-standard-1",
+			},
+			wantedMapping: map[string]interface{}{
+				"CL2_MY_PARAM": "100",
+			},
+		},
+		{
+			name: "Multiple CL2 envs",
+			env: map[string]string{
+				"CL2_MY_PARAM1": "100",
+				"CL2_MY_PARAM2": "XXX",
+			},
+			wantedMapping: map[string]interface{}{
+				"CL2_MY_PARAM1": "100",
+				"CL2_MY_PARAM2": "XXX",
+			},
+		},
+		{
+			name: "No CL2 envs",
+			env: map[string]string{
+				"NODE_SIZE": "n1-standard-1",
+				"CLUSTER":   "my-cluster",
+			},
+			wantedMapping: map[string]interface{}{},
+		},
+		{
+			name: "Env prefix is case sensitive",
+			env: map[string]string{
+				"cl2_my_param": "123",
+			},
+			wantedMapping: map[string]interface{}{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			os.Clearenv()
+			for k, v := range tt.env {
+				os.Setenv(k, v)
+			}
+			mapping, err := LoadCL2Envs()
+			if err != nil {
+				t.Error(err)
+			}
+			if !reflect.DeepEqual(mapping, tt.wantedMapping) {
+				t.Errorf("wanted: %v, got: %v", tt.wantedMapping, mapping)
+			}
+		})
+	}
+}
+
+func TestMergeMappings(t *testing.T) {
+	tests := []struct {
+		name    string
+		a       map[string]interface{}
+		b       map[string]interface{}
+		wantedA map[string]interface{}
+		wantErr bool
+	}{
+		{
+			name: "Different keys",
+			a:    map[string]interface{}{"ENABLE_XXX": true},
+			b:    map[string]interface{}{"CL2_PARAM1": 123},
+			wantedA: map[string]interface{}{
+				"ENABLE_XXX": true,
+				"CL2_PARAM1": 123,
+			},
+		},
+		{
+			name: "Same keys, no conflict",
+			a:    map[string]interface{}{"CL2_PARAM1": 100},
+			b:    map[string]interface{}{"CL2_PARAM1": 100},
+			wantedA: map[string]interface{}{
+				"CL2_PARAM1": 100,
+			},
+		},
+		{
+			name:    "Same keys, conflict",
+			a:       map[string]interface{}{"CL2_PARAM1": 100},
+			b:       map[string]interface{}{"CL2_PARAM1": 105},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := MergeMappings(tt.a, tt.b); err != nil {
+				if !tt.wantErr {
+					t.Errorf("unexpceted MergeMappings() error: %v", err)
+				}
+				return
+			}
+			if !reflect.DeepEqual(tt.a, tt.wantedA) {
+				t.Errorf("wanted: %v, got: %v", tt.wantedA, tt.a)
 			}
 		})
 	}


### PR DESCRIPTION
This will make all env variables starting with CL2_ prefix available in the CL2 template files.

It will allow us to leverage the presets mechanism in cl2 templates and (in some cases) use it instead of relying on cumbersome test override files.

The problem it solves is that sometimes we want to set something for almost all (but not all tests) tests.
Currently, the only way to do that is the create an override file and pass it to many test definitions.
This is arduous for many reasons, e.g. it requires at least 2 PRs (one to perf-test with the override file, second to test-infra) and it requires keeping many places in sync.