### PR TITLE
Use Measurement's indentifier in logging.

### DIFF
--- a/clusterloader2/pkg/measurement/common/slos/api_responsiveness_prometheus.go
+++ b/clusterloader2/pkg/measurement/common/slos/api_responsiveness_prometheus.go
@@ -74,13 +74,13 @@ type apiResponsivenessGatherer struct{}
 func (a *apiResponsivenessGatherer) Gather(executor QueryExecutor, startTime time.Time, config *measurement.MeasurementConfig) (measurement.Summary, error) {
 	apiCalls, err := a.gatherAPICalls(executor, startTime, config)
 	if err != nil {
-		klog.Errorf("%s: samples gathering error: %v", apiResponsivenessMeasurementName, err)
+		klog.Errorf("%s: samples gathering error: %v", config.Identifier, err)
 		return nil, err
 	}
 
 	metrics := &apiResponsiveness{ApiCalls: apiCalls}
 
-	badMetrics := validateAPICalls(apiResponsivenessPrometheusMeasurementName, metrics)
+	badMetrics := validateAPICalls(config.Identifier, metrics)
 
 	content, err := util.PrettyPrintJSON(apiCallToPerfData(metrics))
 	if err != nil {
@@ -232,7 +232,7 @@ func getSLOThreshold(verb, scope string) time.Duration {
 	return namespaceThreshold
 }
 
-func validateAPICalls(logPrefix string, metrics *apiResponsiveness) []string {
+func validateAPICalls(identifier string, metrics *apiResponsiveness) []string {
 	badMetrics := make([]string, 0)
 	top := topToPrint
 
@@ -250,7 +250,7 @@ func validateAPICalls(logPrefix string, metrics *apiResponsiveness) []string {
 			if isBad {
 				prefix = "WARNING "
 			}
-			klog.Infof("%s: %vTop latency metric: %+v; threshold: %v", logPrefix, prefix, apiCall, sloThreshold)
+			klog.Infof("%s: %vTop latency metric: %+v; threshold: %v", identifier, prefix, apiCall, sloThreshold)
 		}
 	}
 	return badMetrics

--- a/clusterloader2/pkg/measurement/common/slos/prometheus_measurement.go
+++ b/clusterloader2/pkg/measurement/common/slos/prometheus_measurement.go
@@ -56,12 +56,12 @@ type prometheusMeasurement struct {
 
 func (m *prometheusMeasurement) Execute(config *measurement.MeasurementConfig) ([]measurement.Summary, error) {
 	if config.PrometheusFramework == nil {
-		klog.Warningf("%s: Prometheus is disabled, skipping the measurement!", m)
+		klog.Warningf("%s: Prometheus is disabled, skipping the measurement!", config.Identifier)
 		return nil, nil
 	}
 
 	if !m.gatherer.IsEnabled(config) {
-		klog.Warningf("%s: disabled, skipping the measuerment!", m)
+		klog.Warningf("%s: disabled, skipping the measuerment!", config.Identifier)
 		return nil, nil
 	}
 
@@ -72,11 +72,11 @@ func (m *prometheusMeasurement) Execute(config *measurement.MeasurementConfig) (
 
 	switch action {
 	case "start":
-		klog.Infof("%s has started", m)
+		klog.Infof("%s has started", config.Identifier)
 		m.startTime = time.Now()
 		return nil, nil
 	case "gather":
-		klog.Infof("%s gathering results", m)
+		klog.Infof("%s gathering results", config.Identifier)
 		enableViolations, err := util.GetBoolOrDefault(config.Params, "enableViolations", false)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
This allows to clearly identify logs if we have two, distinct instances of the same measurement.

/assign @mm4tt 