### PR TITLE
WIP - Remove -min_confidence=0.9 from golint

### DIFF
--- a/verify/verify-golint.sh
+++ b/verify/verify-golint.sh
@@ -26,7 +26,7 @@ GOLINT=${GOLINT:-"golint"}
 PACKAGES=($(go list ./... | grep -v /vendor/))
 bad_files=()
 for package in "${PACKAGES[@]}"; do
-  out=$("${GOLINT}" -min_confidence=0.9 "${package}")
+  out=$("${GOLINT}" "${package}")
   if [[ -n "${out}" ]]; then
     bad_files+=("${out}")
   fi


### PR DESCRIPTION
This change will make golint complain about naming and case conventions.

ref https://github.com/kubernetes/perf-tests/issues/573