### PR TITLE
Implement fetching prow config from directories

### DIFF
--- a/perfdash/Makefile
+++ b/perfdash/Makefile
@@ -18,9 +18,7 @@ run: perfdash
 		--address=0.0.0.0:8080 \
 		--builds=20 \
 		--force-builds \
-		--configPath=https://raw.githubusercontent.com/kubernetes/test-infra/master/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml \
-		--configPath=https://raw.githubusercontent.com/kubernetes/test-infra/master/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml \
-		--configPath=https://raw.githubusercontent.com/kubernetes/test-infra/master/config/jobs/kubernetes/sig-scalability/sig-scalability-experimental-periodic-jobs.yaml
+		--githubConfigDir=https://api.github.com/repos/kubernetes/test-infra/contents/config/jobs/kubernetes/sig-scalability
 
 container: perfdash
 	docker build --pull -t $(REPO)/perfdash:$(TAG) .

--- a/perfdash/deployment.yaml
+++ b/perfdash/deployment.yaml
@@ -23,9 +23,7 @@ spec:
           -   --dir=/www
           -   --address=0.0.0.0:8080
           -   --builds=100
-          -   --configPath=https://raw.githubusercontent.com/kubernetes/test-infra/master/config/jobs/kubernetes/sig-scalability/sig-scalability-experimental-periodic-jobs.yaml
-          -   --configPath=https://raw.githubusercontent.com/kubernetes/test-infra/master/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
-          -   --configPath=https://raw.githubusercontent.com/kubernetes/test-infra/master/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+          -   --githubConfigDir=https://api.github.com/repos/kubernetes/test-infra/contents/config/jobs/kubernetes/sig-scalability
         imagePullPolicy: Always
         ports:
         - name: status

--- a/perfdash/github-configs-fetcher.go
+++ b/perfdash/github-configs-fetcher.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+
+	"gopkg.in/yaml.v2"
+)
+
+type githubDirContent struct {
+	Name        string `yaml:"name"`
+	Path        string `yaml:"path"`
+	DownloadUrl string `yaml:"download_url"`
+	Type        string `yaml:"type"`
+	Url         string `yaml:"url"`
+}
+
+// GetConfigsFromGithub gets config paths from github directory. It uses github API,
+// which is documented here: https://developer.github.com/v3/repos/contents/
+//
+// Example url: https://api.github.com/repos/kubernetes/test-infra/contents/config/jobs/kubernetes/sig-release/release-branch-jobs
+//
+// Different branch can be specified by appending "?ref=branch-name" parameter at the end
+// of the url.
+func GetConfigsFromGithub(url string) ([]string, error) {
+	var result []string
+	contents, err := getGithubDirContents(url)
+	if err != nil {
+		return nil, err
+	}
+	for _, c := range contents {
+		// Dirs and non-yaml files are ignored; this means that there is no
+		// recursive search, it should be good enough for now.
+		if c.Type == "file" && strings.HasSuffix(c.Name, ".yaml") {
+			result = append(result, c.DownloadUrl)
+		}
+	}
+	return result, nil
+}
+
+func getGithubDirContents(url string) ([]githubDirContent, error) {
+	fmt.Printf("Downloading github spec from %v\n", url)
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("error calling github API %s: %v", url, err)
+	}
+	b, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("error reading github response %s: %v", url, err)
+	}
+	var decoded []githubDirContent
+	err = yaml.Unmarshal(b, &decoded)
+	if err != nil {
+		return nil, err
+	}
+	return decoded, nil
+}

--- a/perfdash/perfdash.go
+++ b/perfdash/perfdash.go
@@ -45,9 +45,12 @@ var (
 )
 
 func initGoogleDownloaderOptions() {
-	pflag.BoolVar(&options.OverrideBuildCount, "force-builds", false, "Whether to enforce number of builds to process as passed via --builds flag. This would override values defined by \"perfDashBuildsCount\" label on prow job")
+	pflag.BoolVar(&options.OverrideBuildCount, "force-builds", false, "Whether to enforce number of builds to process as passed via --builds flag. "+
+		"This would override values defined by \"perfDashBuildsCount\" label on prow job")
 	pflag.IntVar(&options.DefaultBuildsCount, "builds", maxBuilds, "Total builds number")
 	pflag.StringArrayVar(&options.ConfigPaths, "configPath", []string{}, "Paths/urls to the prow config")
+	pflag.StringArrayVar(&options.GithubConfigDirs, "githubConfigDir", []string{}, "Github API url to the prow config directory, all configs from this dir will be used."+
+		"To specify more than one dir, this arg shall be specified multiple times, one time for each dir.")
 	pflag.StringVar(&options.CredentialPath, "credentialPath", "", "Path to the gcs credential json")
 	pflag.StringVar(&options.LogsBucket, "logsBucket", "kubernetes-jenkins", "Name of the data bucket")
 	pflag.StringVar(&options.LogsPath, "logsPath", "logs", "Path to the logs inside the logs bucket")
@@ -65,11 +68,6 @@ func run() error {
 	initGoogleDownloaderOptions()
 	pflag.Parse()
 	initGlobalConfig()
-
-	fmt.Printf("config paths - %d\n", len(options.ConfigPaths))
-	for i := 0; i < len(options.ConfigPaths); i++ {
-		fmt.Printf("config path %d: %s\n", i+1, (options.ConfigPaths)[i])
-	}
 
 	if options.DefaultBuildsCount > maxBuilds || options.DefaultBuildsCount < 0 {
 		fmt.Printf("Invalid number of builds: %d, setting to %d\n", options.DefaultBuildsCount, maxBuilds)


### PR DESCRIPTION
At this point, we need to specify each prow config file explicitly in
deployment yaml. This will be a problem for adding sig-release jobs to
pefdash, since these configs are autogenerated by config forker.

With this change, we'd be able to just specify "githubConfigDir" to the
sig-release dir and perfdash will ingest all the configs from that dir.

Testing:
* started perfdash locally with
githubConfigDir=path-to-sig-release-configs, verified configs are
fetched
* tested that perfadash still works without providing githubConfigDir
flag