### PR TITLE
Increase maxSamples to 100000000 (from default 50000000).

### DIFF
--- a/clusterloader2/pkg/prometheus/manifests/prometheus-prometheus.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/prometheus-prometheus.yaml
@@ -47,3 +47,5 @@ spec:
           requests:
             # Start with 10Gi, add 10Gi for each 1K nodes.
             storage: {{MultiplyInt 10 (AddInt 1 (DivideInt .Nodes 1000))}}Gi
+  query:
+    maxSamples: 100000000


### PR DESCRIPTION
This should mitigate: "query processing would load too many samples into memory in query execution" error in gce5000.

ref https://github.com/kubernetes/kubernetes/issues/86082

/assign @mm4tt 