### PR TITLE
Support for windows nodes

### DIFF
--- a/clusterloader2/testing/node-throughput/config.yaml
+++ b/clusterloader2/testing/node-throughput/config.yaml
@@ -2,8 +2,10 @@
 # - This test is designed for 1-node cluster.
 
 #Constants
-{{$POD_COUNT := 100}}
+{{$POD_COUNT := DefaultParam .POD_COUNT 100}}
 {{$POD_THROUGHPUT := DefaultParam .POD_THROUGHPUT 2}}
+{{$CONTAINER_IMAGE := DefaultParam .CONTAINER_IMAGE "k8s.gcr.io/pause:3.1"}}
+{{$POD_STARTUP_LATENCY_THRESHOLD := DefaultParam .POD_STARTUP_LATENCY_THRESHOLD "5s"}}
 
 name: node-throughput
 automanagedNamespaces: {{$POD_COUNT}}
@@ -22,6 +24,7 @@ steps:
     Params:
       action: start
       labelSelector: group = latency
+      threshold: {{$POD_STARTUP_LATENCY_THRESHOLD}}
 - measurements:
   - Identifier: WaitForRunningLatencyRCs
     Method: WaitForControlledPodsRunning
@@ -43,6 +46,7 @@ steps:
       templateFillMap:
         Replicas: 1
         Group: latency
+        Image: {{$CONTAINER_IMAGE}}
 - measurements:
   - Identifier: WaitForRunningLatencyRCs
     Method: WaitForControlledPodsRunning

--- a/clusterloader2/testing/node-throughput/rc.yaml
+++ b/clusterloader2/testing/node-throughput/rc.yaml
@@ -17,7 +17,7 @@ spec:
       # Do not automount default service account, to eliminate its impact.
       automountServiceAccountToken: false
       containers:
-      - image: k8s.gcr.io/pause:3.1
+      - image: {{.Image}}
         imagePullPolicy: IfNotPresent
         name: {{.Name}}
         ports:

--- a/clusterloader2/testing/node-throughput/windows_override.yaml
+++ b/clusterloader2/testing/node-throughput/windows_override.yaml
@@ -1,0 +1,3 @@
+POD_COUNT: 80
+CONTAINER_IMAGE: gcr.io/gke-release/pause-win:1.0.0
+POD_STARTUP_LATENCY_THRESHOLD: 20m


### PR DESCRIPTION
Add support for windows nodes to do node-throughput test.
1. the pod startup latency threshold on windows node is not clear yet, so set 20m for now.

cmd to run on k8s windows cluster:

$GOPATH/src/k8s.io/perf-tests/run-e2e.sh cluster-loader2 --nodes=1 --provider=gce --report-dir=/workspace/_artifacts --testconfig=testing/node-throughput/config.yaml --testoverrides=./testing/node-throughput/windows_override.yaml