### PR TITLE
Add sig-release GCE-100 jobs to perfdash

### DIFF
--- a/perfdash/Makefile
+++ b/perfdash/Makefile
@@ -1,7 +1,7 @@
 all: push
 
 # See pod.yaml for the version currently running-- bump this ahead before rebuilding!
-TAG = 2.16
+TAG = 2.17
 
 REPO = gcr.io/k8s-testimages
 GODEP = CGO_ENABLED=0 GOOS=linux godep
@@ -18,7 +18,8 @@ run: perfdash
 		--address=0.0.0.0:8080 \
 		--builds=20 \
 		--force-builds \
-		--githubConfigDir=https://api.github.com/repos/kubernetes/test-infra/contents/config/jobs/kubernetes/sig-scalability
+		--githubConfigDir=https://api.github.com/repos/kubernetes/test-infra/contents/config/jobs/kubernetes/sig-scalability \
+		--githubConfigDir=https://api.github.com/repos/kubernetes/test-infra/contents/config/jobs/kubernetes/sig-release/release-branch-jobs
 
 container: perfdash
 	docker build --pull -t $(REPO)/perfdash:$(TAG) .

--- a/perfdash/deployment.yaml
+++ b/perfdash/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: perfdash
-        image: gcr.io/k8s-testimages/perfdash:2.16
+        image: gcr.io/k8s-testimages/perfdash:2.17
         command:
           - /perfdash
           -   --www=true
@@ -24,6 +24,7 @@ spec:
           -   --address=0.0.0.0:8080
           -   --builds=100
           -   --githubConfigDir=https://api.github.com/repos/kubernetes/test-infra/contents/config/jobs/kubernetes/sig-scalability
+          -   --githubConfigDir=https://api.github.com/repos/kubernetes/test-infra/contents/config/jobs/kubernetes/sig-release/release-branch-jobs
         imagePullPolicy: Always
         ports:
         - name: status


### PR DESCRIPTION
Also, bumping version to 2.17 so that new version of perfdash can be
deployed.

Testing:
* ran manually using make run, verified release jobs are present in the
ui