### PR TITLE
add scheduling cycle e2e latency

### DIFF
--- a/clusterloader2/pkg/measurement/common/scheduler_latency.go
+++ b/clusterloader2/pkg/measurement/common/scheduler_latency.go
@@ -36,7 +36,10 @@ import (
 )
 
 const (
-	schedulerLatencyMetricName  = "SchedulingMetrics"
+	schedulerLatencyMetricName = "SchedulingMetrics"
+
+	e2eScheduling = "e2eScheduling"
+
 	schedulingLatencyMetricName = model.LabelValue(schedulermetric.SchedulerSubsystem + "_" + schedulermetric.SchedulingLatencyName)
 	singleRestCallTimeout       = 5 * time.Minute
 )
@@ -130,7 +133,10 @@ func (s *schedulerLatencyMeasurement) getSchedulingLatency(c clientset.Interface
 			metric = &result.PreemptionEvaluationLatency
 		case schedulermetric.Binding:
 			metric = &result.BindingLatency
+		case e2eScheduling:
+			metric = &result.E2eSchedulingLatency
 		}
+
 		if metric == nil {
 			continue
 		}
@@ -210,4 +216,5 @@ type schedulingMetrics struct {
 	PriorityEvaluationLatency   measurementutil.LatencyMetric `json:"priorityEvaluationLatency"`
 	PreemptionEvaluationLatency measurementutil.LatencyMetric `json:"preemptionEvaluationLatency"`
 	BindingLatency              measurementutil.LatencyMetric `json:"bindingLatency"`
+	E2eSchedulingLatency        measurementutil.LatencyMetric `json:"e2eSchedulingLatency"`
 }

--- a/perfdash/parser.go
+++ b/perfdash/parser.go
@@ -249,6 +249,7 @@ type schedulingMetrics struct {
 	PriorityEvaluationLatency   latencyMetric `json:"priorityEvaluationLatency"`
 	PreemptionEvaluationLatency latencyMetric `json:"preemptionEvaluationLatency"`
 	BindingLatency              latencyMetric `json:"bindingLatency"`
+	E2eSchedulingLatency        latencyMetric `json:"e2eSchedulingLatency"`
 	ThroughputAverage           float64       `json:"throughputAverage"`
 	ThroughputPerc50            float64       `json:"throughputPerc50"`
 	ThroughputPerc90            float64       `json:"throughputPerc90"`
@@ -279,6 +280,8 @@ func parseSchedulingLatency(data []byte, buildNumber int, testResult *BuildData)
 	testResult.Builds[build] = append(testResult.Builds[build], preemptionEvaluation)
 	binding := parseOperationLatency(obj.BindingLatency, "binding")
 	testResult.Builds[build] = append(testResult.Builds[build], binding)
+	e2eSchedulingLatency := parseOperationLatency(obj.E2eSchedulingLatency, "e2eScheduling")
+	testResult.Builds[build] = append(testResult.Builds[build], e2eSchedulingLatency)
 }
 
 type schedulingThroughputMetric struct {


### PR DESCRIPTION
add e2e_scheduling_duration_seconds to perf_test
ref  [#86216](https://github.com/kubernetes/kubernetes/issues/86126)