### PR TITLE
Use APIResponsivenessPrometheusSimple in legacy test configs.

### DIFF
--- a/clusterloader2/testing/experimental/storage/pod-startup/config.yaml
+++ b/clusterloader2/testing/experimental/storage/pod-startup/config.yaml
@@ -37,11 +37,11 @@ tuningSets:
 steps:
 # Start measurements
 - measurements:
-  - Identifier: APIResponsiveness
-    Method: APIResponsiveness
-    Params:
-      action: reset
   - Identifier: APIResponsivenessPrometheus
+    Method: APIResponsivenessPrometheus
+    Params:
+      action: start
+  - Identifier: APIResponsivenessPrometheusSimple
     Method: APIResponsivenessPrometheus
     Params:
       action: start
@@ -144,10 +144,13 @@ steps:
 {{ end }}
 # Collect measurements
 - measurements:
-  - Identifier: APIResponsiveness
-    Method: APIResponsiveness
+  - Identifier: APIResponsivenessPrometheusSimple
+    Method: APIResponsivenessPrometheus
     Params:
       action: gather
+      enableViolations: true
+      useSimpleLatencyQuery: true
+      summaryName: APIResponsivenessPrometheus_simple
   - Identifier: APIResponsivenessPrometheus
     Method: APIResponsivenessPrometheus
     Params:

--- a/clusterloader2/testing/node-throughput/config.yaml
+++ b/clusterloader2/testing/node-throughput/config.yaml
@@ -15,10 +15,10 @@ tuningSets:
     qps: {{$POD_THROUGHPUT}}
 steps:
 - measurements:
-  - Identifier: APIResponsiveness
-    Method: APIResponsiveness
+  - Identifier: APIResponsivenessPrometheusSimple
+    Method: APIResponsivenessPrometheus
     Params:
-      action: reset
+      action: start
   - Identifier: PodStartupLatency
     Method: PodStartupLatency
     Params:
@@ -73,7 +73,10 @@ steps:
     Params:
       action: gather
 - measurements:
-  - Identifier: APIResponsiveness
-    Method: APIResponsiveness
+  - Identifier: APIResponsivenessPrometheusSimple
+    Method: APIResponsivenessPrometheus
     Params:
       action: gather
+      enableViolations: true
+      useSimpleLatencyQuery: true
+      summaryName: APIResponsivenessPrometheus_simple


### PR DESCRIPTION
Some scalability tests are failing after https://github.com/kubernetes/perf-tests/pull/915 was merged

https://k8s-testgrid.appspot.com/sig-scalability-experiments#storage
https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/ci-kubernetes-storage-scalability/1205162963401445380

https://k8s-testgrid.appspot.com/sig-scalability-node#node-throughput
https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-node-throughput/1205121688543432710

```
[measurement call APIResponsiveness - APIResponsiveness error: unknown measurement method APIResponsiveness
measurement call APIResponsiveness - APIResponsiveness error: unknown measurement method APIResponsiveness]
```

/cc oxddr