### PR TITLE
Implement GlobalQPSLoad tuning set.

### DIFF
--- a/clusterloader2/api/types.go
+++ b/clusterloader2/api/types.go
@@ -138,6 +138,8 @@ type TuningSet struct {
 	RandomizedTimeLimitedLoad *RandomizedTimeLimitedLoad `json: randomizedTimeLimitedLoad`
 	// ParallelismLimitedLoad is a definition for ParallelismLimitedLoad tuning set.
 	ParallelismLimitedLoad *ParallelismLimitedLoad `json: parallelismLimitedLoad`
+	// GlobalQPSLoad is a definition for GlobalQPSLoad tuning set.
+	GlobalQPSLoad *GlobalQPSLoad `json: globalQPSLoad`
 }
 
 // Measurement is a structure that defines the measurement method call.
@@ -189,6 +191,15 @@ type RandomizedTimeLimitedLoad struct {
 type ParallelismLimitedLoad struct {
 	// ParallelismLimit specifies the limit of the parallelism for the action executions.
 	ParallelismLimit int32 `json: parallelismLimit`
+}
+
+// GlobalQPSLoad defines a uniform load with a given QPS.
+// The rate limiter is shared across all phases using this tuning set.
+type GlobalQPSLoad struct {
+	// QPS defines desired average rate of actions.
+	QPS float64 `json: qps`
+	// Burst defines maxumim number of actions that can happen at the same time.
+	Burst int `json: burst`
 }
 
 // ChaosMonkeyConfig descibes simulated component failures.

--- a/clusterloader2/pkg/tuningset/global_qps_load.go
+++ b/clusterloader2/pkg/tuningset/global_qps_load.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tuningset
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/perf-tests/clusterloader2/api"
+
+	"golang.org/x/time/rate"
+)
+
+type globalQPSLoad struct {
+	limiter *rate.Limiter
+}
+
+func newGlobalQPSLoad(params *api.GlobalQPSLoad) TuningSet {
+	return &globalQPSLoad{
+		limiter: rate.NewLimiter(rate.Limit(params.QPS), params.Burst),
+	}
+}
+
+func (ql *globalQPSLoad) Execute(actions []func()) {
+	var wg wait.Group
+	for i := range actions {
+		ql.limiter.Wait(context.TODO())
+		wg.Start(actions[i])
+	}
+	wg.Wait()
+}

--- a/clusterloader2/pkg/tuningset/simple_tuning_set_factory.go
+++ b/clusterloader2/pkg/tuningset/simple_tuning_set_factory.go
@@ -60,6 +60,8 @@ func (tf *simpleTuningSetFactory) CreateTuningSet(name string) (TuningSet, error
 		return newRandomizedTimeLimitedLoad(tuningSet.RandomizedTimeLimitedLoad), nil
 	case tuningSet.ParallelismLimitedLoad != nil:
 		return newParallelismLimitedLoad(tuningSet.ParallelismLimitedLoad), nil
+	case tuningSet.GlobalQPSLoad != nil:
+		return newGlobalQPSLoad(tuningSet.GlobalQPSLoad), nil
 	default:
 		return nil, fmt.Errorf("incorrect tuning set: %v", tuningSet)
 	}


### PR DESCRIPTION
It is essentially the same as QPSLoad, but all phases share the same limiter.

The difference compared to "standard" qpsLoad: if you have n phases running simultaneously, with QPS limit set to x:
* globalQPSLoad will run all of them with max rate of x
* qpsLoad will maintain limiter for each of n phases separately, so this will give total rate of n * x.

/assign @wojtek-t 