### PR TITLE
Fix GlobalQPSLoad to really share rate.Limiter

### DIFF
--- a/clusterloader2/pkg/tuningset/simple_tuning_set_factory.go
+++ b/clusterloader2/pkg/tuningset/simple_tuning_set_factory.go
@@ -23,13 +23,15 @@ import (
 )
 
 type simpleTuningSetFactory struct {
-	tuningSetMap map[string]*api.TuningSet
+	tuningSetMap         map[string]*api.TuningSet
+	globalQPSLoadFactory *globalQPSLoadFactory
 }
 
 // NewTuningSetFactory creates new ticker factory.
 func NewTuningSetFactory() TuningSetFactory {
 	return &simpleTuningSetFactory{
-		tuningSetMap: make(map[string]*api.TuningSet),
+		tuningSetMap:         make(map[string]*api.TuningSet),
+		globalQPSLoadFactory: newGlobalQPSLoadFactory(),
 	}
 }
 
@@ -61,7 +63,7 @@ func (tf *simpleTuningSetFactory) CreateTuningSet(name string) (TuningSet, error
 	case tuningSet.ParallelismLimitedLoad != nil:
 		return newParallelismLimitedLoad(tuningSet.ParallelismLimitedLoad), nil
 	case tuningSet.GlobalQPSLoad != nil:
-		return newGlobalQPSLoad(tuningSet.GlobalQPSLoad), nil
+		return tf.globalQPSLoadFactory.GetOrCreate(name, tuningSet.GlobalQPSLoad), nil
 	default:
 		return nil, fmt.Errorf("incorrect tuning set: %v", tuningSet)
 	}


### PR DESCRIPTION
The previous attempt doesn't work. Cluster loader creates new instance of GlobalQPSLoad for all phases, so fact that they use inner *rate.Limiter doesn't change anything.

/assign @wojtek-t