### PR TITLE
Create initial files for Application Performance & Benchmarking SP

### DIFF
--- a/appbench/OWNERS
+++ b/appbench/OWNERS
@@ -1,0 +1,8 @@
+reviewers:
+- sig-scalability-reviewers
+  
+approvers:
+- sig-scalability-approvers
+- jberkus
+- aakarshg
+- tduzan

--- a/appbench/README.md
+++ b/appbench/README.md
@@ -1,0 +1,25 @@
+# Application Performance and Benchmarking
+
+This directory contains the files for the Application Performance and Benchmarking subproject of SIG-Scalability.  The subproject's mission is:
+
+* Develop repeatable benchmarking scripts, tools, and configurations for testing the performance of applications running on Kubernetes together with stack components
+* Share and publish results of benchmarking tests
+* Develop automated tests to monitor for application performance regressions
+
+## Subdirectories
+
+TBD
+
+## Discussion and Contacts
+
+- Issues: file issues in this repository
+- Chat: #sig-scalability in slack.k8s.io
+- Meetings: no meetings scheduled yet
+
+## Owners
+
+Initial subproject owners are:
+
+- Josh Berkus (@jberkus) of Red Hat
+- Tyler Duzan (@tduzan) of Percona
+- Aakarsh Gopi (@aakarshg) of Red Hat


### PR DESCRIPTION
Create initial folder in the perf-tests repo for the Application Performance and Benchmarking subproject.  Includes README with scope of subproject, plus initial three owners.

Once we get going, we'll probably select new owners.

If this is accepted, next steps are:

* Updating /community/sig-scalability with subproject info
* Meeting on slack to discuss first projects/information

I'd also like to potentially have a label added to this repo for kind/appbench so that we can tag issues/PRs for this project.