### PR TITLE
[Access-tokens] Update access-tokens to version v0.0.6

### DIFF
--- a/util-images/access-tokens/Makefile
+++ b/util-images/access-tokens/Makefile
@@ -1,6 +1,6 @@
 PROJECT ?= k8s-testimages
 IMG = gcr.io/$(PROJECT)/perf-tests-util/access-tokens
-TAG = v0.0.5
+TAG = v0.0.6
 
 all: push
 

--- a/util-images/access-tokens/example/example.yaml.template
+++ b/util-images/access-tokens/example/example.yaml.template
@@ -67,7 +67,7 @@ spec:
           image: gcr.io/${PROJECT}/perf-tests-util/access-tokens:latest
           args:
             - --access-token-dirs=/var/tokens/access-token
-            - --qps-per-worker=1
+            - --qps-per-worker=10
             - --namespace=access-tokens
           resources:
             limits:


### PR DESCRIPTION
Changelog:
* Add layer of parallelization per token
* Make requests cheaper with  ResoruceVersion : 0

/sig scalability