### PR TITLE
port number of etcd insecure access should be configurable

### DIFF
--- a/clusterloader2/cmd/clusterloader.go
+++ b/clusterloader2/cmd/clusterloader.go
@@ -61,6 +61,7 @@ func initClusterFlags() {
 	flags.StringEnvVar(&clusterLoaderConfig.ClusterConfig.KubeConfigPath, "kubeconfig", "KUBECONFIG", "", "Path to the kubeconfig file")
 	flags.IntEnvVar(&clusterLoaderConfig.ClusterConfig.Nodes, "nodes", "NUM_NODES", 0, "number of nodes")
 	flags.StringEnvVar(&clusterLoaderConfig.ClusterConfig.Provider, "provider", "PROVIDER", "", "Cluster provider")
+	flags.IntEnvVar(&clusterLoaderConfig.ClusterConfig.EtcdInsecurePort, "etcd-insecure-port", "ETCD_INSECURE_PORT", 2382, "Inscure http port")
 	flags.StringEnvVar(&clusterLoaderConfig.ClusterConfig.MasterName, "mastername", "MASTER_NAME", "", "Name of the masternode")
 	// TODO(#595): Change the name of the MASTER_IP and MASTER_INTERNAL_IP flags and vars to plural
 	flags.StringSliceEnvVar(&clusterLoaderConfig.ClusterConfig.MasterIPs, "masterip", "MASTER_IP", nil /*defaultValue*/, "Hostname/IP of the master node, supports multiple values when separated by commas")

--- a/clusterloader2/pkg/config/cluster.go
+++ b/clusterloader2/pkg/config/cluster.go
@@ -34,6 +34,7 @@ type ClusterConfig struct {
 	KubeConfigPath             string
 	Nodes                      int
 	Provider                   string
+	EtcdInsecurePort           int
 	MasterIPs                  []string
 	MasterInternalIPs          []string
 	MasterName                 string


### PR DESCRIPTION
The port number should be configurable instead of hard-coded,
actually, for the cluster which is setup by kubeadm, the insecure
access number is "2381" by default.

It's hard-coded as "2382", this will make end-users face issues
when etcd metrics is needed, change source code to gather data for
end-user does not make sense, we'd better to provide a option so that
the port number could be specified before the job is started.