### PR TITLE
Modify ListRuntimeObjectsForKind to work for CRDs as well

### DIFF
--- a/clusterloader2/pkg/measurement/common/wait_for_controlled_pods.go
+++ b/clusterloader2/pkg/measurement/common/wait_for_controlled_pods.go
@@ -360,8 +360,10 @@ func (w *waitForControlledPodsRunningMeasurement) updateOpResourceVersion(runtim
 func (w *waitForControlledPodsRunningMeasurement) getObjectCountAndMaxVersion() (int, uint64, error) {
 	var desiredCount int
 	var maxResourceVersion uint64
-	objects, err := runtimeobjects.ListRuntimeObjectsForKind(w.clusterFramework.GetClientSets().GetClient(),
-		w.kind, w.selector.Namespace, w.selector.LabelSelector, w.selector.FieldSelector)
+	objects, err := runtimeobjects.ListRuntimeObjectsForKind(
+		w.clusterFramework.GetClientSets().GetClient(),
+		w.clusterFramework.GetDynamicClients().GetClient(),
+		w.gvr, w.kind, w.selector.Namespace, w.selector.LabelSelector, w.selector.FieldSelector)
 	if err != nil {
 		return desiredCount, maxResourceVersion, fmt.Errorf("listing objects error: %v", err)
 	}


### PR DESCRIPTION
With this change WaitForControlledPodsRunning should work for CRDs wrapping groups of pods with format like:

```
metadata:
  namespace: namespace-1
spec:
  replicas: 200
  selector:
     # any labelSelector, e.g.
     matchLabels:
       name: xx
```
i.e.:
* metadata.namespace must point to the namespace that the object lives in
* spec.replicas must describe desired number of pods
* spec.selector must describe a selector that can be used to find all pods associated with given CRD

WaitForControlledPodsRunning will wait until exactly `spec.replica` pods in given namespace match `spec.selector` and is in running state.