### PR TITLE
Initial creation of subdirectory for application-benchmarks subproject.

### DIFF
--- a/application-benchmarks/OWNERS
+++ b/application-benchmarks/OWNERS
@@ -1,0 +1,7 @@
+reviewers:
+- sig-scalability-reviewers
+
+approvers:
+- sig-scalability-approvers
+- jberkus
+- wojtek-t

--- a/application-benchmarks/README.md
+++ b/application-benchmarks/README.md
@@ -1,0 +1,22 @@
+# Application Performance and Benchmarking
+
+This directory contains the files for the Application Performance and Benchmarking subproject of SIG-Scalability.  The subproject's mission is:
+
+* Develop repeatable benchmarking scripts, tools, and configurations for testing the performance of applications running on Kubernetes together with stack components such as CSI drivers and network overlays
+* Share and publish results of benchmarking tests
+* Develop automated tests to monitor for application performance regressions
+
+## Discussion and Contacts
+
+- Issues: file issues in this repository
+- Chat: #sig-scalability in slack.k8s.io
+- Meetings: no meetings scheduled yet
+
+## Owners
+
+Initial subproject owners are:
+
+- Josh Berkus (@jberkus) of Red Hat
+- Wojciech Tyczynski (@wojtek-t) of Google
+
+Once we have built out results and test parameters, the owners list will be updated with the actual contributors to the project.


### PR DESCRIPTION
Replaces PR #974.

Just create initial subdirectory, preparatory to actually starting to put data and benchmarks into it.  Initial owners are jberkus and wojtek-t because other contributors don't have Kubernetes accounts yet.  

If this is accepted, next steps are:

    Updating /community/sig-scalability with subproject info
    Meeting on slack to discuss first projects/information

I'd also like to potentially have a label added to this repo for kind/appbench so that we can tag issues/PRs for this project.

(Apologies for new PR; renaming the directory isn't compatible with squashing the commit)

/assign @wojtek-t 