### PR TITLE
Differentiate different kinds of errors

### DIFF
--- a/clusterloader2/pkg/measurement/common/etcd_metrics.go
+++ b/clusterloader2/pkg/measurement/common/etcd_metrics.go
@@ -204,8 +204,10 @@ func (e *etcdMetricsMeasurement) getEtcdMetrics(host, provider string, port int)
 
 func (e *etcdMetricsMeasurement) sshEtcdMetrics(cmd, host, provider string) ([]*model.Sample, error) {
 	sshResult, err := measurementutil.SSH(cmd, host+":22", provider)
-	if err != nil || sshResult.Code != 0 {
+	if err != nil {
 		return nil, fmt.Errorf("unexpected error (code: %d) in ssh connection to master: %#v", sshResult.Code, err)
+	} else if sshResult.Code != 0 {
+		return nil, fmt.Errorf("failed running command: %s on the host: %s", cmd, host)
 	}
 	data := sshResult.Stdout
 


### PR DESCRIPTION
If the ssh connection to the host is successful but the cmd run failed,
the error message should be more helpful instead of misleading us with
ssh connection error.

`runSSHCommand` method provides us a way to judge this based on the return
`code`.