### PR TITLE
Add pod update checking to WaitForControlledPodsRunning

### DIFF
--- a/clusterloader2/pkg/measurement/common/scheduling_throughput.go
+++ b/clusterloader2/pkg/measurement/common/scheduling_throughput.go
@@ -111,7 +111,7 @@ func (s *schedulingThroughputMeasurement) start(clientSet clientset.Interface, s
 				return
 			case <-time.After(defaultWaitForPodsInterval):
 				pods := ps.List()
-				podsStatus := measurementutil.ComputePodsStartupStatus(pods, 0)
+				podsStatus := measurementutil.ComputePodsStartupStatus(pods, 0, nil /* updatePodPredicate */)
 				throughput := float64(podsStatus.Scheduled-lastScheduledCount) / float64(defaultWaitForPodsInterval/time.Second)
 				s.schedulingThroughputs = append(s.schedulingThroughputs, throughput)
 				lastScheduledCount = podsStatus.Scheduled

--- a/clusterloader2/pkg/measurement/common/wait_for_controlled_pods.go
+++ b/clusterloader2/pkg/measurement/common/wait_for_controlled_pods.go
@@ -22,6 +22,7 @@ import (
 	"sync"
 	"time"
 
+	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -63,19 +64,20 @@ func createWaitForControlledPodsRunningMeasurement() measurement.Measurement {
 }
 
 type waitForControlledPodsRunningMeasurement struct {
-	apiVersion        string
-	kind              string
-	selector          *measurementutil.ObjectSelector
-	operationTimeout  time.Duration
-	stopCh            chan struct{}
-	isRunning         bool
-	queue             workerqueue.Interface
-	handlingGroup     wait.Group
-	lock              sync.Mutex
-	opResourceVersion uint64
-	gvr               schema.GroupVersionResource
-	checkerMap        checker.CheckerMap
-	clusterFramework  *framework.Framework
+	apiVersion            string
+	kind                  string
+	selector              *measurementutil.ObjectSelector
+	operationTimeout      time.Duration
+	stopCh                chan struct{}
+	isRunning             bool
+	queue                 workerqueue.Interface
+	handlingGroup         wait.Group
+	lock                  sync.Mutex
+	opResourceVersion     uint64
+	gvr                   schema.GroupVersionResource
+	checkerMap            checker.CheckerMap
+	clusterFramework      *framework.Framework
+	checkIfPodsAreUpdated bool
 }
 
 // Execute waits until all specified controlling objects have all pods running or until timeout happens.
@@ -105,6 +107,11 @@ func (w *waitForControlledPodsRunningMeasurement) Execute(config *measurement.Me
 			return nil, err
 		}
 		w.operationTimeout, err = util.GetDurationOrDefault(config.Params, "operationTimeout", defaultOperationTimeout)
+		if err != nil {
+			return nil, err
+		}
+		// TODO(mborsz): Change default to true.
+		w.checkIfPodsAreUpdated, err = util.GetBoolOrDefault(config.Params, "checkIfPodsAreUpdated", false)
 		if err != nil {
 			return nil, err
 		}
@@ -400,6 +407,13 @@ func (w *waitForControlledPodsRunningMeasurement) waitForRuntimeObject(obj runti
 	if err != nil {
 		return nil, err
 	}
+	var isPodUpdated func(*v1.Pod) bool
+	if w.checkIfPodsAreUpdated {
+		isPodUpdated, err = runtimeobjects.GetIsPodUpdatedPredicateFromRuntimeObject(obj)
+		if err != nil {
+			return nil, err
+		}
+	}
 	if isDeleted {
 		runtimeObjectReplicas = 0
 	}
@@ -422,6 +436,7 @@ func (w *waitForControlledPodsRunningMeasurement) waitForRuntimeObject(obj runti
 			EnableLogging:       true,
 			CallerName:          w.String(),
 			WaitForPodsInterval: defaultWaitForPodsInterval,
+			IsPodUpdated:        isPodUpdated,
 		}
 		// This function sets the status (and error message) for the object checker.
 		// The handling of bad statuses and errors is done by gather() function of the measurement.

--- a/clusterloader2/pkg/measurement/util/pods.go
+++ b/clusterloader2/pkg/measurement/util/pods.go
@@ -39,16 +39,17 @@ type PodsStartupStatus struct {
 	Unknown            int
 	Inactive           int
 	Created            int
+	RunningUpdated     int
 }
 
 // String returns string representation for podsStartupStatus.
 func (s *PodsStartupStatus) String() string {
-	return fmt.Sprintf("Pods: %d out of %d created, %d running, %d pending scheduled, %d not scheduled, %d inactive, %d terminating, %d unknown, %d runningButNotReady ",
-		s.Created, s.Expected, s.Running, s.Pending, s.Waiting, s.Inactive, s.Terminating, s.Unknown, s.RunningButNotReady)
+	return fmt.Sprintf("Pods: %d out of %d created, %d running (%d updated), %d pending scheduled, %d not scheduled, %d inactive, %d terminating, %d unknown, %d runningButNotReady ",
+		s.Created, s.Expected, s.Running, s.RunningUpdated, s.Pending, s.Waiting, s.Inactive, s.Terminating, s.Unknown, s.RunningButNotReady)
 }
 
 // ComputePodsStartupStatus computes PodsStartupStatus for a group of pods.
-func ComputePodsStartupStatus(pods []*corev1.Pod, expected int) PodsStartupStatus {
+func ComputePodsStartupStatus(pods []*corev1.Pod, expected int, isPodUpdated func(*corev1.Pod) bool) PodsStartupStatus {
 	startupStatus := PodsStartupStatus{
 		Expected: expected,
 	}
@@ -69,6 +70,9 @@ func ComputePodsStartupStatus(pods []*corev1.Pod, expected int) PodsStartupStatu
 			if ready {
 				// Only count a pod is running when it is also ready.
 				startupStatus.Running++
+				if isPodUpdated == nil || isPodUpdated(p) {
+					startupStatus.RunningUpdated++
+				}
 			} else {
 				startupStatus.RunningButNotReady++
 			}

--- a/clusterloader2/pkg/measurement/util/runtimeobjects/runtimeobjects.go
+++ b/clusterloader2/pkg/measurement/util/runtimeobjects/runtimeobjects.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"strconv"
 
+	goerrors "github.com/go-errors/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	batch "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -233,6 +234,35 @@ func getSelectorFromUnstrutured(obj *unstructured.Unstructured) (labels.Selector
 		}
 		return metav1.LabelSelectorAsSelector(&selector)
 	}
+}
+
+// GetIsPodUpdatedPredicateFromRuntimeObject returns a func(*corev1.Pod) bool predicate
+// that can be used to check if given pod represents the desired state of pod.
+func GetIsPodUpdatedPredicateFromRuntimeObject(obj runtime.Object) (func(*corev1.Pod) bool, error) {
+	switch typed := obj.(type) {
+	case *unstructured.Unstructured:
+		return getIsPodUpdatedPodPredicateFromUnstructured(typed)
+	default:
+		return nil, goerrors.Errorf("unsupported kind when getting updated pod predicate: %v", obj)
+	}
+}
+
+func getIsPodUpdatedPodPredicateFromUnstructured(obj *unstructured.Unstructured) (func(_ *corev1.Pod) bool, error) {
+	templateMap, ok, err := unstructured.NestedMap(obj.UnstructuredContent(), "spec", "template")
+	if err != nil {
+		return nil, goerrors.Errorf("failed to get pod template: %v", err)
+	}
+	if !ok {
+		return nil, goerrors.Errorf("spec.template is not set in object %v", obj.UnstructuredContent())
+	}
+	template := corev1.PodTemplateSpec{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(templateMap, &template); err != nil {
+		return nil, goerrors.Errorf("failed to parse spec.teemplate as v1.PodTemplateSpec")
+	}
+
+	return func(pod *corev1.Pod) bool {
+		return equality.Semantic.DeepDerivative(template.Spec, pod.Spec)
+	}, nil
 }
 
 // GetSpecFromRuntimeObject returns spec of given runtime object.


### PR DESCRIPTION
This implements an experimental support for waiting for pod updates in WaitForControlledPodsRunning.

```
- name: Starting measurement for waiting for pods
  measurements:
  - Identifier: WaitForRunningPods
    Method: WaitForControlledPodsRunning
    Params:
      action: start
      apiVersion: apps/v1
      kind: Deployment
      labelSelector: l1 = v1
      checkIfPodsAreUpdated: true
      operationTimeout: 1h
- name: Create deployments with envVar set to old
  phases:
  - namespaceRange:
      min: 1
      max: 1
    replicasPerNamespace: 1
    tuningSet: 100qps
    objectBundle:
    - basename: foo
      objectTemplatePath: deployment.yaml
      templateFillMap:
         envToSet: old
- name: Waiting for objects become created
  measurements:
  - Identifier: WaitForRunningPods
    Method: WaitForControlledPodsRunning
    Params:
      action: gather
```

The new logic is enabled by setting `checkIfPodsAreUpdated: true` flag (name TBD).
At this point, nothing special happens.

Let's trigger some update:
```
- name: Update Foos
  phases:
  - namespaceRange:
      min: 1
      max: 1
    replicasPerNamespace: 1
    tuningSet: 100qps
    objectBundle:
    - basename: foo
      objectTemplatePath: deployment.yaml
      templateFillMap:
         envToSet: new
- name: Waiting for objects become updated
  measurements:
  - Identifier: WaitForRunningPods
    Method: WaitForControlledPodsRunning
    Params:
      action: gather
```
The `gather` call will block here until `replicas` pods exist in given deployment **that match deployment's spec.template.spec**.
Without this change, we would wait only for any `replicas` pod exist in given deployment (regardless if they are updated or not) which is not correct.

/assign @wojtekt-t
/assign @mm4tt 