### PR TITLE
WIP - Use a threshold of 1000ms in in-cluster network latency SLI.

### DIFF
--- a/clusterloader2/testing/density/config.yaml
+++ b/clusterloader2/testing/density/config.yaml
@@ -65,6 +65,7 @@ steps:
     Params:
       action: start
       replicasPerProbe: {{AddInt 2 (DivideInt .Nodes 100)}}
+      threshold: 1000ms
   - Identifier: DnsLookupLatency
     Method: DnsLookupLatency
     Params:

--- a/clusterloader2/testing/load/config.yaml
+++ b/clusterloader2/testing/load/config.yaml
@@ -93,6 +93,7 @@ steps:
     Params:
       action: start
       replicasPerProbe: {{AddInt 2 (DivideInt .Nodes 100)}}
+      threshold: 1000ms
   - Identifier: DnsLookupLatency
     Method: DnsLookupLatency
     Params:


### PR DESCRIPTION
Test will fail if the latency exceeds the threshold.