### PR TITLE
Add "etcd_operation" and "etcd_type" variables to Grafana dashboard

### DIFF
--- a/clusterloader2/pkg/prometheus/manifests/dashboards/master-dashboard.json
+++ b/clusterloader2/pkg/prometheus/manifests/dashboards/master-dashboard.json
@@ -1101,7 +1101,7 @@
               "instant": false,
               "interval": "5s",
               "intervalFactor": 1,
-              "legendFormat": "",
+              "legendFormat": "{{instance}}",
               "metric": "",
               "refId": "",
               "step": 10,
@@ -1197,7 +1197,7 @@
               "instant": false,
               "interval": "5s",
               "intervalFactor": 1,
-              "legendFormat": "",
+              "legendFormat": "{{instance}}",
               "metric": "",
               "refId": "",
               "step": 10,
@@ -1288,12 +1288,12 @@
           "targets": [
             {
               "datasource": "",
-              "expr": "sum(rate(etcd_request_duration_seconds_count{operation=\"list\"}[1m])) by (type)",
+              "expr": "sum(rate(etcd_request_duration_seconds_count{operation=~\"${etcd_operation:regex}\", type=~\".*(${etcd_type:pipe})\"}[1m])) by (operation, type)",
               "format": "time_series",
               "instant": false,
               "interval": "5s",
               "intervalFactor": 1,
-              "legendFormat": "",
+              "legendFormat": "{{operation}} {{type}}",
               "metric": "",
               "refId": "",
               "step": 10,
@@ -1302,7 +1302,7 @@
           ],
           "timeFrom": null,
           "timeShift": null,
-          "title": "etcd lists rate",
+          "title": "etcd operations rate",
           "tooltip": {
             "msResolution": true,
             "shared": true,
@@ -1384,12 +1384,12 @@
           "targets": [
             {
               "datasource": "",
-              "expr": "sum(rate(etcd_request_duration_seconds_count[1m])) by (operation, type)",
+              "expr": "histogram_quantile(0.99, sum(rate(etcd_request_duration_seconds_bucket{operation=~\"${etcd_operation:regex}\", type=~\".*(${etcd_type:pipe})\"}[1m])) by (le, operation, type, instance))",
               "format": "time_series",
               "instant": false,
               "interval": "5s",
               "intervalFactor": 1,
-              "legendFormat": "",
+              "legendFormat": "{{operation}} {{type}} on {{instance}}",
               "metric": "",
               "refId": "",
               "step": 10,
@@ -1398,7 +1398,7 @@
           ],
           "timeFrom": null,
           "timeShift": null,
-          "title": "etcd operations rate",
+          "title": "etcd get latency by type (99th percentile)",
           "tooltip": {
             "msResolution": true,
             "shared": true,
@@ -1413,7 +1413,7 @@
           "yaxes": [
             {
               "decimals": null,
-              "format": "ops",
+              "format": "s",
               "label": null,
               "logBase": 1,
               "max": null,
@@ -1480,199 +1480,7 @@
           "targets": [
             {
               "datasource": "",
-              "expr": "histogram_quantile(0.99, sum(rate(etcd_request_duration_seconds_bucket{operation=\"get\", type=\"*coordination.Lease\"}[1m])) by (le, type, instance))",
-              "format": "time_series",
-              "instant": false,
-              "interval": "5s",
-              "intervalFactor": 1,
-              "legendFormat": "",
-              "metric": "",
-              "refId": "",
-              "step": 10,
-              "target": ""
-            }
-          ],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "etcd get lease latency by instance (99th percentile)",
-          "tooltip": {
-            "msResolution": true,
-            "shared": true,
-            "sort": 2,
-            "value_type": "cumulative"
-          },
-          "transparent": false,
-          "type": "graph",
-          "xaxis": {
-            "show": true
-          },
-          "yaxes": [
-            {
-              "decimals": null,
-              "format": "s",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": 0,
-              "show": true
-            },
-            {
-              "decimals": null,
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": 0,
-              "show": true
-            }
-          ]
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "datasource": "$source",
-          "description": null,
-          "editable": true,
-          "error": false,
-          "fill": 1,
-          "grid": {
-            "threshold1": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2": null,
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
-          "id": 16,
-          "isNew": true,
-          "legend": {
-            "alignAsTable": false,
-            "avg": false,
-            "current": false,
-            "hideEmpty": false,
-            "hideZero": false,
-            "max": false,
-            "min": false,
-            "rightSide": false,
-            "show": true,
-            "sideWidth": null,
-            "sort": null,
-            "sortDesc": false,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 2,
-          "links": [],
-          "minSpan": null,
-          "nullPointMode": "connected",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "repeat": null,
-          "seriesOverrides": [],
-          "span": 12,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "datasource": "",
-              "expr": "histogram_quantile(0.99, sum(rate(etcd_request_duration_seconds_bucket{operation=\"get\"}[1m])) by (le, type))",
-              "format": "time_series",
-              "instant": false,
-              "interval": "5s",
-              "intervalFactor": 1,
-              "legendFormat": "",
-              "metric": "",
-              "refId": "",
-              "step": 10,
-              "target": ""
-            }
-          ],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "etcd get latency by type (99th percentile)",
-          "tooltip": {
-            "msResolution": true,
-            "shared": true,
-            "sort": 2,
-            "value_type": "cumulative"
-          },
-          "transparent": false,
-          "type": "graph",
-          "xaxis": {
-            "show": true
-          },
-          "yaxes": [
-            {
-              "decimals": null,
-              "format": "s",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": 0,
-              "show": true
-            },
-            {
-              "decimals": null,
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": 0,
-              "show": true
-            }
-          ]
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "datasource": "$source",
-          "description": null,
-          "editable": true,
-          "error": false,
-          "fill": 1,
-          "grid": {
-            "threshold1": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2": null,
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
-          "id": 17,
-          "isNew": true,
-          "legend": {
-            "alignAsTable": false,
-            "avg": false,
-            "current": false,
-            "hideEmpty": false,
-            "hideZero": false,
-            "max": false,
-            "min": false,
-            "rightSide": false,
-            "show": true,
-            "sideWidth": null,
-            "sort": null,
-            "sortDesc": false,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 2,
-          "links": [],
-          "minSpan": null,
-          "nullPointMode": "connected",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "repeat": null,
-          "seriesOverrides": [],
-          "span": 12,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "datasource": "",
-              "expr": "histogram_quantile(0.50, sum(rate(etcd_request_duration_seconds_bucket{operation=\"get\"}[1m])) by (le, type))",
+              "expr": "histogram_quantile(0.50, sum(rate(etcd_request_duration_seconds_bucket{operation=~\"${etcd_operation:regex}\", type=~\".*(${etcd_type:pipe})\"}[1m])) by (le, operation, type, instance))",
               "format": "time_series",
               "instant": false,
               "interval": "5s",
@@ -1733,7 +1541,7 @@
             "threshold2": null,
             "threshold2Color": "rgba(234, 112, 112, 0.22)"
           },
-          "id": 18,
+          "id": 16,
           "isNew": true,
           "legend": {
             "alignAsTable": false,
@@ -1829,7 +1637,7 @@
             "threshold2": null,
             "threshold2Color": "rgba(234, 112, 112, 0.22)"
           },
-          "id": 19,
+          "id": 17,
           "isNew": true,
           "legend": {
             "alignAsTable": false,
@@ -1925,7 +1733,7 @@
             "threshold2": null,
             "threshold2Color": "rgba(234, 112, 112, 0.22)"
           },
-          "id": 20,
+          "id": 18,
           "isNew": true,
           "legend": {
             "alignAsTable": false,
@@ -2021,7 +1829,7 @@
             "threshold2": null,
             "threshold2Color": "rgba(234, 112, 112, 0.22)"
           },
-          "id": 21,
+          "id": 19,
           "isNew": true,
           "legend": {
             "alignAsTable": false,
@@ -2117,7 +1925,7 @@
             "threshold2": null,
             "threshold2Color": "rgba(234, 112, 112, 0.22)"
           },
-          "id": 22,
+          "id": 20,
           "isNew": true,
           "legend": {
             "alignAsTable": false,
@@ -2213,7 +2021,7 @@
             "threshold2": null,
             "threshold2Color": "rgba(234, 112, 112, 0.22)"
           },
-          "id": 23,
+          "id": 21,
           "isNew": true,
           "legend": {
             "alignAsTable": false,
@@ -2309,7 +2117,7 @@
             "threshold2": null,
             "threshold2Color": "rgba(234, 112, 112, 0.22)"
           },
-          "id": 24,
+          "id": 22,
           "isNew": true,
           "legend": {
             "alignAsTable": false,
@@ -2405,7 +2213,7 @@
             "threshold2": null,
             "threshold2Color": "rgba(234, 112, 112, 0.22)"
           },
-          "id": 25,
+          "id": 23,
           "isNew": true,
           "legend": {
             "alignAsTable": false,
@@ -2501,7 +2309,7 @@
             "threshold2": null,
             "threshold2Color": "rgba(234, 112, 112, 0.22)"
           },
-          "id": 26,
+          "id": 24,
           "isNew": true,
           "legend": {
             "alignAsTable": false,
@@ -2597,7 +2405,7 @@
             "threshold2": null,
             "threshold2Color": "rgba(234, 112, 112, 0.22)"
           },
-          "id": 27,
+          "id": 25,
           "isNew": true,
           "legend": {
             "alignAsTable": false,
@@ -2729,7 +2537,7 @@
             "threshold2": null,
             "threshold2Color": "rgba(234, 112, 112, 0.22)"
           },
-          "id": 28,
+          "id": 26,
           "isNew": true,
           "legend": {
             "alignAsTable": false,
@@ -2825,7 +2633,7 @@
             "threshold2": null,
             "threshold2Color": "rgba(234, 112, 112, 0.22)"
           },
-          "id": 29,
+          "id": 27,
           "isNew": true,
           "legend": {
             "alignAsTable": false,
@@ -2921,7 +2729,7 @@
             "threshold2": null,
             "threshold2Color": "rgba(234, 112, 112, 0.22)"
           },
-          "id": 30,
+          "id": 28,
           "isNew": true,
           "legend": {
             "alignAsTable": false,
@@ -3017,7 +2825,7 @@
             "threshold2": null,
             "threshold2Color": "rgba(234, 112, 112, 0.22)"
           },
-          "id": 31,
+          "id": 29,
           "isNew": true,
           "legend": {
             "alignAsTable": false,
@@ -3113,7 +2921,7 @@
             "threshold2": null,
             "threshold2Color": "rgba(234, 112, 112, 0.22)"
           },
-          "id": 32,
+          "id": 30,
           "isNew": true,
           "legend": {
             "alignAsTable": false,
@@ -3209,7 +3017,7 @@
             "threshold2": null,
             "threshold2Color": "rgba(234, 112, 112, 0.22)"
           },
-          "id": 33,
+          "id": 31,
           "isNew": true,
           "legend": {
             "alignAsTable": false,
@@ -3305,7 +3113,7 @@
             "threshold2": null,
             "threshold2Color": "rgba(234, 112, 112, 0.22)"
           },
-          "id": 34,
+          "id": 32,
           "isNew": true,
           "legend": {
             "alignAsTable": false,
@@ -3401,7 +3209,7 @@
             "threshold2": null,
             "threshold2Color": "rgba(234, 112, 112, 0.22)"
           },
-          "id": 35,
+          "id": 33,
           "isNew": true,
           "legend": {
             "alignAsTable": false,
@@ -3497,7 +3305,7 @@
             "threshold2": null,
             "threshold2Color": "rgba(234, 112, 112, 0.22)"
           },
-          "id": 36,
+          "id": 34,
           "isNew": true,
           "legend": {
             "alignAsTable": false,
@@ -3593,7 +3401,7 @@
             "threshold2": null,
             "threshold2Color": "rgba(234, 112, 112, 0.22)"
           },
-          "id": 37,
+          "id": 35,
           "isNew": true,
           "legend": {
             "alignAsTable": false,
@@ -3689,7 +3497,7 @@
             "threshold2": null,
             "threshold2Color": "rgba(234, 112, 112, 0.22)"
           },
-          "id": 38,
+          "id": 36,
           "isNew": true,
           "legend": {
             "alignAsTable": false,
@@ -3785,7 +3593,7 @@
             "threshold2": null,
             "threshold2Color": "rgba(234, 112, 112, 0.22)"
           },
-          "id": 39,
+          "id": 37,
           "isNew": true,
           "legend": {
             "alignAsTable": false,
@@ -3881,7 +3689,7 @@
             "threshold2": null,
             "threshold2Color": "rgba(234, 112, 112, 0.22)"
           },
-          "id": 40,
+          "id": 38,
           "isNew": true,
           "legend": {
             "alignAsTable": false,
@@ -3977,7 +3785,7 @@
             "threshold2": null,
             "threshold2Color": "rgba(234, 112, 112, 0.22)"
           },
-          "id": 41,
+          "id": 39,
           "isNew": true,
           "legend": {
             "alignAsTable": false,
@@ -4083,7 +3891,7 @@
             "threshold2": null,
             "threshold2Color": "rgba(234, 112, 112, 0.22)"
           },
-          "id": 42,
+          "id": 40,
           "isNew": true,
           "legend": {
             "alignAsTable": false,
@@ -4189,7 +3997,7 @@
             "threshold2": null,
             "threshold2Color": "rgba(234, 112, 112, 0.22)"
           },
-          "id": 43,
+          "id": 41,
           "isNew": true,
           "legend": {
             "alignAsTable": false,
@@ -4285,7 +4093,7 @@
             "threshold2": null,
             "threshold2Color": "rgba(234, 112, 112, 0.22)"
           },
-          "id": 44,
+          "id": 42,
           "isNew": true,
           "legend": {
             "alignAsTable": false,
@@ -4381,7 +4189,7 @@
             "threshold2": null,
             "threshold2Color": "rgba(234, 112, 112, 0.22)"
           },
-          "id": 45,
+          "id": 43,
           "isNew": true,
           "legend": {
             "alignAsTable": false,
@@ -4477,7 +4285,7 @@
             "threshold2": null,
             "threshold2Color": "rgba(234, 112, 112, 0.22)"
           },
-          "id": 46,
+          "id": 44,
           "isNew": true,
           "legend": {
             "alignAsTable": false,
@@ -4573,7 +4381,7 @@
             "threshold2": null,
             "threshold2Color": "rgba(234, 112, 112, 0.22)"
           },
-          "id": 47,
+          "id": 45,
           "isNew": true,
           "legend": {
             "alignAsTable": false,
@@ -4682,7 +4490,7 @@
             "threshold2": null,
             "threshold2Color": "rgba(234, 112, 112, 0.22)"
           },
-          "id": 48,
+          "id": 46,
           "isNew": true,
           "legend": {
             "alignAsTable": false,
@@ -4791,7 +4599,7 @@
             "threshold2": null,
             "threshold2Color": "rgba(234, 112, 112, 0.22)"
           },
-          "id": 49,
+          "id": 47,
           "isNew": true,
           "legend": {
             "alignAsTable": false,
@@ -4900,7 +4708,7 @@
             "threshold2": null,
             "threshold2Color": "rgba(234, 112, 112, 0.22)"
           },
-          "id": 50,
+          "id": 48,
           "isNew": true,
           "legend": {
             "alignAsTable": false,
@@ -5009,7 +4817,7 @@
             "threshold2": null,
             "threshold2Color": "rgba(234, 112, 112, 0.22)"
           },
-          "id": 51,
+          "id": 49,
           "isNew": true,
           "legend": {
             "alignAsTable": false,
@@ -5118,7 +4926,7 @@
             "threshold2": null,
             "threshold2Color": "rgba(234, 112, 112, 0.22)"
           },
-          "id": 52,
+          "id": 50,
           "isNew": true,
           "legend": {
             "alignAsTable": false,
@@ -5227,7 +5035,7 @@
             "threshold2": null,
             "threshold2Color": "rgba(234, 112, 112, 0.22)"
           },
-          "id": 53,
+          "id": 51,
           "isNew": true,
           "legend": {
             "alignAsTable": false,
@@ -5368,6 +5176,52 @@
         "tagValuesQuery": null,
         "tagsQuery": null,
         "type": "datasource",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "tags": [],
+          "text": null,
+          "value": null
+        },
+        "datasource": "$source",
+        "hide": 0,
+        "includeAll": true,
+        "label": null,
+        "multi": true,
+        "name": "etcd_type",
+        "options": [],
+        "query": "label_values(etcd_request_duration_seconds_count, type)",
+        "refresh": 1,
+        "regex": "\\*\\[+\\]+(.*)",
+        "sort": 1,
+        "tagValuesQuery": null,
+        "tagsQuery": null,
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "tags": [],
+          "text": null,
+          "value": null
+        },
+        "datasource": "$source",
+        "hide": 0,
+        "includeAll": true,
+        "label": null,
+        "multi": true,
+        "name": "etcd_operation",
+        "options": [],
+        "query": "label_values(etcd_request_duration_seconds_count, operation)",
+        "refresh": 1,
+        "regex": null,
+        "sort": 1,
+        "tagValuesQuery": null,
+        "tagsQuery": null,
+        "type": "query",
         "useTags": false
       }
     ]


### PR DESCRIPTION
This should ease querying and allows to remove some dedicated graphs as they can be now easily substituted. 