### PR TITLE
Change checkIfPodsAreUpdated default to true

### DIFF
--- a/clusterloader2/pkg/measurement/common/wait_for_controlled_pods.go
+++ b/clusterloader2/pkg/measurement/common/wait_for_controlled_pods.go
@@ -110,8 +110,7 @@ func (w *waitForControlledPodsRunningMeasurement) Execute(config *measurement.Me
 		if err != nil {
 			return nil, err
 		}
-		// TODO(mborsz): Change default to true.
-		w.checkIfPodsAreUpdated, err = util.GetBoolOrDefault(config.Params, "checkIfPodsAreUpdated", false)
+		w.checkIfPodsAreUpdated, err = util.GetBoolOrDefault(config.Params, "checkIfPodsAreUpdated", true)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
We should switch default WaitForControllerPodsRunning behavior to the right one: where we correctly distinguish updated pods from state ones.


The original change (https://github.com/kubernetes/perf-tests/pull/1035) has been merged 4 hours ago so maybe let's wait one more day before submitting this.
/hold