### PR TITLE
Migrate ListRuntimeObjectsForKind to use dynamic client

### DIFF
--- a/clusterloader2/pkg/measurement/common/wait_for_controlled_pods.go
+++ b/clusterloader2/pkg/measurement/common/wait_for_controlled_pods.go
@@ -368,7 +368,6 @@ func (w *waitForControlledPodsRunningMeasurement) getObjectCountAndMaxVersion() 
 	var desiredCount int
 	var maxResourceVersion uint64
 	objects, err := runtimeobjects.ListRuntimeObjectsForKind(
-		w.clusterFramework.GetClientSets().GetClient(),
 		w.clusterFramework.GetDynamicClients().GetClient(),
 		w.gvr, w.kind, w.selector.Namespace, w.selector.LabelSelector, w.selector.FieldSelector)
 	if err != nil {


### PR DESCRIPTION
In https://github.com/kubernetes/perf-tests/pull/1023 I implemented using dynamic client as a fallback and we agreed that ultimately we want to migrate all cases to dynamic client how it's done in other places.

/assign @wojtek-t 