### PR TITLE
clusterloader2: display extension points metrics

### DIFF
--- a/clusterloader2/pkg/measurement/common/scheduler_latency.go
+++ b/clusterloader2/pkg/measurement/common/scheduler_latency.go
@@ -19,6 +19,7 @@ package common
 import (
 	"context"
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 	"time"
@@ -38,11 +39,27 @@ import (
 const (
 	schedulerLatencyMetricName = "SchedulingMetrics"
 
-	e2eSchedulingDurationMetricName       = model.LabelValue(schedulermetric.SchedulerSubsystem + "_e2e_scheduling_duration_seconds_bucket")
-	schedulingAlgorithmDurationMetricName = model.LabelValue(schedulermetric.SchedulerSubsystem + "_scheduling_algorithm_duration_seconds_bucket")
+	e2eSchedulingDurationMetricName           = model.LabelValue(schedulermetric.SchedulerSubsystem + "_e2e_scheduling_duration_seconds_bucket")
+	schedulingAlgorithmDurationMetricName     = model.LabelValue(schedulermetric.SchedulerSubsystem + "_scheduling_algorithm_duration_seconds_bucket")
+	frameworkExtensionPointDurationMetricName = model.LabelValue(schedulermetric.SchedulerSubsystem + "_framework_extension_point_duration_seconds_bucket")
+	schedulingLatencyMetricName               = model.LabelValue(schedulermetric.SchedulerSubsystem + "_" + schedulermetric.DeprecatedSchedulingDurationName)
 
-	schedulingLatencyMetricName = model.LabelValue(schedulermetric.SchedulerSubsystem + "_" + schedulermetric.DeprecatedSchedulingDurationName)
-	singleRestCallTimeout       = 5 * time.Minute
+	singleRestCallTimeout = 5 * time.Minute
+)
+
+var (
+	extentionsPoints = []string{
+		"PreFilter",
+		"Filter",
+		"PreScore",
+		"Score",
+		"PreBind",
+		"Bind",
+		"PostBind",
+		"Reserve",
+		"Unreserve",
+		"Permit",
+	}
 )
 
 func init() {
@@ -129,7 +146,9 @@ func (s *schedulerLatencyMeasurement) resetSchedulerMetrics(c clientset.Interfac
 
 // Retrieves scheduler latency metrics.
 func (s *schedulerLatencyMeasurement) getSchedulingLatency(c clientset.Interface, host, provider, masterName string, masterRegistered bool) ([]measurement.Summary, error) {
-	result := schedulingMetrics{}
+	result := schedulingMetrics{
+		FrameworkExtensionPointDuration: make(map[string]*measurementutil.LatencyMetric),
+	}
 	data, err := s.sendRequestToScheduler(c, "GET", host, provider, masterName, masterRegistered)
 	if err != nil {
 		return nil, err
@@ -140,49 +159,59 @@ func (s *schedulerLatencyMeasurement) getSchedulingLatency(c clientset.Interface
 		return nil, err
 	}
 
-	e2eSchedulingMetricHist := measurementutil.NewHistogram(nil)
+	e2eSchedulingDurationHist := measurementutil.NewHistogram(nil)
 	schedulingAlgorithmDurationHist := measurementutil.NewHistogram(nil)
-	for _, sample := range samples {
-		if sample.Metric[model.MetricNameLabel] == e2eSchedulingDurationMetricName {
-			measurementutil.ConvertSampleToHistogram(sample, e2eSchedulingMetricHist)
-			continue
-		}
-		if sample.Metric[model.MetricNameLabel] == schedulingAlgorithmDurationMetricName {
-			measurementutil.ConvertSampleToHistogram(sample, schedulingAlgorithmDurationHist)
-			continue
-		}
-		if sample.Metric[model.MetricNameLabel] != schedulingLatencyMetricName {
-			continue
-		}
 
-		var metric *measurementutil.LatencyMetric
-		switch sample.Metric[schedulermetric.OperationLabel] {
-		case schedulermetric.PredicateEvaluation:
-			metric = &result.PredicateEvaluationLatency
-		case schedulermetric.PriorityEvaluation:
-			metric = &result.PriorityEvaluationLatency
-		case schedulermetric.PreemptionEvaluation:
-			metric = &result.PreemptionEvaluationLatency
-		case schedulermetric.Binding:
-			metric = &result.BindingLatency
-		}
-
-		if metric == nil {
-			continue
-		}
-
-		quantile, err := strconv.ParseFloat(string(sample.Metric[model.QuantileLabel]), 64)
-		if err != nil {
-			return nil, err
-		}
-		metric.SetQuantile(quantile, time.Duration(int64(float64(sample.Value)*float64(time.Second))))
+	frameworkExtensionPointDurationHist := make(map[string]*measurementutil.Histogram)
+	for _, ePoint := range extentionsPoints {
+		frameworkExtensionPointDurationHist[ePoint] = measurementutil.NewHistogram(nil)
+		result.FrameworkExtensionPointDuration[ePoint] = &measurementutil.LatencyMetric{}
 	}
 
-	if err := s.setQuantileFromHistogram(&result.E2eSchedulingLatency, e2eSchedulingMetricHist); err != nil {
+	for _, sample := range samples {
+		switch sample.Metric[model.MetricNameLabel] {
+		case e2eSchedulingDurationMetricName:
+			measurementutil.ConvertSampleToHistogram(sample, e2eSchedulingDurationHist)
+		case schedulingAlgorithmDurationMetricName:
+			measurementutil.ConvertSampleToHistogram(sample, schedulingAlgorithmDurationHist)
+		case frameworkExtensionPointDurationMetricName:
+			ePoint := string(sample.Metric["extension_point"])
+			if _, exists := frameworkExtensionPointDurationHist[ePoint]; exists {
+				measurementutil.ConvertSampleToHistogram(sample, frameworkExtensionPointDurationHist[ePoint])
+			}
+		case schedulingLatencyMetricName:
+			var metric *measurementutil.LatencyMetric
+			switch sample.Metric[schedulermetric.OperationLabel] {
+			case schedulermetric.PredicateEvaluation:
+				metric = &result.PredicateEvaluationLatency
+			case schedulermetric.PriorityEvaluation:
+				metric = &result.PriorityEvaluationLatency
+			case schedulermetric.PreemptionEvaluation:
+				metric = &result.PreemptionEvaluationLatency
+			case schedulermetric.Binding:
+				metric = &result.BindingLatency
+			}
+			if metric != nil {
+				quantile, err := strconv.ParseFloat(string(sample.Metric[model.QuantileLabel]), 64)
+				if err != nil {
+					return nil, err
+				}
+				metric.SetQuantile(quantile, time.Duration(int64(float64(sample.Value)*float64(time.Second))))
+			}
+		}
+	}
+
+	if err := s.setQuantileFromHistogram(&result.E2eSchedulingLatency, e2eSchedulingDurationHist); err != nil {
 		return nil, err
 	}
 	if err := s.setQuantileFromHistogram(&result.SchedulingLatency, schedulingAlgorithmDurationHist); err != nil {
 		return nil, err
+	}
+
+	for _, ePoint := range extentionsPoints {
+		if err := s.setQuantileFromHistogram(result.FrameworkExtensionPointDuration[ePoint], frameworkExtensionPointDurationHist[ePoint]); err != nil {
+			return nil, err
+		}
 	}
 
 	content, err := util.PrettyPrintJSON(result)
@@ -201,7 +230,11 @@ func (s *schedulerLatencyMeasurement) setQuantileFromHistogram(metric *measureme
 		if err != nil {
 			return err
 		}
-		metric.SetQuantile(quantile, time.Duration(int64(histQuantile*float64(time.Second))))
+		// NaN is returned only when there are less than two buckets.
+		// In which case all quantiles are NaN and all latency metrics are untouched.
+		if !math.IsNaN(histQuantile) {
+			metric.SetQuantile(quantile, time.Duration(int64(histQuantile*float64(time.Second))))
+		}
 	}
 
 	return nil
@@ -245,10 +278,13 @@ func (s *schedulerLatencyMeasurement) sendRequestToScheduler(c clientset.Interfa
 }
 
 type schedulingMetrics struct {
-	PredicateEvaluationLatency  measurementutil.LatencyMetric `json:"predicateEvaluationLatency"`
-	PriorityEvaluationLatency   measurementutil.LatencyMetric `json:"priorityEvaluationLatency"`
+	PredicateEvaluationLatency measurementutil.LatencyMetric `json:"predicateEvaluationLatency"`
+	PriorityEvaluationLatency  measurementutil.LatencyMetric `json:"priorityEvaluationLatency"`
+	BindingLatency             measurementutil.LatencyMetric `json:"bindingLatency"`
+
+	FrameworkExtensionPointDuration map[string]*measurementutil.LatencyMetric `json:"frameworkExtensionPointDuration"`
+
 	PreemptionEvaluationLatency measurementutil.LatencyMetric `json:"preemptionEvaluationLatency"`
-	BindingLatency              measurementutil.LatencyMetric `json:"bindingLatency"`
 	E2eSchedulingLatency        measurementutil.LatencyMetric `json:"e2eSchedulingLatency"`
 
 	// To track scheduling latency without binding, this allows to easier present the ceiling of the scheduler throughput.

--- a/clusterloader2/vendor/vendor.json
+++ b/clusterloader2/vendor/vendor.json
@@ -2768,10 +2768,10 @@
 			"revisionTime": "2020-02-13T22:13:11Z"
 		},
 		{
-			"checksumSHA1": "PZpJx8QjvJ+8AaJk7X75grYjdbo=",
+			"checksumSHA1": "tYhijn6reqc1ZeBGfT6Gz5a8u4Q=",
 			"path": "k8s.io/component-base/metrics/testutil",
-			"revision": "52da27f0465b85ae877364eda9b9195cbc9d5d2c",
-			"revisionTime": "2020-02-13T22:13:11Z"
+			"revision": "be09e7a8fe3f71c28d3e9acfb11578cda8ad1d64",
+			"revisionTime": "2020-04-02T03:50:37Z"
 		},
 		{
 			"checksumSHA1": "BkvIW5ZCT/Cx62qq/9zdeiGYPc4=",

--- a/perfdash/parser.go
+++ b/perfdash/parser.go
@@ -32,6 +32,21 @@ import (
 	"k8s.io/kubernetes/test/e2e/perftype"
 )
 
+var (
+	extentionsPoints = []string{
+		"PreFilter",
+		"Filter",
+		"PreScore",
+		"Score",
+		"PreBind",
+		"Bind",
+		"PostBind",
+		"Reserve",
+		"Unreserve",
+		"Permit",
+	}
+)
+
 func stripCount(data *perftype.DataItem) {
 	delete(data.Labels, "Count")
 }
@@ -256,6 +271,8 @@ type schedulingMetrics struct {
 	ThroughputPerc50            float64       `json:"throughputPerc50"`
 	ThroughputPerc90            float64       `json:"throughputPerc90"`
 	ThroughputPerc99            float64       `json:"throughputPerc99"`
+
+	FrameworkExtensionPointDuration map[string]latencyMetric `json:"frameworkExtensionPointDuration"`
 }
 
 func parseOperationLatency(latency latencyMetric, operationName string) perftype.DataItem {
@@ -286,6 +303,11 @@ func parseSchedulingLatency(data []byte, buildNumber int, testResult *BuildData)
 	testResult.Builds[build] = append(testResult.Builds[build], e2eScheduling)
 	scheduling := parseOperationLatency(obj.SchedulingLatency, "scheduling")
 	testResult.Builds[build] = append(testResult.Builds[build], scheduling)
+
+	for _, ePoint := range extentionsPoints {
+		frameworkExtensionPointDuration := parseOperationLatency(obj.FrameworkExtensionPointDuration[ePoint], fmt.Sprintf("extension_point_duration_%v_latency", strings.ToLower(ePoint)))
+		testResult.Builds[build] = append(testResult.Builds[build], frameworkExtensionPointDuration)
+	}
 }
 
 type schedulingThroughputMetric struct {


### PR DESCRIPTION
Collecting the following extension points:
- PreFilter
- PreFilterExtensionAddPod
- PreFilterExtensionRemovePod
- Filter
- PreScore
- Score
- ScoreExtensionNormalize
- PreBind
- Bind
- PostBind
- Reserve
- Unreserve
- Permit

As per https://github.com/kubernetes/perf-tests/issues/1074#issuecomment-589963229