### PR TITLE
clusterloader2: collect scheduling_algorithm_duration_seconds to see algorithm latency without binding

### DIFF
--- a/clusterloader2/vendor/vendor.json
+++ b/clusterloader2/vendor/vendor.json
@@ -2966,10 +2966,10 @@
 			"revisionTime": "2019-01-30T13:32:55Z"
 		},
 		{
-			"checksumSHA1": "qk53SHqnC2UqDtJ5IqyX2P7kd7k=",
+			"checksumSHA1": "itPwGUss3QQORDq9CuLllvHtjl0=",
 			"path": "k8s.io/kubernetes/pkg/scheduler/metrics",
-			"revision": "48ddf3be87789c92e6824c9ce536c76d008f5c19",
-			"revisionTime": "2019-11-12T09:10:07Z"
+			"revision": "aaca31c35e6f3ff66c24c22ce759eca0863efd51",
+			"revisionTime": "2020-02-27T08:15:46Z"
 		},
 		{
 			"checksumSHA1": "BPA+HgAgf1dzkl3tlDAnbcccl0g=",

--- a/perfdash/parser.go
+++ b/perfdash/parser.go
@@ -251,6 +251,7 @@ type schedulingMetrics struct {
 	PreemptionEvaluationLatency latencyMetric `json:"preemptionEvaluationLatency"`
 	BindingLatency              latencyMetric `json:"bindingLatency"`
 	E2eSchedulingLatency        latencyMetric `json:"e2eSchedulingLatency"`
+	SchedulingLatency           latencyMetric `json:"schedulingLatency"`
 	ThroughputAverage           float64       `json:"throughputAverage"`
 	ThroughputPerc50            float64       `json:"throughputPerc50"`
 	ThroughputPerc90            float64       `json:"throughputPerc90"`
@@ -283,6 +284,8 @@ func parseSchedulingLatency(data []byte, buildNumber int, testResult *BuildData)
 	testResult.Builds[build] = append(testResult.Builds[build], binding)
 	e2eScheduling := parseOperationLatency(obj.E2eSchedulingLatency, "e2eScheduling")
 	testResult.Builds[build] = append(testResult.Builds[build], e2eScheduling)
+	scheduling := parseOperationLatency(obj.SchedulingLatency, "scheduling")
+	testResult.Builds[build] = append(testResult.Builds[build], scheduling)
 }
 
 type schedulingThroughputMetric struct {


### PR DESCRIPTION
Also, update vendored `k8s.io/kubernetes/pkg/scheduler/metrics`.