### PR TITLE
perfdash: display metrics from ci-benchmark-scheduler-perf-master

### DIFF
--- a/perfdash/config.go
+++ b/perfdash/config.go
@@ -298,6 +298,15 @@ var (
 				OutputFilePrefix: "BenchmarkResults",
 				Parser:           parsePerfData,
 			}},
+			"BenchmarkPerfResults": []TestDescription{{
+				// Expected file prefix string is constructed as
+				// OutputFilePrefix+"_"+Name. Given we currently generate
+				// file prefixed with "BenchmarkPerfScheduling_" followed by a date,
+				// set the Name to an empty string.
+				Name:             "",
+				OutputFilePrefix: "BenchmarkPerfScheduling",
+				Parser:           parsePerfData,
+			}},
 		},
 	}
 


### PR DESCRIPTION
Time to display collected metrics from test/integration/scheduler_perf.

Jenkins Job: https://github.com/kubernetes/test-infra/pull/16421

Fixes: https://github.com/kubernetes/kubernetes/issues/86972