### PR TITLE
Disable Go modules in perfdash make targets.

### DIFF
--- a/perfdash/Makefile
+++ b/perfdash/Makefile
@@ -4,7 +4,7 @@ all: push
 TAG = 2.20
 
 REPO = gcr.io/k8s-testimages
-GODEP = CGO_ENABLED=0 GOOS=linux godep
+GODEP = CGO_ENABLED=0 GOOS=linux GO111MODULE=off godep
 
 test: perfdash.go parser.go config.go downloader.go google-gcs-downloader.go
 	${GODEP} go test


### PR DESCRIPTION
Go modules need to be explicitly disabled, as in newer Go versions, they are enabled by default. Perfdash won't build with Go modules enabled. 

/assign @mm4tt 