### PR TITLE
Add measurement to collect windows node cpu usage per process

### DIFF
--- a/clusterloader2/pkg/measurement/common/slos/windows_node_resource_usage.go
+++ b/clusterloader2/pkg/measurement/common/slos/windows_node_resource_usage.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package slos
+
+import (
+	"math"
+	"time"
+
+	"github.com/prometheus/common/model"
+	"k8s.io/klog"
+	"k8s.io/perf-tests/clusterloader2/pkg/measurement"
+	measurementutil "k8s.io/perf-tests/clusterloader2/pkg/measurement/util"
+	"k8s.io/perf-tests/clusterloader2/pkg/util"
+)
+
+const (
+	windowsResourceUsagePrometheusMeasurementName = "WindowsResourceUsagePrometheus"
+	// get top 10 non-system processes with highest cpu usage within 1min query window size
+	cpuUsageQueryTop10                        = `topk(10, sum by (process) (rate(wmi_process_cpu_time_total{process!~"Idle|Total|System"}[1m]) / on(job) group_left wmi_cs_logical_processors) * 100)`
+	currentWindowsResourceUsageMetricsVersion = "v1"
+)
+
+type windowsResourceUsageGatherer struct{}
+
+func (w *windowsResourceUsageGatherer) IsEnabled(config *measurement.MeasurementConfig) bool {
+	return true
+}
+
+func (w *windowsResourceUsageGatherer) String() string {
+	return windowsResourceUsagePrometheusMeasurementName
+}
+
+func init() {
+	create := func() measurement.Measurement { return createPrometheusMeasurement(&windowsResourceUsageGatherer{}) }
+	if err := measurement.Register(windowsResourceUsagePrometheusMeasurementName, create); err != nil {
+		klog.Fatalf("Cannot register %s: %v", windowsResourceUsagePrometheusMeasurementName, err)
+	}
+}
+
+func convertToPerfData(samples []*model.Sample) *measurementutil.PerfData {
+	perfData := &measurementutil.PerfData{Version: currentWindowsResourceUsageMetricsVersion}
+	for _, sample := range samples {
+		item := measurementutil.DataItem{
+			Data: map[string]float64{
+				"CPU_Usage": math.Round(float64(sample.Value)*100) / 100,
+			},
+			Unit: "%",
+			Labels: map[string]string{
+				"Process": string(sample.Metric["process"]),
+			},
+		}
+		perfData.DataItems = append(perfData.DataItems, item)
+	}
+	return perfData
+}
+
+// Gather gathers the metrics and convert to json summary
+func (w *windowsResourceUsageGatherer) Gather(executor QueryExecutor, startTime time.Time, config *measurement.MeasurementConfig) (measurement.Summary, error) {
+	samples, err := executor.Query(cpuUsageQueryTop10, time.Now())
+	if err != nil {
+		return nil, err
+	}
+	content, err := util.PrettyPrintJSON(convertToPerfData(samples))
+	if err != nil {
+		return nil, err
+	}
+	summaryName, err := util.GetStringOrDefault(config.Params, "summaryName", windowsResourceUsagePrometheusMeasurementName)
+	if err != nil {
+		return nil, err
+	}
+	summary := measurement.CreateSummary(summaryName, "json", content)
+	return summary, nil
+}

--- a/clusterloader2/pkg/prometheus/gce_windows_util.go
+++ b/clusterloader2/pkg/prometheus/gce_windows_util.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package prometheus
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog"
+	"k8s.io/perf-tests/clusterloader2/pkg/config"
+	"k8s.io/perf-tests/clusterloader2/pkg/framework/client"
+)
+
+// gceNode is a struct storing gce node info
+type gceNode struct {
+	projectID string
+	zone      string
+	nodeName  string
+}
+
+func setUpWindowsNodeAndTemplate(k8sClient kubernetes.Interface, mapping map[string]interface{}) error {
+	// Get the gce windows node info
+	windowsNode, err := getGceWindowsNodeFromKubernetesService(k8sClient)
+	if err != nil {
+		return err
+	}
+	// Install the wmi exporter onto windows node
+	if err := installWmiExporter(k8sClient, windowsNode, mapping); err != nil {
+		return err
+	}
+	mapping["WINDOWS_NODE_NAME"] = windowsNode.nodeName
+	mapping["PROMETHEUS_SCRAPE_WINDOWS_NODES"] = true
+	return nil
+}
+
+func isWindowsNodeScrapingEnabled(mapping map[string]interface{}, clusterLoaderConfig *config.ClusterLoaderConfig) bool {
+	if windowsNodeTest, exists := mapping["WINDOWS_NODE_TEST"]; exists && windowsNodeTest.(bool) && clusterLoaderConfig.ClusterConfig.Provider == "gce" {
+		return true
+	}
+	return false
+}
+
+func installWmiExporter(k8sClient kubernetes.Interface, windowsNode *gceNode, mapping map[string]interface{}) error {
+	wmiExporterURL, ok := mapping["WMI_EXPORTER_URL"]
+	if !ok {
+		return fmt.Errorf("missing setting up wmi exporter download url")
+	}
+	wmiExporterCollectors, ok := mapping["WMI_EXPORTER_ENABLED_COLLECTORS"]
+	if !ok {
+		return fmt.Errorf("missing setting up wmi exporter enabled collectors")
+	}
+	// Tried executing the invoke-webrequest cmd directly in gcloud ssh bash, but get this error:
+	// 		invoke-webrequest : Win32 internal error "Access is denied" 0x5 occurred while reading the console output buffer.
+	// 		Contact Microsoft Customer Support Services.
+	// After wrap it up in script block, it works well, also support timeout setting.
+	installWmiCmdTemplate := `Start-Job -Name InstallWmiExporter -ScriptBlock {invoke-webrequest -uri %s -outfile C:\wmi_exporter.msi; Start-Process msiexec.exe -Wait -ArgumentList '/I C:\wmi_exporter.msi ENABLED_COLLECTORS=%s LISTEN_PORT=5000 /quiet'}; Wait-Job -Timeout 300 -Name InstallWmiExporter`
+	installWmiExporterCmd := fmt.Sprintf(installWmiCmdTemplate, wmiExporterURL, wmiExporterCollectors)
+	powershellCmd := fmt.Sprintf(`powershell.exe -Command "%s"`, installWmiExporterCmd)
+	if windowsNode == nil {
+		return fmt.Errorf("no windows nodes available to install wmi exporter")
+	}
+	klog.Infof("Installing wmi exporter onto projectId: %s, zone: %s, nodeName: %s with cmd: %s", windowsNode.projectID, windowsNode.zone, windowsNode.nodeName, installWmiExporterCmd)
+	cmd := exec.Command("gcloud", "compute", "ssh", "--project", windowsNode.projectID, "--zone", windowsNode.zone, windowsNode.nodeName, "--command", powershellCmd)
+	err := cmd.Run()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func getGceWindowsNodeFromKubernetesService(k8sClient kubernetes.Interface) (*gceNode, error) {
+	var nodeList *corev1.NodeList
+	f := func() error {
+		var err error
+		nodeList, err = k8sClient.CoreV1().Nodes().List(metav1.ListOptions{LabelSelector: "kubernetes.io/os=windows"})
+		return err
+	}
+
+	if err := client.RetryWithExponentialBackOff(client.RetryFunction(f)); err != nil {
+		return nil, err
+	}
+
+	if len(nodeList.Items) == 0 {
+		return nil, fmt.Errorf("no windows nodes available in kubernetes service")
+	}
+	// TODO: Modify to support multiple windows nodes soon.
+	providerStrs := strings.Split(nodeList.Items[0].Spec.ProviderID, "/")
+	if len(providerStrs) < 5 {
+		return nil, fmt.Errorf("no valid gce provider ID available")
+	}
+
+	// Gce providerID format: gce://{projectID}/{zone}/{nodeName}
+	return &gceNode{
+		projectID: providerStrs[2],
+		zone:      providerStrs[3],
+		nodeName:  providerStrs[4],
+	}, nil
+}

--- a/clusterloader2/pkg/prometheus/manifests/prometheus-prometheus.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/prometheus-prometheus.yaml
@@ -1,4 +1,5 @@
 {{$PROMETHEUS_SCRAPE_KUBELETS := DefaultParam .PROMETHEUS_SCRAPE_KUBELETS false}}
+{{$PROMETHEUS_SCRAPE_WINDOWS_NODES := DefaultParam .PROMETHEUS_SCRAPE_WINDOWS_NODES false}}
 
 apiVersion: monitoring.coreos.com/v1
 kind: Prometheus
@@ -47,3 +48,8 @@ spec:
             storage: {{MultiplyInt 10 (AddInt 1 (DivideInt .Nodes 1000))}}Gi
   query:
     maxSamples: 100000000
+  {{if $PROMETHEUS_SCRAPE_WINDOWS_NODES}}
+  additionalScrapeConfigs:
+    name: windows-scrape-configs
+    key: windows-scrape-configs.yaml
+  {{end}}

--- a/clusterloader2/pkg/prometheus/manifests/prometheus-windows-scrape-configs.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/prometheus-windows-scrape-configs.yaml
@@ -1,0 +1,12 @@
+{{$WINDOWS_NODE_NAME := DefaultParam .WINDOWS_NODE_NAME ""}}
+
+apiVersion: v1
+kind: Secret
+metadata:
+  namespace: monitoring
+  name: windows-scrape-configs
+stringData:
+  windows-scrape-configs.yaml: |-
+    - job_name: "monitoring/windows_static"
+      static_configs:
+      - targets: ["{{$WINDOWS_NODE_NAME}}:5000"]

--- a/clusterloader2/testing/node-throughput/config.yaml
+++ b/clusterloader2/testing/node-throughput/config.yaml
@@ -17,6 +17,12 @@ tuningSets:
     qps: {{$POD_THROUGHPUT}}
 steps:
 - measurements:
+  {{if $WINDOWS_NODE_TEST}}
+  - Identifier: WindowsResourceUsagePrometheus
+    Method: WindowsResourceUsagePrometheus
+    Params:
+      action: start
+  {{end}}
   - Identifier: APIResponsivenessPrometheusSimple
     Method: APIResponsivenessPrometheus
     Params:
@@ -55,6 +61,12 @@ steps:
     Method: WaitForControlledPodsRunning
     Params:
       action: gather
+  {{if $WINDOWS_NODE_TEST}}
+  - Identifier: WindowsResourceUsagePrometheus
+    Method: WindowsResourceUsagePrometheus
+    Params:
+      action: gather
+  {{end}}
 - phases:
   - namespaceRange:
       min: 1

--- a/clusterloader2/testing/node-throughput/windows_override.yaml
+++ b/clusterloader2/testing/node-throughput/windows_override.yaml
@@ -4,3 +4,5 @@ POD_THROUGHPUT: 0.03
 CONTAINER_IMAGE: gcr.io/gke-release/pause-win:1.1.0
 OPERATION_TIMEOUT: 90m
 POD_STARTUP_LATENCY_THRESHOLD: 60m
+WMI_EXPORTER_URL: "https://github.com/martinlindhe/wmi_exporter/releases/download/v0.10.1/wmi_exporter-0.10.1-amd64.msi"
+WMI_EXPORTER_ENABLED_COLLECTORS: "process,cs"


### PR DESCRIPTION
1. As windows server container doesn't support privileged containers, so to collect the cpu usage per process, have to install the [wmi_exporter](https://github.com/martinlindhe/wmi_exporter#installation) onto windows node using `gcloud ssh` command. As a result, this feature is only supported for GCE cluster.
2. Use the "[Additional Scrape configs](https://github.com/coreos/prometheus-operator/blob/master/Documentation/additional-scrape-config.md)" in prometheus-operator to scrape windows node.
3. Add a new measurement to collect the metrics once when all pods are running, as we want to find out if there's any noticeable high cpu usage process. Later on, we may change to calculate the percentiles during the test run and put it on perf-dash board.