### PR TITLE
clusterloader2: improve experience on aks

### DIFF
--- a/clusterloader2/cmd/clusterloader.go
+++ b/clusterloader2/cmd/clusterloader.go
@@ -144,10 +144,10 @@ func completeConfig(m *framework.MultiClientSet) error {
 		}
 	}
 	if clusterLoaderConfig.ClusterConfig.Provider != "aks" || clusterLoaderConfig.ClusterConfig.Provider != "gke" {
-		clusterLoaderConfig.ClusterConfig.IsSSHSupported = true
+		clusterLoaderConfig.ClusterConfig.IsSSHToMasterSupported = true
 	}
 	if clusterLoaderConfig.ClusterConfig.Provider != "aks" {
-		clusterLoaderConfig.ClusterConfig.IsPprofSupported = true
+		clusterLoaderConfig.ClusterConfig.IsAPIServerPprofExposed = true
 	}
 	return nil
 }

--- a/clusterloader2/cmd/clusterloader.go
+++ b/clusterloader2/cmd/clusterloader.go
@@ -147,7 +147,7 @@ func completeConfig(m *framework.MultiClientSet) error {
 		clusterLoaderConfig.ClusterConfig.IsSSHToMasterSupported = true
 	}
 	if clusterLoaderConfig.ClusterConfig.Provider != "aks" {
-		clusterLoaderConfig.ClusterConfig.IsAPIServerPprofExposed = true
+		clusterLoaderConfig.ClusterConfig.IsAPIServerPprofEnabled = true
 	}
 	return nil
 }

--- a/clusterloader2/cmd/clusterloader.go
+++ b/clusterloader2/cmd/clusterloader.go
@@ -143,8 +143,11 @@ func completeConfig(m *framework.MultiClientSet) error {
 			klog.Errorf("Getting master internal ip error: %v", err)
 		}
 	}
-	if clusterLoaderConfig.ClusterConfig.Provider == "aks" || clusterLoaderConfig.ClusterConfig.Provider == "gke" {
-		clusterLoaderConfig.ClusterConfig.IsSSHSupported = false
+	if clusterLoaderConfig.ClusterConfig.Provider != "aks" || clusterLoaderConfig.ClusterConfig.Provider != "gke" {
+		clusterLoaderConfig.ClusterConfig.IsSSHSupported = true
+	}
+	if clusterLoaderConfig.ClusterConfig.Provider != "aks" {
+		clusterLoaderConfig.ClusterConfig.IsPprofSupported = true
 	}
 	return nil
 }

--- a/clusterloader2/cmd/clusterloader.go
+++ b/clusterloader2/cmd/clusterloader.go
@@ -143,6 +143,9 @@ func completeConfig(m *framework.MultiClientSet) error {
 			klog.Errorf("Getting master internal ip error: %v", err)
 		}
 	}
+	if clusterLoaderConfig.ClusterConfig.Provider == "aks" || clusterLoaderConfig.ClusterConfig.Provider == "gke" {
+		clusterLoaderConfig.ClusterConfig.IsSSHSupported = false
+	}
 	return nil
 }
 

--- a/clusterloader2/pkg/config/cluster.go
+++ b/clusterloader2/pkg/config/cluster.go
@@ -43,9 +43,9 @@ type ClusterConfig struct {
 	// IsSSHToMasterSupported is false on some managed providers.
 	// Clusterloader will not attempt operations requiring SSH when this value is false, such as some metrics collection routines.
 	IsSSHToMasterSupported bool
-	// IsAPIServerPprofExposed is false for some managed providers.
-	// When IsAPIServerPprofExposed is false, clusterloader will avoid using using pprof to collect metrics.
-	IsAPIServerPprofExposed bool
+	// IsAPIServerPprofEnabled is false for some managed providers.
+	// When IsAPIServerPprofEnabled is false, clusterloader will avoid collecting kube-apiserver pprofs.
+	IsAPIServerPprofEnabled bool
 }
 
 // PrometheusConfig represents all flags used by prometheus.

--- a/clusterloader2/pkg/config/cluster.go
+++ b/clusterloader2/pkg/config/cluster.go
@@ -40,8 +40,12 @@ type ClusterConfig struct {
 	MasterName                 string
 	KubemarkRootKubeConfigPath string
 	DeleteStaleNamespaces      bool
-	IsSSHSupported             bool
-	IsPprofSupported           bool
+	// IsSSHToMasterSupported is false on some managed providers.
+	// Clusterloader will not attempt operations requiring SSH when this value is false, such as some metrics collection routines.
+	IsSSHToMasterSupported bool
+	// IsAPIServerPprofExposed is false for some managed providers.
+	// When IsAPIServerPprofExposed is false, clusterloader will avoid using using pprof to collect metrics.
+	IsAPIServerPprofExposed bool
 }
 
 // PrometheusConfig represents all flags used by prometheus.

--- a/clusterloader2/pkg/config/cluster.go
+++ b/clusterloader2/pkg/config/cluster.go
@@ -40,6 +40,7 @@ type ClusterConfig struct {
 	MasterName                 string
 	KubemarkRootKubeConfigPath string
 	DeleteStaleNamespaces      bool
+	IsSSHSupported             bool
 }
 
 // PrometheusConfig represents all flags used by prometheus.

--- a/clusterloader2/pkg/config/cluster.go
+++ b/clusterloader2/pkg/config/cluster.go
@@ -41,6 +41,7 @@ type ClusterConfig struct {
 	KubemarkRootKubeConfigPath string
 	DeleteStaleNamespaces      bool
 	IsSSHSupported             bool
+	IsPprofSupported           bool
 }
 
 // PrometheusConfig represents all flags used by prometheus.

--- a/clusterloader2/pkg/measurement/common/etcd_metrics.go
+++ b/clusterloader2/pkg/measurement/common/etcd_metrics.go
@@ -75,7 +75,7 @@ func (e *etcdMetricsMeasurement) Execute(config *measurement.MeasurementConfig) 
 	}
 
 	etcdInsecurePort := config.ClusterFramework.GetClusterConfig().EtcdInsecurePort
-	isSSHSupported := config.ClusterLoaderConfig.ClusterConfig.IsSSHSupported
+	isSSHSupported := config.ClusterFramework.GetClusterConfig().IsSSHSupported
 	switch action {
 	case "start":
 		klog.Infof("%s: starting etcd metrics collecting...", e)
@@ -186,7 +186,7 @@ func (e *etcdMetricsMeasurement) stopAndSummarize(host, provider string, port in
 func (e *etcdMetricsMeasurement) getEtcdMetrics(host, provider string, port int, isSSHSupported bool) ([]*model.Sample, error) {
 	// Etcd is only exposed on localhost level. We are using ssh method
 	if isSSHSupported {
-		klog.Infof("%s: not grabbing etcd metrics through master SSH: unsupported for provider", e, provider)
+		klog.Infof("%s: not grabbing etcd metrics through master SSH: unsupported for provider, %s", e, provider)
 		return nil, nil
 	}
 

--- a/clusterloader2/pkg/measurement/common/etcd_metrics.go
+++ b/clusterloader2/pkg/measurement/common/etcd_metrics.go
@@ -60,9 +60,8 @@ type etcdMetricsMeasurement struct {
 // - start - Starts collecting etcd metrics.
 // - gather - Gathers and prints etcd metrics summary.
 func (e *etcdMetricsMeasurement) Execute(config *measurement.MeasurementConfig) ([]measurement.Summary, error) {
-	isSSHSupported := config.ClusterFramework.GetClusterConfig().IsSSHSupported
 	// Etcd is only exposed on localhost level. We are using ssh method
-	if isSSHSupported {
+	if !config.ClusterFramework.GetClusterConfig().IsSSHToMasterSupported {
 		klog.Infof("not grabbing etcd metrics through master SSH: unsupported for provider, %s", config.ClusterFramework.GetClusterConfig().Provider)
 		return nil, nil
 	}

--- a/clusterloader2/pkg/measurement/common/etcd_metrics.go
+++ b/clusterloader2/pkg/measurement/common/etcd_metrics.go
@@ -184,7 +184,8 @@ func (e *etcdMetricsMeasurement) stopAndSummarize(host, provider string, port in
 
 func (e *etcdMetricsMeasurement) getEtcdMetrics(host, provider string, port int) ([]*model.Sample, error) {
 	// Etcd is only exposed on localhost level. We are using ssh method
-	if provider == "gke" {
+	// TODO(ace): --managed flag instead of provider switch?
+	if provider == "gke" || provider == "aks" {
 		klog.Infof("%s: not grabbing etcd metrics through master SSH: unsupported for gke", e)
 		return nil, nil
 	}

--- a/clusterloader2/pkg/measurement/common/profile.go
+++ b/clusterloader2/pkg/measurement/common/profile.go
@@ -187,6 +187,11 @@ func (p *profileMeasurement) gatherProfile(c clientset.Interface) ([]measurement
 	for _, host := range p.config.hosts {
 		profilePrefix := fmt.Sprintf("%s_%s_%s", host, p.config.componentName, p.name)
 
+		// ssh to collect profile metrics not supported on aks masters
+		if p.config.provider == "aks" {
+			return nil, nil
+		}
+
 		// Get the profile data over SSH.
 		// Start by checking that the provider allows us to do so.
 		if p.config.provider == "gke" || shouldGetAPIServerByK8sClient(p.config.componentName) {

--- a/clusterloader2/pkg/measurement/common/profile.go
+++ b/clusterloader2/pkg/measurement/common/profile.go
@@ -147,9 +147,9 @@ func (p *profileMeasurement) stop() {
 // Execute gathers memory profile of a given component.
 func (p *profileMeasurement) Execute(config *measurement.MeasurementConfig) ([]measurement.Summary, error) {
 	IsSSHToMasterSupported := config.ClusterFramework.GetClusterConfig().IsSSHToMasterSupported
-	IsAPIServerPprofExposed := config.ClusterFramework.GetClusterConfig().IsAPIServerPprofExposed
+	IsAPIServerPprofEnabled := config.ClusterFramework.GetClusterConfig().IsAPIServerPprofEnabled
 
-	if !IsSSHToMasterSupported && !IsAPIServerPprofExposed {
+	if !IsSSHToMasterSupported && !IsAPIServerPprofEnabled {
 		klog.Warningf("fetching profile data from is not possible from provider: %s", p.config.provider)
 		return nil, nil
 	}

--- a/clusterloader2/pkg/measurement/common/profile.go
+++ b/clusterloader2/pkg/measurement/common/profile.go
@@ -115,7 +115,7 @@ func (p *profileMeasurement) start(config *measurement.MeasurementConfig) error 
 	// We may want to revisit ot adjust it in the future.
 	numNodes := config.ClusterFramework.GetClusterConfig().Nodes
 	profileFrequency := time.Duration(5+numNodes/250) * time.Minute
-	isSSHSupported := config.ClusterLoaderConfig.ClusterConfig.IsSSHSupported
+	isSSHSupported := config.ClusterFramework.GetClusterConfig().IsSSHSupported
 	go func() {
 		defer p.wg.Done()
 		for {

--- a/clusterloader2/pkg/measurement/common/profile.go
+++ b/clusterloader2/pkg/measurement/common/profile.go
@@ -187,10 +187,15 @@ func (p *profileMeasurement) gatherProfile(c clientset.Interface, isSSHSupported
 	for _, host := range p.config.hosts {
 		profilePrefix := fmt.Sprintf("%s_%s_%s", host, p.config.componentName, p.name)
 
+		if p.config.provider == "aks" {
+			klog.Warningf("%s: fetching profile data from AKS is not possible.", p.name)
+			return nil, nil
+		}
+
 		// Get the profile data over SSH.
 		// Start by checking that the provider allows us to do so.
 		if !isSSHSupported || shouldGetAPIServerByK8sClient(p.config.componentName) {
-			// SSH to master is not possible in gke/ or ks, but if the component is
+			// SSH to master is not possible, but if the component is
 			// kube-apiserver we can get the profile via k8s client.
 			// TODO(#246): This will connect to a random master in HA (multi-master) clusters, fix it.
 			if p.config.componentName == "kube-apiserver" {

--- a/clusterloader2/pkg/measurement/common/scheduler_latency.go
+++ b/clusterloader2/pkg/measurement/common/scheduler_latency.go
@@ -81,10 +81,10 @@ func (s *schedulerLatencyMeasurement) Execute(config *measurement.MeasurementCon
 	switch action {
 	case "reset":
 		klog.Infof("%s: resetting latency metrics in scheduler...", s)
-		return nil, s.resetSchedulerMetrics(config.ClusterFramework.GetClientSets().GetClient(), masterIP, provider, masterName, config.ClusterLoaderConfig.ClusterConfig.IsSSHSupported)
+		return nil, s.resetSchedulerMetrics(config.ClusterFramework.GetClientSets().GetClient(), masterIP, provider, masterName, config.ClusterFramework.GetClusterConfig().IsSSHSupported)
 	case "gather":
 		klog.Infof("%s: gathering latency metrics in scheduler...", s)
-		return s.getSchedulingLatency(config.ClusterFramework.GetClientSets().GetClient(), masterIP, provider, masterName, config.ClusterLoaderConfig.ClusterConfig.IsSSHSupported)
+		return s.getSchedulingLatency(config.ClusterFramework.GetClientSets().GetClient(), masterIP, provider, masterName, config.ClusterFramework.GetClusterConfig().IsSSHSupported)
 	default:
 		return nil, fmt.Errorf("unknown action %v", action)
 	}

--- a/clusterloader2/pkg/measurement/common/scheduler_latency.go
+++ b/clusterloader2/pkg/measurement/common/scheduler_latency.go
@@ -61,7 +61,7 @@ type schedulerLatencyMeasurement struct{}
 // - reset - Resets latency data on api scheduler side.
 // - gather - Gathers and prints current scheduler latency data.
 func (s *schedulerLatencyMeasurement) Execute(config *measurement.MeasurementConfig) ([]measurement.Summary, error) {
-	isSSHSupported := config.ClusterFramework.GetClusterConfig().IsSSHSupported
+	IsSSHToMasterSupported := config.ClusterFramework.GetClusterConfig().IsSSHToMasterSupported
 
 	c := config.ClusterFramework.GetClientSets().GetClient()
 	nodes, err := c.CoreV1().Nodes().List(metav1.ListOptions{})
@@ -81,7 +81,7 @@ func (s *schedulerLatencyMeasurement) Execute(config *measurement.MeasurementCon
 		return nil, err
 	}
 
-	if !isSSHSupported || !masterRegistered {
+	if !IsSSHToMasterSupported || !masterRegistered {
 		klog.Infof("unable to fetch scheduler metrics for provider: %s", provider)
 		return nil, nil
 	}

--- a/clusterloader2/pkg/measurement/common/scheduler_latency.go
+++ b/clusterloader2/pkg/measurement/common/scheduler_latency.go
@@ -226,7 +226,7 @@ func (s *schedulerLatencyMeasurement) sendRequestToScheduler(c clientset.Interfa
 		responseText = string(body)
 	} else {
 		// If master is not registered fall back to old method of using SSH.
-		if provider == "gke" {
+		if provider == "gke" || provider == "aks" {
 			klog.Infof("%s: not grabbing scheduler metrics through master SSH: unsupported for gke", s)
 			return "", nil
 		}

--- a/clusterloader2/pkg/prometheus/prometheus.go
+++ b/clusterloader2/pkg/prometheus/prometheus.go
@@ -96,7 +96,7 @@ func NewPrometheusController(clusterLoaderConfig *config.ClusterLoaderConfig) (p
 		delete(mapping, "MasterIps")
 	}
 	if _, exists := mapping["PROMETHEUS_SCRAPE_APISERVER_ONLY"]; !exists {
-		mapping["PROMETHEUS_SCRAPE_APISERVER_ONLY"] = clusterLoaderConfig.ClusterConfig.Provider == "gke"
+		mapping["PROMETHEUS_SCRAPE_APISERVER_ONLY"] = clusterLoaderConfig.ClusterConfig.Provider == "gke" || clusterLoaderConfig.ClusterConfig.Provider == "aks"
 	}
 	// TODO: Change to pure assignments when overrides are not used.
 	if _, exists := mapping["PROMETHEUS_SCRAPE_ETCD"]; !exists {


### PR DESCRIPTION
AKS, much like GKE, does not support SSH to master nodes or similar methods of contacting them. This PR avoids trying to do so as part of cluster loader tests for AKS. Without this, the TestMetrics gather step fails to SSH without a signer for the provider.

I imagine the same patterns would be broadly applicable for managed clusters. Perhaps we could generalize this?