### PR TITLE
Expand the scraping timeout

### DIFF
--- a/clusterloader2/pkg/measurement/common/slos/windows_node_resource_usage.go
+++ b/clusterloader2/pkg/measurement/common/slos/windows_node_resource_usage.go
@@ -30,7 +30,7 @@ import (
 const (
 	windowsResourceUsagePrometheusMeasurementName = "WindowsResourceUsagePrometheus"
 	// get top 10 non-system processes with highest cpu usage within 1min query window size
-	cpuUsageQueryTop10                        = `topk(10, sum by (process) (rate(wmi_process_cpu_time_total{process!~"Idle|Total|System"}[1m]) / on(job) group_left wmi_cs_logical_processors) * 100)`
+	cpuUsageQueryTop10                        = `topk(10, sum by (process) (irate(wmi_process_cpu_time_total{process!~"Idle|Total|System"}[5m]) / on(job) group_left wmi_cs_logical_processors) * 100)`
 	currentWindowsResourceUsageMetricsVersion = "v1"
 )
 

--- a/clusterloader2/pkg/prometheus/manifests/prometheus-windows-scrape-configs.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/prometheus-windows-scrape-configs.yaml
@@ -8,5 +8,7 @@ metadata:
 stringData:
   windows-scrape-configs.yaml: |-
     - job_name: "monitoring/windows_static"
+      scrape_interval: {{DefaultParam .CL2_WINDOWS_SCRAPE_INTERVAL "130s"}}
+      scrape_timeout: {{DefaultParam .CL2_WINDOWS_SCRAPE_TIMEOUT "120s"}}
       static_configs:
       - targets: ["{{$WINDOWS_NODE_NAME}}:5000"]


### PR DESCRIPTION
Found we couldn't get the cpu usage per process data during windows [load test](https://testgrid.k8s.io/google-windows#gce-windows-node-throughput).
So figured out that the scraping is pretty slow for `process` collector in wmi_exporter.
Tried locally, the prometheus server took around 1m30s to scrape windows target data when all 80 pods are running, so expand the scrape_timeout and interval.

Also created an [issue](https://github.com/martinlindhe/wmi_exporter/issues/487) for tracking