### PR TITLE
[NodeKiller] Rebooting broken nodes before exiting the test

### DIFF
--- a/clusterloader2/pkg/chaos/monkey.go
+++ b/clusterloader2/pkg/chaos/monkey.go
@@ -19,6 +19,7 @@ package chaos
 import (
 	"fmt"
 	"strings"
+	"sync"
 
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/perf-tests/clusterloader2/api"
@@ -38,17 +39,19 @@ func NewMonkey(client clientset.Interface, provider string) *Monkey {
 
 // Init initializes Monkey with given config.
 // When stopCh is closed, the Monkey will stop simulating failures.
-func (m *Monkey) Init(config api.ChaosMonkeyConfig, stopCh <-chan struct{}) error {
+func (m *Monkey) Init(config api.ChaosMonkeyConfig, stopCh <-chan struct{}) (*sync.WaitGroup, error) {
+	wg := sync.WaitGroup{}
 	if config.NodeFailure != nil {
 		nodeKiller, err := NewNodeKiller(*config.NodeFailure, m.client, m.provider)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		m.nodeKiller = nodeKiller
-		go m.nodeKiller.Run(stopCh)
+		wg.Add(1)
+		go m.nodeKiller.Run(stopCh, &wg)
 	}
 
-	return nil
+	return &wg, nil
 }
 
 // Summary logs Monkey execution

--- a/clusterloader2/pkg/test/simple_test_executor.go
+++ b/clusterloader2/pkg/test/simple_test_executor.go
@@ -55,11 +55,46 @@ func (ste *simpleTestExecutor) ExecuteTest(ctx Context, conf *api.Config) *error
 	klog.Infof("AutomanagedNamespacePrefix: %s", ctx.GetClusterFramework().GetAutomanagedNamespacePrefix())
 	defer cleanupResources(ctx)
 	ctx.GetTuningSetFactory().Init(conf.TuningSets)
+
 	stopCh := make(chan struct{})
-	defer close(stopCh)
-	if err := ctx.GetChaosMonkey().Init(conf.ChaosMonkey, stopCh); err != nil {
+	chaosMonkeyWaitGroup, err := ctx.GetChaosMonkey().Init(conf.ChaosMonkey, stopCh)
+	if err != nil {
+		close(stopCh)
 		return errors.NewErrorList(fmt.Errorf("error while creating chaos monkey: %v", err))
 	}
+	errList := ste.ExecuteTestSteps(ctx, conf)
+	close(stopCh)
+
+	if chaosMonkeyWaitGroup != nil {
+		// Wait for the Chaos Monkey subroutine to end
+		klog.Info("Waiting for the chaos monkey subroutine to end...")
+		chaosMonkeyWaitGroup.Wait()
+		klog.Info("Chaos monkey ended.")
+	}
+
+	for _, summary := range ctx.GetMeasurementManager().GetSummaries() {
+		if ctx.GetClusterLoaderConfig().ReportDir == "" {
+			klog.Infof("%v: %v", summary.SummaryName(), summary.SummaryContent())
+		} else {
+			testDistinctor := ""
+			if ctx.GetClusterLoaderConfig().TestScenario.Identifier != "" {
+				testDistinctor = "_" + ctx.GetClusterLoaderConfig().TestScenario.Identifier
+			}
+			// TODO(krzysied): Remember to keep original filename style for backward compatibility.
+			fileName := strings.Join([]string{summary.SummaryName(), conf.Name + testDistinctor, summary.SummaryTime().Format(time.RFC3339)}, "_")
+			filePath := path.Join(ctx.GetClusterLoaderConfig().ReportDir, strings.Join([]string{fileName, summary.SummaryExt()}, "."))
+			if err := ioutil.WriteFile(filePath, []byte(summary.SummaryContent()), 0644); err != nil {
+				errList.Append(fmt.Errorf("writing to file %v error: %v", filePath, err))
+				continue
+			}
+		}
+	}
+	klog.Infof(ctx.GetChaosMonkey().Summary())
+	return errList
+}
+
+// ExecuteTestSteps executes all test steps provided in configuration
+func (ste *simpleTestExecutor) ExecuteTestSteps(ctx Context, conf *api.Config) *errors.ErrorList {
 	automanagedNamespacesList, staleNamespaces, err := ctx.GetClusterFramework().ListAutomanagedNamespaces()
 	if err != nil {
 		return errors.NewErrorList(fmt.Errorf("automanaged namespaces listing failed: %v", err))
@@ -89,29 +124,6 @@ func (ste *simpleTestExecutor) ExecuteTest(ctx Context, conf *api.Config) *error
 			}
 		}
 	}
-
-	for _, summary := range ctx.GetMeasurementManager().GetSummaries() {
-		if err != nil {
-			errList.Append(fmt.Errorf("printing summary %s error: %v", summary.SummaryName(), err))
-			continue
-		}
-		if ctx.GetClusterLoaderConfig().ReportDir == "" {
-			klog.Infof("%v: %v", summary.SummaryName(), summary.SummaryContent())
-		} else {
-			testDistinctor := ""
-			if ctx.GetClusterLoaderConfig().TestScenario.Identifier != "" {
-				testDistinctor = "_" + ctx.GetClusterLoaderConfig().TestScenario.Identifier
-			}
-			// TODO(krzysied): Remember to keep original filename style for backward compatibility.
-			fileName := strings.Join([]string{summary.SummaryName(), conf.Name + testDistinctor, summary.SummaryTime().Format(time.RFC3339)}, "_")
-			filePath := path.Join(ctx.GetClusterLoaderConfig().ReportDir, strings.Join([]string{fileName, summary.SummaryExt()}, "."))
-			if err := ioutil.WriteFile(filePath, []byte(summary.SummaryContent()), 0644); err != nil {
-				errList.Append(fmt.Errorf("writing to file %v error: %v", filePath, err))
-				continue
-			}
-		}
-	}
-	klog.Infof(ctx.GetChaosMonkey().Summary())
 	return errList
 }
 


### PR DESCRIPTION
With this change I tried to introduce some sort of wait mechanism for the NodeKiller subroutine.
The rationale behind is it avoiding that cluster nodes are left in a broken state by NodeKiller if the test finishes while downtime is being simulated for some nodes.

Now the chaos monkey can return back to its caller a WaitGroup that can be used to wait for the subroutine termination before proceeding to test summary.

/assign @jprzychodzen 
Ref: #1130 