### PR TITLE
Decouple SSH command execution in util.SSH to enable unit testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ clusterloader2/clusterloader
 
 # Vscode files
 .vscode
+
+# GoLand files
+.idea

--- a/clusterloader2/pkg/util/ssh.go
+++ b/clusterloader2/pkg/util/ssh.go
@@ -25,9 +25,17 @@ import (
 	"k8s.io/klog"
 )
 
+// SSHExecutor interface can run commands in cluster nodes via SSH
+type SSHExecutor interface {
+	Exec(command string, node *v1.Node, stdin io.Reader) error
+}
+
+// GCloudSSHExecutor runs commands in GCloud cluster nodes
+type GCloudSSHExecutor struct{}
+
 // SSH executes command on a given node with stdin provided.
 // If stdin is nil, the process reads from null device.
-func SSH(command string, node *v1.Node, stdin io.Reader) error {
+func (e *GCloudSSHExecutor) Exec(command string, node *v1.Node, stdin io.Reader) error {
 	zone, ok := node.Labels["failure-domain.beta.kubernetes.io/zone"]
 	if !ok {
 		return fmt.Errorf("unknown zone for %q node: no failure-domain.beta.kubernetes.io/zone label", node.Name)


### PR DESCRIPTION
Following up with #1137 we are starting to decouple code that depends on real cloud components to allow unit testing, starting with util.SSH. This utility executes commands against a GCloud cluster so it should be abstracted with an interface and replaceable in a go test.
- create interface for command execution in cluster nodes through SSH
- refactor code that is currently using util.SSH to use the new executor interface