### PR TITLE
Add load test for iis container

### DIFF
--- a/clusterloader2/pkg/prometheus/manifests/prometheus-windows-scrape-configs.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/prometheus-windows-scrape-configs.yaml
@@ -8,7 +8,7 @@ metadata:
 stringData:
   windows-scrape-configs.yaml: |-
     - job_name: "monitoring/windows_static"
-      scrape_interval: {{DefaultParam .CL2_WINDOWS_SCRAPE_INTERVAL "130s"}}
-      scrape_timeout: {{DefaultParam .CL2_WINDOWS_SCRAPE_TIMEOUT "120s"}}
+      scrape_interval: {{DefaultParam .CL2_WINDOWS_SCRAPE_INTERVAL "1m"}}
+      scrape_timeout: {{DefaultParam .CL2_WINDOWS_SCRAPE_TIMEOUT "10s"}}
       static_configs:
       - targets: ["{{$WINDOWS_NODE_NAME}}:5000"]

--- a/clusterloader2/testing/node-throughput/windows_override.yaml
+++ b/clusterloader2/testing/node-throughput/windows_override.yaml
@@ -1,8 +1,9 @@
 WINDOWS_NODE_TEST: true
 POD_COUNT: 80
 POD_THROUGHPUT: 0.03
-CONTAINER_IMAGE: gcr.io/gke-release/pause-win:1.1.0
+CONTAINER_IMAGE: gcr.io/gke-release/pause-win:1.2.1
 OPERATION_TIMEOUT: 90m
 POD_STARTUP_LATENCY_THRESHOLD: 60m
-WMI_EXPORTER_URL: "https://github.com/martinlindhe/wmi_exporter/releases/download/v0.10.1/wmi_exporter-0.10.1-amd64.msi"
+# TODO: Will update it once the offical version is released.
+WMI_EXPORTER_URL: "https://github.com/YangLu1031/wmi_exporter/releases/download/v0.10.3-alpha/wmi_exporter.exe"
 WMI_EXPORTER_ENABLED_COLLECTORS: "process,cs"

--- a/clusterloader2/testing/windows-tests/OWNERS
+++ b/clusterloader2/testing/windows-tests/OWNERS
@@ -1,0 +1,3 @@
+approvers:
+- pjh
+- YangLu1031

--- a/clusterloader2/testing/windows-tests/config.yaml
+++ b/clusterloader2/testing/windows-tests/config.yaml
@@ -1,0 +1,91 @@
+# ASSUMPTIONS:
+# - This test is designed for 1-node cluster.
+
+#Constants
+{{$POD_COUNT := DefaultParam .CL2_POD_COUNT 80}}
+{{$POD_THROUGHPUT := DefaultParam .CL2_POD_THROUGHPUT 0.03}}
+{{$CONTAINER_IMAGE := DefaultParam .CL2_CONTAINER_IMAGE "gcr.io/gke-release/pause-win:1.2.0"}}
+{{$POD_STARTUP_LATENCY_THRESHOLD := DefaultParam .CL2_POD_STARTUP_LATENCY_THRESHOLD "60m"}}
+{{$OPERATION_TIMEOUT := DefaultParam .CL2_OPERATION_TIMEOUT "90m"}}
+
+name: node-throughput
+automanagedNamespaces: {{$POD_COUNT}}
+tuningSets:
+- name: UniformQPS
+  qpsLoad:
+    qps: {{$POD_THROUGHPUT}}
+steps:
+- measurements:
+  - Identifier: WindowsResourceUsagePrometheus
+    Method: WindowsResourceUsagePrometheus
+    Params:
+      action: start
+  - Identifier: APIResponsivenessPrometheusSimple
+    Method: APIResponsivenessPrometheus
+    Params:
+      action: start
+  - Identifier: PodStartupLatency
+    Method: PodStartupLatency
+    Params:
+      action: start
+      labelSelector: group = latency
+      threshold: {{$POD_STARTUP_LATENCY_THRESHOLD}}
+- measurements:
+  - Identifier: WaitForRunningLatencyRCs
+    Method: WaitForControlledPodsRunning
+    Params:
+      action: start
+      apiVersion: v1
+      kind: ReplicationController
+      labelSelector: group = latency
+      operationTimeout: {{$OPERATION_TIMEOUT}}
+- phases:
+  - namespaceRange:
+      min: 1
+      max: {{$POD_COUNT}}
+    replicasPerNamespace: 1
+    tuningSet: UniformQPS
+    objectBundle:
+    - basename: latency-pod-rc
+      objectTemplatePath: rc.yaml
+      templateFillMap:
+        Replicas: 1
+        Group: latency
+        Image: {{$CONTAINER_IMAGE}}
+- measurements:
+  - Identifier: WaitForRunningLatencyRCs
+    Method: WaitForControlledPodsRunning
+    Params:
+      action: gather
+  - Identifier: WindowsResourceUsagePrometheus
+    Method: WindowsResourceUsagePrometheus
+    Params:
+      action: gather
+- phases:
+  - namespaceRange:
+      min: 1
+      max: {{$POD_COUNT}}
+    replicasPerNamespace: 0
+    tuningSet: UniformQPS
+    objectBundle:
+    - basename: latency-pod-rc
+      objectTemplatePath: rc.yaml
+- measurements:
+  - Identifier: WaitForRunningLatencyRCs
+    Method: WaitForControlledPodsRunning
+    Params:
+      action: gather
+# Collect measurements
+- measurements:
+  - Identifier: PodStartupLatency
+    Method: PodStartupLatency
+    Params:
+      action: gather
+- measurements:
+  - Identifier: APIResponsivenessPrometheusSimple
+    Method: APIResponsivenessPrometheus
+    Params:
+      action: gather
+      enableViolations: true
+      useSimpleLatencyQuery: true
+      summaryName: APIResponsivenessPrometheus_simple

--- a/clusterloader2/testing/windows-tests/rc.yaml
+++ b/clusterloader2/testing/windows-tests/rc.yaml
@@ -1,0 +1,40 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: {{.Name}}
+  labels:
+    group: {{.Group}}
+spec:
+  replicas: {{.Replicas}}
+  selector:
+    name: {{.Name}}
+  template:
+    metadata:
+      labels:
+        name: {{.Name}}
+        group: {{.Group}}
+    spec:
+      # Do not automount default service account, to eliminate its impact.
+      automountServiceAccountToken: false
+      nodeSelector:
+        kubernetes.io/os: windows
+      containers:
+      - image: {{.Image}}
+        imagePullPolicy: IfNotPresent
+        name: {{.Name}}
+        ports:
+        - containerPort: 80
+      tolerations:
+      - key: "node.kubernetes.io/os"
+        operator: "Exists"
+        effect: "NoSchedule"
+      # Add not-ready/unreachable tolerations for 15 minutes so that node
+      # failure doesn't trigger pod deletion.
+      - key: "node.kubernetes.io/not-ready"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 900
+      - key: "node.kubernetes.io/unreachable"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 900

--- a/clusterloader2/testing/windows-tests/windows_override.yaml
+++ b/clusterloader2/testing/windows-tests/windows_override.yaml
@@ -1,0 +1,1 @@
+WINDOWS_NODE_TEST: true


### PR DESCRIPTION
1. Added a `windows-tests` folder to contain all windows yaml configs, and planning to deprecate the windows test configs in `node-throughput` folder later.
2. Reference to the pre-release fast version of wmi_exporter, so decrease the scrape interval and timeout, also change to `CL2_` variables for easier update in test definitions.
3. Bumped the pause image version 