### PR TITLE
Unpack the string values from the CL2_.* envs

### DIFF
--- a/clusterloader2/pkg/config/template_provider.go
+++ b/clusterloader2/pkg/config/template_provider.go
@@ -25,6 +25,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"text/template"
@@ -240,9 +241,22 @@ func LoadCL2Envs() (map[string]interface{}, error) {
 			return nil, goerrors.Errorf("unparsable string in os.Eviron(): %v", keyValue)
 		}
 		key, value := split[0], split[1]
-		mapping[key] = value
+		mapping[key] = unpackStringValue(value)
 	}
 	return mapping, nil
+}
+
+func unpackStringValue(str string) interface{} {
+	if v, err := strconv.ParseBool(str); err == nil {
+		return v
+	}
+	if v, err := strconv.ParseInt(str, 10, 64); err == nil {
+		return v
+	}
+	if v, err := strconv.ParseFloat(str, 64); err == nil {
+		return v
+	}
+	return str
 }
 
 // MergeMappings modifies map b to contain all new key=value pairs from b.

--- a/clusterloader2/pkg/config/template_provider_test.go
+++ b/clusterloader2/pkg/config/template_provider_test.go
@@ -80,18 +80,22 @@ func TestLoadCL2Envs(t *testing.T) {
 				"NODE_SIZE":    "n1-standard-1",
 			},
 			wantedMapping: map[string]interface{}{
-				"CL2_MY_PARAM": "100",
+				"CL2_MY_PARAM": int64(100),
 			},
 		},
 		{
 			name: "Multiple CL2 envs",
 			env: map[string]string{
 				"CL2_MY_PARAM1": "100",
-				"CL2_MY_PARAM2": "XXX",
+				"CL2_MY_PARAM2": "true",
+				"CL2_MY_PARAM3": "99.99",
+				"CL2_MY_PARAM4": "XXX",
 			},
 			wantedMapping: map[string]interface{}{
-				"CL2_MY_PARAM1": "100",
-				"CL2_MY_PARAM2": "XXX",
+				"CL2_MY_PARAM1": int64(100),
+				"CL2_MY_PARAM2": true,
+				"CL2_MY_PARAM3": 99.99,
+				"CL2_MY_PARAM4": "XXX",
 			},
 		},
 		{


### PR DESCRIPTION
Without doing it, it's impossible to easily override boolean param via env. E.g. if I do
```
--env=ENABLE_MY_FEATURE=false
```

The 'false' will be treated as string, and then in the config file the if statement like this:
```
{{if .ENABLE_MY_FEATURE}}
...
{{end}}
```

Will evaluate to true and will be executed, because "false" is non-empty string that evaluates to true :)