### PR TITLE
Extend load test to immutable secrets/configmaps

### DIFF
--- a/clusterloader2/testing/load/configmap.yaml
+++ b/clusterloader2/testing/load/configmap.yaml
@@ -2,6 +2,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{.Name}}
+{{if not (eq (Mod .Index 20) 0 19) }} # .Index % 20 in {0,19} - only 10% deployments will have non-immutable ConfigMap.
+immutable: true
+{{end}}
 data:
   data.yaml: |-
     a: 1

--- a/clusterloader2/testing/load/deployment.yaml
+++ b/clusterloader2/testing/load/deployment.yaml
@@ -28,14 +28,10 @@ spec:
             cpu: {{$CpuRequest}}
             memory: {{$MemoryRequest}}
         volumeMounts:
-          {{if (eq (Mod .Index 20) 0 19) }} # .Index % 20 in {0,19} - 10% deployments will have ConfigMap
           - name: configmap
             mountPath: /var/configmap
-          {{end}}
-          {{if (eq (Mod .Index 20) 10 19) }} # .Index % 20 in {10,19} - 10% deployments will have Secret
           - name: secret
             mountPath: /var/secret
-          {{end}}
       dnsPolicy: Default
       terminationGracePeriodSeconds: 1
       # Add not-ready/unreachable tolerations for 15 minutes so that node
@@ -50,14 +46,10 @@ spec:
         effect: "NoExecute"
         tolerationSeconds: 900
       volumes:
-        {{if (eq (Mod .Index 20) 0 19) }} # .Index % 20 in {0,19} - 10% deployments will have ConfigMap
         - name: configmap
           configMap:
             name: {{.BaseName}}-{{.Index}}
-        {{end}}
-        {{if (eq (Mod .Index 20) 10 19) }} # .Index % 20 in {10,19} - 10% deployments will have Secret
         - name: secret
           secret:
             secretName: {{.BaseName}}-{{.Index}}
-        {{end}}
 

--- a/clusterloader2/testing/load/secret.yaml
+++ b/clusterloader2/testing/load/secret.yaml
@@ -2,6 +2,9 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{.Name}}
+{{if not (eq (Mod .Index 20) 10 19) }} # .Index % 20 in {10,19} - only 10% deployments will have non-immutable Secret.
+immutable: true
+{{end}}
 type: Opaque
 data:
   password: c2NhbGFiaWxpdHkK


### PR DESCRIPTION
Each deployment in load test has now both secret and configmap mounted. 90% of them are marked as immutable, only 10% is mutable (as it was before).

Scalability test coverage is a requirement for graduating "Immutable Secrets/ConfigMaps" feature to Beta.

This has been scale-tested already and the features was enabled by default in https://github.com/kubernetes/kubernetes/pull/89594

ref https://github.com/kubernetes/enhancements/issues/1412