### PR TITLE
[Density][ChaosMonkey] Make config more predictable

### DIFF
--- a/clusterloader2/testing/density/config.yaml
+++ b/clusterloader2/testing/density/config.yaml
@@ -44,9 +44,9 @@ tuningSets:
 chaosMonkey:
   nodeFailure:
     failureRate: 0.01
-    interval: 1m
-    jitterFactor: 10.0
-    simulatedDowntime: 10m
+    interval: 5m
+    jitterFactor: 1.0
+    simulatedDowntime: 5m
 {{end}}
 steps:
 - name: Starting measurements


### PR DESCRIPTION
Density test flakes a lot with NodeKiller enabled. It's related to
very unstable and unpredictable when nodes will be removed from cluster

Ref. kubernetes/kubernetes#89051

/sig scalability
/assign Matt Matejczyk