### PR TITLE
[NodeKiller][Config] Add known components to node killer expected crashes

### DIFF
--- a/clusterloader2/testing/chaosmonkey/ignore_node_killer_container_restarts_100.yaml
+++ b/clusterloader2/testing/chaosmonkey/ignore_node_killer_container_restarts_100.yaml
@@ -1,7 +1,9 @@
 RESTART_COUNT_THRESHOLD_OVERRIDES: |
   # Main purpose of this check is detection crashlooping pods.
   # With enabled node killer pods runing on a killed node crash, and this is expected
+  coredns: 1
   fluentd-gcp: 1
   kube-proxy: 1
   metadata-proxy: 1
   prometheus-to-sd-exporter: 1
+  volume-snapshot-controller: 1


### PR DESCRIPTION
Node Killer is running under https://testgrid.k8s.io/sig-scalability-experiments#gce-cos-master-scalability-100-nodekiller and sometime there are failing tests.

Some components are missing from [ignore override](../tree/master/clusterloader2/testing/chaosmonkey/ignore_node_killer_container_restarts_100.yaml).

Log 1:
```
[measurement call TestMetrics - TestMetrics error: [restart counts violation: RestartCount(coredns-78ff568f7c-8ddpw, coredns)=1, want <= 0]]
```

Log 2:
```
[measurement call TestMetrics - TestMetrics error: [restart counts violation: RestartCount(volume-snapshot-controller-0, volume-snapshot-controller)=1, want <= 0]]
```

Log 3:
```
[measurement call TestMetrics - TestMetrics error: [restart counts violation: RestartCount(volume-snapshot-controller-0, volume-snapshot-controller)=1, want <= 0]] :0
-- | -- | -- | --
[measurement call TestMetrics - TestMetrics error: [restart counts violation: RestartCount(coredns-78ff568f7c-twcbj, coredns)=1, want <= 0]] :0
```

Log 4:
```
[measurement call TestMetrics - TestMetrics error: [restart counts violation: RestartCount(coredns-78ff568f7c-d54zb, coredns)=1, want <= 0]]
```

/assign @mm4tt 