### PR TITLE
Run dnsclient as a deployment in DNS performance tests

### DIFF
--- a/dns/README.md
+++ b/dns/README.md
@@ -221,6 +221,7 @@ query_file: ["nx-domain.txt", "outside.txt", "pod-ip.txt", "service.txt"]
 CREATE TABLE runs (
   run_id,
   run_subid,
+  pod_name,
   run_length_seconds,
   dnsmasq_cpu,
   dnsmasq_cache,
@@ -233,6 +234,7 @@ CREATE TABLE runs (
 CREATE TABLE results (
   run_id,
   run_subid,
+  pod_name,
   queries_sent,
   queries_completed,
   queries_lost,

--- a/dns/cluster/dnsperf-deploy.yaml
+++ b/dns/cluster/dnsperf-deploy.yaml
@@ -1,0 +1,44 @@
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dns-perf-client
+spec:
+  replicas: 4
+  selector:
+    matchLabels:
+      app: dns-perf-client
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: dns-perf-client
+    spec:
+      terminationGracePeriodSeconds: 1
+      containers:
+      - command: ["sh", "-c", "while true; do echo `date`: MARK; sleep 10; done"]
+        image: k8s.gcr.io/kube-dns-perf-client-amd64:1.1
+        imagePullPolicy: Always
+        name: dnsperf
+        resources:
+          requests:
+            cpu: 250m
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always

--- a/dns/jsonify/main.go
+++ b/dns/jsonify/main.go
@@ -65,6 +65,7 @@ type BenchmarkParams struct {
 	DnsmasqCpu       *float64 `yaml:"dnsmasq_cpu"`
 	DnsmasqCache     *float64 `yaml:"dnsmasq_cache"`
 	MaxQps           *float64 `yaml:"max_qps"`
+	PodName          string   `yaml:"pod_name"`
 }
 
 func main() {

--- a/dns/py/params.py
+++ b/dns/py/params.py
@@ -211,9 +211,10 @@ class MaxQPS(DnsperfCmdlineParam):
 
 
 class TestCase(object):
-  def __init__(self, run_id, run_subid, pv):
+  def __init__(self, run_id, run_subid, pod_name, pv):
     self.run_id = run_id
     self.run_subid = run_subid
+    self.pod_name = pod_name
     self.pv = pv
 
   def __repr__(self):
@@ -223,6 +224,7 @@ class TestCase(object):
     fields = {
         'run_id': self.run_id,
         'run_subid': self.run_subid,
+        'pod_name': self.pod_name,
     }
     for param, value in self.pv:
       fields[param.name] = value
@@ -261,7 +263,7 @@ class TestCases(object):
     def iterate(remaining, pv):
       if len(remaining) == 0:
         run_subid = len(cases)
-        return cases.append(TestCase(run_id, run_subid, pv))
+        return cases.append(TestCase(run_id, run_subid, "", pv))
 
       param = remaining[0]
       if param.name not in self.values or \

--- a/dns/py/run_perf.py
+++ b/dns/py/run_perf.py
@@ -47,7 +47,7 @@ def parse_args():
       '--configmap-yaml', type=str, default='',
       help='yaml for the dns server configmap')
   parser.add_argument(
-      '--dnsperf-yaml', type=str, default='cluster/dnsperf.yaml',
+      '--dnsperf-yaml', type=str, default='cluster/dnsperf-deploy.yaml',
       help='yaml for the dnsperf client')
   parser.add_argument(
       '--query-dir', type=str, default='queries/',


### PR DESCRIPTION
This change supports running dnsclient as a deployment. The replicas can be configured by editing the cluster/dnsperf-deploy.py, it will be made configurable in a followup change. This will help measure ClusterDNS and NodeLocal DNSCache performance at scale.