### PR TITLE
Return multiple summaries in Gather method

### DIFF
--- a/clusterloader2/pkg/measurement/common/slos/api_responsiveness_prometheus.go
+++ b/clusterloader2/pkg/measurement/common/slos/api_responsiveness_prometheus.go
@@ -100,7 +100,7 @@ func (a *apiResponsiveness) Less(i, j int) bool {
 
 type apiResponsivenessGatherer struct{}
 
-func (a *apiResponsivenessGatherer) Gather(executor QueryExecutor, startTime time.Time, config *measurement.MeasurementConfig) (measurement.Summary, error) {
+func (a *apiResponsivenessGatherer) Gather(executor QueryExecutor, startTime time.Time, config *measurement.MeasurementConfig) ([]measurement.Summary, error) {
 	apiCalls, err := a.gatherAPICalls(executor, startTime, config)
 	if err != nil {
 		klog.Errorf("%s: samples gathering error: %v", config.Identifier, err)
@@ -122,10 +122,11 @@ func (a *apiResponsivenessGatherer) Gather(executor QueryExecutor, startTime tim
 	}
 
 	summary := measurement.CreateSummary(summaryName, "json", content)
+	summaries := []measurement.Summary{summary}
 	if len(badMetrics) > 0 {
-		return summary, errors.NewMetricViolationError("top latency metric", fmt.Sprintf("there should be no high-latency requests, but: %v", badMetrics))
+		return summaries, errors.NewMetricViolationError("top latency metric", fmt.Sprintf("there should be no high-latency requests, but: %v", badMetrics))
 	}
-	return summary, nil
+	return summaries, nil
 }
 
 func (a *apiResponsivenessGatherer) String() string {

--- a/clusterloader2/pkg/measurement/common/slos/network_programming.go
+++ b/clusterloader2/pkg/measurement/common/slos/network_programming.go
@@ -55,14 +55,15 @@ func (n *netProgGatherer) IsEnabled(config *measurement.MeasurementConfig) bool 
 	return config.CloudProvider != "kubemark"
 }
 
-func (n *netProgGatherer) Gather(executor QueryExecutor, startTime time.Time, config *measurement.MeasurementConfig) (measurement.Summary, error) {
+func (n *netProgGatherer) Gather(executor QueryExecutor, startTime time.Time, config *measurement.MeasurementConfig) ([]measurement.Summary, error) {
 	latency, err := n.query(executor, startTime)
 	if err != nil {
 		return nil, err
 	}
 
 	klog.Infof("%s: got %v", netProg, latency)
-	return n.createSummary(latency)
+	summary, err := n.createSummary(latency)
+	return []measurement.Summary{summary}, err
 }
 
 func (n *netProgGatherer) String() string {

--- a/clusterloader2/pkg/measurement/common/slos/network_programming_test.go
+++ b/clusterloader2/pkg/measurement/common/slos/network_programming_test.go
@@ -52,7 +52,7 @@ func TestGather(t *testing.T) {
 
 func testGatherer(t *testing.T, executor QueryExecutor, wantData *measurementutil.PerfData, wantError error) {
 	g := &netProgGatherer{}
-	summary, err := g.Gather(executor, time.Now(), nil)
+	summaries, err := g.Gather(executor, time.Now(), nil)
 	if err != nil {
 		if wantError != nil {
 			assert.Equal(t, wantError, err)
@@ -60,13 +60,16 @@ func testGatherer(t *testing.T, executor QueryExecutor, wantData *measurementuti
 		}
 		t.Errorf("Unexpected error:  %v", err)
 	}
-	assert.Equal(t, netProg, summary.SummaryName())
-	assert.Equal(t, "json", summary.SummaryExt())
-	assert.NotNil(t, summary.SummaryTime())
+	if len(summaries) != 1 {
+		t.Errorf("Should have only one summary")
+	}
+	assert.Equal(t, netProg, summaries[0].SummaryName())
+	assert.Equal(t, "json", summaries[0].SummaryExt())
+	assert.NotNil(t, summaries[0].SummaryTime())
 
 	var data measurementutil.PerfData
-	if err := json.Unmarshal([]byte(summary.SummaryContent()), &data); err != nil {
-		t.Errorf("Error while decoding summary: %v. Summary: %v", err, summary.SummaryContent())
+	if err := json.Unmarshal([]byte(summaries[0].SummaryContent()), &data); err != nil {
+		t.Errorf("Error while decoding summary: %v. Summary: %v", err, summaries[0].SummaryContent())
 
 	}
 	assert.Equal(t, wantData, &data)

--- a/clusterloader2/pkg/measurement/common/slos/prometheus_measurement.go
+++ b/clusterloader2/pkg/measurement/common/slos/prometheus_measurement.go
@@ -43,7 +43,7 @@ type QueryExecutor interface {
 // It's assumed Prometheus is up, running and instructed to scrape required metrics in the test cluster
 // (please see clusterloader2/pkg/prometheus/manifests).
 type Gatherer interface {
-	Gather(executor QueryExecutor, startTime time.Time, config *measurement.MeasurementConfig) (measurement.Summary, error)
+	Gather(executor QueryExecutor, startTime time.Time, config *measurement.MeasurementConfig) ([]measurement.Summary, error)
 	IsEnabled(config *measurement.MeasurementConfig) bool
 	String() string
 }
@@ -94,7 +94,7 @@ func (m *prometheusMeasurement) Execute(config *measurement.MeasurementConfig) (
 				err = nil
 			}
 		}
-		return []measurement.Summary{summary}, err
+		return summary, err
 	default:
 		return nil, fmt.Errorf("unknown action: %v", action)
 	}

--- a/clusterloader2/pkg/measurement/common/slos/windows_node_resource_usage.go
+++ b/clusterloader2/pkg/measurement/common/slos/windows_node_resource_usage.go
@@ -69,7 +69,7 @@ func convertToPerfData(samples []*model.Sample) *measurementutil.PerfData {
 }
 
 // Gather gathers the metrics and convert to json summary
-func (w *windowsResourceUsageGatherer) Gather(executor QueryExecutor, startTime time.Time, config *measurement.MeasurementConfig) (measurement.Summary, error) {
+func (w *windowsResourceUsageGatherer) Gather(executor QueryExecutor, startTime time.Time, config *measurement.MeasurementConfig) ([]measurement.Summary, error) {
 	samples, err := executor.Query(cpuUsageQueryTop10, time.Now())
 	if err != nil {
 		return nil, err
@@ -83,5 +83,5 @@ func (w *windowsResourceUsageGatherer) Gather(executor QueryExecutor, startTime 
 		return nil, err
 	}
 	summary := measurement.CreateSummary(summaryName, "json", content)
-	return summary, nil
+	return []measurement.Summary{summary}, nil
 }


### PR DESCRIPTION
Execute() method in `prometheus_measurement.go` could return multiple summary, but the Gather() method return only one summary, which seems not reasonable.
So modify it to collect multiple summaries in one file for prometheus measurements.