### PR TITLE
Revert "Improve perfdash container build #1154"

### DIFF
--- a/perfdash/Dockerfile
+++ b/perfdash/Dockerfile
@@ -12,18 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Build the application
-FROM golang:1.14-buster as build
-
-RUN go get -u github.com/tools/godep
-WORKDIR /go/src/app
-COPY . /go/src/app
-RUN CGO_ENABLED=0 GOOS=linux GO111MODULE=off godep go test
-RUN CGO_ENABLED=0 GOOS=linux GO111MODULE=off godep go build -a -installsuffix cgo -ldflags '-w' -o perfdash
-
-# Copy files into run image
-FROM gcr.io/distroless/base-debian10
-WORKDIR /app
-COPY --from=build /go/src/app/perfdash perfdash
-COPY www/ www
-ENTRYPOINT ["/app/perfdash"]
+FROM debian:jessie
+RUN apt-get update
+RUN apt-get install -y -qq ca-certificates
+ADD perfdash /perfdash
+ADD www /www

--- a/perfdash/Makefile
+++ b/perfdash/Makefile
@@ -21,7 +21,7 @@ run: perfdash
 		--githubConfigDir=https://api.github.com/repos/kubernetes/test-infra/contents/config/jobs/kubernetes/sig-scalability \
 		--githubConfigDir=https://api.github.com/repos/kubernetes/test-infra/contents/config/jobs/kubernetes/sig-release/release-branch-jobs
 
-container:
+container: perfdash
 	docker build --pull -t $(REPO)/perfdash:$(TAG) .
 
 push: container


### PR DESCRIPTION
The change broke deploying new versions of perf-dash. There are at least two things wrong:
1. The app was moved in the container from `/perfdash` to `/app/perfdash` but the `deployment.yaml` wasn't updated to reflect this change
2. Even with the fixed binary path the perf-dash is still not operational, it seems to be working, but it's impossible to connect to it via https. I assume it's because of the missing ca-certificates

I spent over 30 minutes debugging it. It looks like the change wasn't tested, please remember to test your changes in future. 
/assign @oxddr 
/cc @skurtzemann 