### PR TITLE
Improve perf-dash container build and fix deployment

### DIFF
--- a/perfdash/Dockerfile
+++ b/perfdash/Dockerfile
@@ -12,8 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM debian:jessie
-RUN apt-get update
-RUN apt-get install -y -qq ca-certificates
-ADD perfdash /perfdash
-ADD www /www
+# Build the application
+FROM golang:1.14-buster as build
+
+RUN go get -u github.com/tools/godep
+WORKDIR /go/src/app
+COPY . /go/src/app
+RUN CGO_ENABLED=0 GOOS=linux GO111MODULE=off godep go test
+RUN CGO_ENABLED=0 GOOS=linux GO111MODULE=off godep go build -a -installsuffix cgo -ldflags '-w' -o perfdash
+
+# Copy files into run image
+FROM gcr.io/distroless/base-debian10
+WORKDIR /
+COPY --from=build /go/src/app/perfdash perfdash
+COPY www/ www

--- a/perfdash/Makefile
+++ b/perfdash/Makefile
@@ -21,7 +21,7 @@ run: perfdash
 		--githubConfigDir=https://api.github.com/repos/kubernetes/test-infra/contents/config/jobs/kubernetes/sig-scalability \
 		--githubConfigDir=https://api.github.com/repos/kubernetes/test-infra/contents/config/jobs/kubernetes/sig-release/release-branch-jobs
 
-container: perfdash
+container:
 	docker build --pull -t $(REPO)/perfdash:$(TAG) .
 
 push: container


### PR DESCRIPTION
This PR is 
- to resolve issue #604
- fix errors in https://github.com/kubernetes/perf-tests/pull/1161#issue-399878169

---
I have already test the `deployment.yaml` (with less builds) on a GKE cluster and it's works fine : cf. http://perf-dash-k8s.lab.kurtzemann.fr/

For the https connection I think the error doesn't comes from the container (and ca-certificates) but from the `perfdash-service.yaml` manifest with only declare a `LoadBalancer` service on port `80`. GCP will no create a LoadBalancer on port 443... Actually https://perf-dash.k8s.io doesn't work :(
