### PR TITLE
ClusterLoader - fix provider check that is always true

### DIFF
--- a/clusterloader2/cmd/clusterloader.go
+++ b/clusterloader2/cmd/clusterloader.go
@@ -146,7 +146,7 @@ func completeConfig(m *framework.MultiClientSet) error {
 			klog.Errorf("Getting master internal ip error: %v", err)
 		}
 	}
-	if clusterLoaderConfig.ClusterConfig.Provider != "aks" || clusterLoaderConfig.ClusterConfig.Provider != "gke" {
+	if clusterLoaderConfig.ClusterConfig.Provider != "aks" && clusterLoaderConfig.ClusterConfig.Provider != "gke" {
 		clusterLoaderConfig.ClusterConfig.SSHToMasterSupported = true
 	}
 	if clusterLoaderConfig.ClusterConfig.Provider == "aks" {

--- a/clusterloader2/pkg/measurement/common/bundle/test_metrics.go
+++ b/clusterloader2/pkg/measurement/common/bundle/test_metrics.go
@@ -40,46 +40,46 @@ func createTestMetricsMeasurement() measurement.Measurement {
 	var metrics testMetrics
 	var err error
 	if metrics.etcdMetrics, err = measurement.CreateMeasurement("EtcdMetrics"); err != nil {
-		klog.Errorf("%s: etcdMetrics creation error: %v", metrics, err)
+		klog.Errorf("%v: etcdMetrics creation error: %v", metrics, err)
 	}
 	if metrics.schedulingMetrics, err = measurement.CreateMeasurement("SchedulingMetrics"); err != nil {
-		klog.Errorf("%s: schedulingMetrics creation error: %v", metrics, err)
+		klog.Errorf("%v: schedulingMetrics creation error: %v", metrics, err)
 	}
 	if metrics.metricsForE2E, err = measurement.CreateMeasurement("MetricsForE2E"); err != nil {
-		klog.Errorf("%s: metricsForE2E creation error: %v", metrics, err)
+		klog.Errorf("%v: metricsForE2E creation error: %v", metrics, err)
 	}
 	if metrics.resourceUsageSummary, err = measurement.CreateMeasurement("ResourceUsageSummary"); err != nil {
-		klog.Errorf("%s: resourceUsageSummary creation error: %v", metrics, err)
+		klog.Errorf("%v: resourceUsageSummary creation error: %v", metrics, err)
 	}
 	if metrics.etcdCPUProfile, err = measurement.CreateMeasurement("CPUProfile"); err != nil {
-		klog.Errorf("%s: etcdCPUProfile creation error: %v", metrics, err)
+		klog.Errorf("%v: etcdCPUProfile creation error: %v", metrics, err)
 	}
 	if metrics.etcdMemoryProfile, err = measurement.CreateMeasurement("MemoryProfile"); err != nil {
-		klog.Errorf("%s: etcdMemoryProfile creation error: %v", metrics, err)
+		klog.Errorf("%v: etcdMemoryProfile creation error: %v", metrics, err)
 	}
 	if metrics.etcdMutexProfile, err = measurement.CreateMeasurement("MutexProfile"); err != nil {
-		klog.Errorf("%s: etcdMutexProfile creation error: %v", metrics, err)
+		klog.Errorf("%v: etcdMutexProfile creation error: %v", metrics, err)
 	}
 	if metrics.apiserverCPUProfile, err = measurement.CreateMeasurement("CPUProfile"); err != nil {
-		klog.Errorf("%s: apiserverCPUProfile creation error: %v", metrics, err)
+		klog.Errorf("%v: apiserverCPUProfile creation error: %v", metrics, err)
 	}
 	if metrics.apiserverMemoryProfile, err = measurement.CreateMeasurement("MemoryProfile"); err != nil {
-		klog.Errorf("%s: apiserverMemoryProfile creation error: %v", metrics, err)
+		klog.Errorf("%v: apiserverMemoryProfile creation error: %v", metrics, err)
 	}
 	if metrics.schedulerCPUProfile, err = measurement.CreateMeasurement("CPUProfile"); err != nil {
-		klog.Errorf("%s: schedulerCPUProfile creation error: %v", metrics, err)
+		klog.Errorf("%v: schedulerCPUProfile creation error: %v", metrics, err)
 	}
 	if metrics.schedulerMemoryProfile, err = measurement.CreateMeasurement("MemoryProfile"); err != nil {
-		klog.Errorf("%s: schedulerMemoryProfile creation error: %v", metrics, err)
+		klog.Errorf("%v: schedulerMemoryProfile creation error: %v", metrics, err)
 	}
 	if metrics.controllerManagerCPUProfile, err = measurement.CreateMeasurement("CPUProfile"); err != nil {
-		klog.Errorf("%s: controllerManagerCPUProfile creation error: %v", metrics, err)
+		klog.Errorf("%v: controllerManagerCPUProfile creation error: %v", metrics, err)
 	}
 	if metrics.controllerManagerMemoryProfile, err = measurement.CreateMeasurement("MemoryProfile"); err != nil {
-		klog.Errorf("%s: controllerManagerMemoryProfile creation error: %v", metrics, err)
+		klog.Errorf("%v: controllerManagerMemoryProfile creation error: %v", metrics, err)
 	}
 	if metrics.systemPodMetrics, err = measurement.CreateMeasurement("SystemPodMetrics"); err != nil {
-		klog.Errorf("%s: systemPodMetrics creation error: %v", metrics, err)
+		klog.Errorf("%v: systemPodMetrics creation error: %v", metrics, err)
 	}
 	return &metrics
 }


### PR DESCRIPTION
Golang >=1.12 throws a "suspect or" error

Before the change:
```
% go test ./...
?   	k8s.io/perf-tests/clusterloader2/api	[no test files]
# k8s.io/perf-tests/clusterloader2/pkg/measurement/common/bundle
pkg/measurement/common/bundle/test_metrics.go:43:3: Errorf format %s has arg metrics of wrong type k8s.io/perf-tests/clusterloader2/pkg/measurement/common/bundle.testMetrics
pkg/measurement/common/bundle/test_metrics.go:46:3: Errorf format %s has arg metrics of wrong type k8s.io/perf-tests/clusterloader2/pkg/measurement/common/bundle.testMetrics
pkg/measurement/common/bundle/test_metrics.go:49:3: Errorf format %s has arg metrics of wrong type k8s.io/perf-tests/clusterloader2/pkg/measurement/common/bundle.testMetrics
pkg/measurement/common/bundle/test_metrics.go:52:3: Errorf format %s has arg metrics of wrong type k8s.io/perf-tests/clusterloader2/pkg/measurement/common/bundle.testMetrics
pkg/measurement/common/bundle/test_metrics.go:55:3: Errorf format %s has arg metrics of wrong type k8s.io/perf-tests/clusterloader2/pkg/measurement/common/bundle.testMetrics
pkg/measurement/common/bundle/test_metrics.go:58:3: Errorf format %s has arg metrics of wrong type k8s.io/perf-tests/clusterloader2/pkg/measurement/common/bundle.testMetrics
pkg/measurement/common/bundle/test_metrics.go:61:3: Errorf format %s has arg metrics of wrong type k8s.io/perf-tests/clusterloader2/pkg/measurement/common/bundle.testMetrics
pkg/measurement/common/bundle/test_metrics.go:64:3: Errorf format %s has arg metrics of wrong type k8s.io/perf-tests/clusterloader2/pkg/measurement/common/bundle.testMetrics
pkg/measurement/common/bundle/test_metrics.go:67:3: Errorf format %s has arg metrics of wrong type k8s.io/perf-tests/clusterloader2/pkg/measurement/common/bundle.testMetrics
pkg/measurement/common/bundle/test_metrics.go:70:3: Errorf format %s has arg metrics of wrong type k8s.io/perf-tests/clusterloader2/pkg/measurement/common/bundle.testMetrics
pkg/measurement/common/bundle/test_metrics.go:73:3: Errorf format %s has arg metrics of wrong type k8s.io/perf-tests/clusterloader2/pkg/measurement/common/bundle.testMetrics
pkg/measurement/common/bundle/test_metrics.go:76:3: Errorf format %s has arg metrics of wrong type k8s.io/perf-tests/clusterloader2/pkg/measurement/common/bundle.testMetrics
pkg/measurement/common/bundle/test_metrics.go:79:3: Errorf format %s has arg metrics of wrong type k8s.io/perf-tests/clusterloader2/pkg/measurement/common/bundle.testMetrics
pkg/measurement/common/bundle/test_metrics.go:82:3: Errorf format %s has arg metrics of wrong type k8s.io/perf-tests/clusterloader2/pkg/measurement/common/bundle.testMetrics
# k8s.io/perf-tests/clusterloader2/cmd
cmd/clusterloader.go:149:5: suspect or: clusterLoaderConfig.ClusterConfig.Provider != "aks" || clusterLoaderConfig.ClusterConfig.Provider != "gke"
```
After the change:
```
% go test ./...
?   	k8s.io/perf-tests/clusterloader2/api	[no test files]
?   	k8s.io/perf-tests/clusterloader2/cmd	[no test files]
?   	k8s.io/perf-tests/clusterloader2/pkg/chaos	[no test files]
ok  	k8s.io/perf-tests/clusterloader2/pkg/config	(cached)
?   	k8s.io/perf-tests/clusterloader2/pkg/errors	[no test files]
?   	k8s.io/perf-tests/clusterloader2/pkg/execservice	[no test files]
?   	k8s.io/perf-tests/clusterloader2/pkg/flags	[no test files]
?   	k8s.io/perf-tests/clusterloader2/pkg/framework	[no test files]
ok  	k8s.io/perf-tests/clusterloader2/pkg/framework/client	(cached)
?   	k8s.io/perf-tests/clusterloader2/pkg/framework/config	[no test files]
?   	k8s.io/perf-tests/clusterloader2/pkg/imagepreload	[no test files]
?   	k8s.io/perf-tests/clusterloader2/pkg/measurement	[no test files]
ok  	k8s.io/perf-tests/clusterloader2/pkg/measurement/common	(cached)
?   	k8s.io/perf-tests/clusterloader2/pkg/measurement/common/bundle	[no test files]
?   	k8s.io/perf-tests/clusterloader2/pkg/measurement/common/probes	[no test files]
ok  	k8s.io/perf-tests/clusterloader2/pkg/measurement/common/slos	(cached)
ok  	k8s.io/perf-tests/clusterloader2/pkg/measurement/util	(cached)
?   	k8s.io/perf-tests/clusterloader2/pkg/measurement/util/checker	[no test files]
?   	k8s.io/perf-tests/clusterloader2/pkg/measurement/util/gatherers	[no test files]
?   	k8s.io/perf-tests/clusterloader2/pkg/measurement/util/informer	[no test files]
?   	k8s.io/perf-tests/clusterloader2/pkg/measurement/util/kubelet	[no test files]
?   	k8s.io/perf-tests/clusterloader2/pkg/measurement/util/kubemark	[no test files]
ok  	k8s.io/perf-tests/clusterloader2/pkg/measurement/util/runtimeobjects	(cached)
?   	k8s.io/perf-tests/clusterloader2/pkg/measurement/util/workerqueue	[no test files]
ok  	k8s.io/perf-tests/clusterloader2/pkg/prometheus	(cached)
?   	k8s.io/perf-tests/clusterloader2/pkg/state	[no test files]
?   	k8s.io/perf-tests/clusterloader2/pkg/test	[no test files]
?   	k8s.io/perf-tests/clusterloader2/pkg/tuningset	[no test files]
?   	k8s.io/perf-tests/clusterloader2/pkg/util	[no test files]
```