### PR TITLE
ClusterLoader - add kubelet port override option

### DIFF
--- a/clusterloader2/cmd/clusterloader.go
+++ b/clusterloader2/cmd/clusterloader.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"fmt"
+	"k8s.io/kubernetes/pkg/master/ports"
 	"os"
 	"path"
 	"time"
@@ -60,6 +61,7 @@ var (
 func initClusterFlags() {
 	flags.StringEnvVar(&clusterLoaderConfig.ClusterConfig.KubeConfigPath, "kubeconfig", "KUBECONFIG", "", "Path to the kubeconfig file")
 	flags.IntEnvVar(&clusterLoaderConfig.ClusterConfig.Nodes, "nodes", "NUM_NODES", 0, "number of nodes")
+	flags.IntEnvVar(&clusterLoaderConfig.ClusterConfig.KubeletPort, "kubelet-port", "KUBELET_PORT", ports.KubeletPort, "Port of the kubelet to use")
 	flags.StringEnvVar(&clusterLoaderConfig.ClusterConfig.Provider, "provider", "PROVIDER", "", "Cluster provider")
 	flags.StringEnvVar(&clusterLoaderConfig.ClusterConfig.EtcdCertificatePath, "etcd-certificate", "ETCD_CERTIFICATE", "/etc/srv/kubernetes/pki/etcd-apiserver-server.crt", "Path to the etcd certificate on the master machine")
 	flags.StringEnvVar(&clusterLoaderConfig.ClusterConfig.EtcdKeyPath, "etcd-key", "ETCD_KEY", "/etc/srv/kubernetes/pki/etcd-apiserver-server.key", "Path to the etcd key on the master machine")

--- a/clusterloader2/pkg/config/cluster.go
+++ b/clusterloader2/pkg/config/cluster.go
@@ -48,6 +48,7 @@ type ClusterConfig struct {
 	// APIServerPprofByClientEnabled determines whether kube-apiserver pprof endpoint can be accessed
 	// using kubernetes client. If false, clusterloader will avoid collecting kube-apiserver profiles.
 	APIServerPprofByClientEnabled bool
+	KubeletPort                   int
 }
 
 // PrometheusConfig represents all flags used by prometheus.

--- a/clusterloader2/pkg/measurement/common/resource_usage.go
+++ b/clusterloader2/pkg/measurement/common/resource_usage.go
@@ -104,13 +104,14 @@ func (e *resourceUsageMetricMeasurement) Execute(config *measurement.Measurement
 		}
 
 		klog.Infof("%s: starting resource usage collecting...", e)
-		e.gatherer, err = gatherers.NewResourceUsageGatherer(config.ClusterFramework.GetClientSets().GetClient(), host, provider, gatherers.ResourceGathererOptions{
-			InKubemark:                        strings.ToLower(provider) == "kubemark",
-			Nodes:                             nodesSet,
-			ResourceDataGatheringPeriod:       60 * time.Second,
-			MasterResourceDataGatheringPeriod: 10 * time.Second,
-			PrintVerboseLogs:                  false,
-		}, nil)
+		e.gatherer, err = gatherers.NewResourceUsageGatherer(config.ClusterFramework.GetClientSets().GetClient(), host, config.ClusterFramework.GetClusterConfig().KubeletPort,
+			provider, gatherers.ResourceGathererOptions{
+				InKubemark:                        strings.ToLower(provider) == "kubemark",
+				Nodes:                             nodesSet,
+				ResourceDataGatheringPeriod:       60 * time.Second,
+				MasterResourceDataGatheringPeriod: 10 * time.Second,
+				PrintVerboseLogs:                  false,
+			}, nil)
 		if err != nil {
 			return nil, err
 		}

--- a/clusterloader2/pkg/measurement/util/gatherers/container_resource_gatherer.go
+++ b/clusterloader2/pkg/measurement/util/gatherers/container_resource_gatherer.go
@@ -72,7 +72,7 @@ type ResourceGathererOptions struct {
 }
 
 // NewResourceUsageGatherer creates new instance of ContainerResourceGatherer
-func NewResourceUsageGatherer(c clientset.Interface, host, provider string, options ResourceGathererOptions, pods *corev1.PodList) (*ContainerResourceGatherer, error) {
+func NewResourceUsageGatherer(c clientset.Interface, host string, port int, provider string, options ResourceGathererOptions, pods *corev1.PodList) (*ContainerResourceGatherer, error) {
 	g := ContainerResourceGatherer{
 		client:       c,
 		isRunning:    true,
@@ -91,6 +91,7 @@ func NewResourceUsageGatherer(c clientset.Interface, host, provider string, opti
 			resourceDataGatheringPeriod: options.ResourceDataGatheringPeriod,
 			printVerboseLogs:            options.PrintVerboseLogs,
 			host:                        host,
+			port:                        port,
 			provider:                    provider,
 		})
 	} else {
@@ -142,6 +143,7 @@ func NewResourceUsageGatherer(c clientset.Interface, host, provider string, opti
 					inKubemark:                  false,
 					resourceDataGatheringPeriod: resourceDataGatheringPeriod,
 					printVerboseLogs:            options.PrintVerboseLogs,
+					port:                        port,
 				})
 				if options.Nodes == MasterNodes {
 					break

--- a/clusterloader2/pkg/measurement/util/gatherers/resource_gather_worker.go
+++ b/clusterloader2/pkg/measurement/util/gatherers/resource_gather_worker.go
@@ -40,6 +40,7 @@ type resourceGatherWorker struct {
 	resourceDataGatheringPeriod time.Duration
 	printVerboseLogs            bool
 	host                        string
+	port                        int
 	provider                    string
 }
 
@@ -58,7 +59,7 @@ func (w *resourceGatherWorker) singleProbe() {
 			}
 		}
 	} else {
-		nodeUsage, err := kubelet.GetOneTimeResourceUsageOnNode(w.c, w.nodeName, func() []string { return w.containerIDs })
+		nodeUsage, err := kubelet.GetOneTimeResourceUsageOnNode(w.c, w.nodeName, w.port, func() []string { return w.containerIDs })
 		if err != nil {
 			klog.Errorf("error while reading data from %v: %v", w.nodeName, err)
 			return


### PR DESCRIPTION
This is intended for clusters whose Kubelets
are not configured with the default 10250 port.