### PR TITLE
clusterloader: add a new flag delete-automanaged-namespaces

### DIFF
--- a/clusterloader2/cmd/clusterloader.go
+++ b/clusterloader2/cmd/clusterloader.go
@@ -67,6 +67,7 @@ func initClusterFlags() {
 	flags.StringEnvVar(&clusterLoaderConfig.ClusterConfig.EtcdKeyPath, "etcd-key", "ETCD_KEY", "/etc/srv/kubernetes/pki/etcd-apiserver-server.key", "Path to the etcd key on the master machine")
 	flags.IntEnvVar(&clusterLoaderConfig.ClusterConfig.EtcdInsecurePort, "etcd-insecure-port", "ETCD_INSECURE_PORT", 2382, "Inscure http port")
 	flags.BoolEnvVar(&clusterLoaderConfig.ClusterConfig.DeleteStaleNamespaces, "delete-stale-namespaces", "DELETE_STALE_NAMESPACES", false, "Whether to delete all stale namespaces before the test execution.")
+	flags.BoolEnvVar(&clusterLoaderConfig.ClusterConfig.DeleteAutomanagedNamespaces, "delete-automanaged-namespaces", "DELETE_AUTOMANAGED_NAMESPACES", true, "Whether to delete all automanaged namespaces after the test execution.")
 	flags.StringEnvVar(&clusterLoaderConfig.ClusterConfig.MasterName, "mastername", "MASTER_NAME", "", "Name of the masternode")
 	// TODO(#595): Change the name of the MASTER_IP and MASTER_INTERNAL_IP flags and vars to plural
 	flags.StringSliceEnvVar(&clusterLoaderConfig.ClusterConfig.MasterIPs, "masterip", "MASTER_IP", nil /*defaultValue*/, "Hostname/IP of the master node, supports multiple values when separated by commas")

--- a/clusterloader2/pkg/config/cluster.go
+++ b/clusterloader2/pkg/config/cluster.go
@@ -31,17 +31,18 @@ type ClusterLoaderConfig struct {
 
 // ClusterConfig is a structure that represents cluster description.
 type ClusterConfig struct {
-	KubeConfigPath             string
-	Nodes                      int
-	Provider                   string
-	EtcdCertificatePath        string
-	EtcdKeyPath                string
-	EtcdInsecurePort           int
-	MasterIPs                  []string
-	MasterInternalIPs          []string
-	MasterName                 string
-	KubemarkRootKubeConfigPath string
-	DeleteStaleNamespaces      bool
+	KubeConfigPath              string
+	Nodes                       int
+	Provider                    string
+	EtcdCertificatePath         string
+	EtcdKeyPath                 string
+	EtcdInsecurePort            int
+	MasterIPs                   []string
+	MasterInternalIPs           []string
+	MasterName                  string
+	KubemarkRootKubeConfigPath  string
+	DeleteStaleNamespaces       bool
+	DeleteAutomanagedNamespaces bool
 	// SSHToMasterSupported determines whether SSH access to master machines is possible.
 	// If false (impossible for many  providers), ClusterLoader will skip operations requiring it.
 	SSHToMasterSupported bool

--- a/clusterloader2/pkg/test/simple_test_executor.go
+++ b/clusterloader2/pkg/test/simple_test_executor.go
@@ -374,9 +374,11 @@ func isErrsCritical(*errors.ErrorList) bool {
 func cleanupResources(ctx Context) {
 	cleanupStartTime := time.Now()
 	ctx.GetMeasurementManager().Dispose()
-	if errList := ctx.GetClusterFramework().DeleteAutomanagedNamespaces(); !errList.IsEmpty() {
-		klog.Errorf("Resource cleanup error: %v", errList.String())
-		return
+	if ctx.GetClusterFramework().GetClusterConfig().DeleteAutomanagedNamespaces {
+		if errList := ctx.GetClusterFramework().DeleteAutomanagedNamespaces(); !errList.IsEmpty() {
+			klog.Errorf("Resource cleanup error: %v", errList.String())
+			return
+		}
 	}
 	klog.Infof("Resources cleanup time: %v", time.Since(cleanupStartTime))
 }


### PR DESCRIPTION
clusterloader automatically creates namespaces for testing and deletes the namespaces and  all resources in the namespaces after the test exits (successfully or failed).  We propose adding a flag _delete-auto-namespaces_ to specify whether or not delete the namespace after a test. 