### PR TITLE
clusterloader: enhance namespace configurations

### DIFF
--- a/clusterloader2/api/default.go
+++ b/clusterloader2/api/default.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"fmt"
+	"k8s.io/perf-tests/clusterloader2/pkg/util"
+)
+
+// SetDefaults set the default configuration parameters.
+func (conf *Config) SetDefaults() {
+	conf.Namespace.SetDefaults()
+
+	// TODO: remove after deprecated automanagedNamespaces is disabled.
+	if conf.Namespace.Number == 1 && conf.AutomanagedNamespaces > 1 {
+		conf.Namespace.Number = conf.AutomanagedNamespaces
+	}
+}
+
+// SetDefaults specifies the default values for namespace parameters.
+func (ns *NamespaceConfig) SetDefaults() {
+	if ns.Number == 0 {
+		ns.Number = 1
+	}
+
+	if ns.Prefix == "" {
+		ns.Prefix = fmt.Sprintf("test-%s", util.RandomDNS1123String(6))
+	}
+
+	defaultDeleteStaleNS := false
+	if ns.DeleteStaleNamespaces == nil {
+		ns.DeleteStaleNamespaces = &defaultDeleteStaleNS
+	}
+
+	defaultDeleteAutoNS := true
+	if ns.DeleteAutomanagedNamespaces == nil {
+		ns.DeleteAutomanagedNamespaces = &defaultDeleteAutoNS
+	}
+}

--- a/clusterloader2/api/types.go
+++ b/clusterloader2/api/types.go
@@ -41,8 +41,11 @@ type TestScenario struct {
 type Config struct {
 	// Name of the test case.
 	Name string `json: name`
-	// AutomanagedNamespaces is a number of automanaged namespaces.
-	AutomanagedNamespaces int32 `json: automanagedNamespaces`
+	// Deprecated: a number of automanaged namespaces.
+	// Use Namespace.Number instead.
+	AutomanagedNamespaces int32 `json: automanagedNamespaces,omitempty`
+	// Namespace is a structure for namespace configuration.
+	Namespace NamespaceConfig `json: namespace`
 	// Steps is a sequence of test steps executed in serial.
 	Steps []Step `json: steps`
 	// TuningSets is a collection of tuning sets that can be used by steps.
@@ -104,6 +107,19 @@ type Object struct {
 // ListUnknownObjectOptions struct specifies options for listing unknown objects.
 type ListUnknownObjectOptions struct {
 	LabelSelector *metav1.LabelSelector `json: labelSelector`
+}
+
+// NamespaceConfig defines namespace parameters.
+type NamespaceConfig struct {
+	// Number is a number of automanaged namespaces.
+	Number int32 `json: number,omitempty`
+	// NamePrefix is the name prefix of automanaged namespaces.
+	// It's optional, if set CL will use it, otherwise generate one with random string.
+	Prefix string `json: prefix,omitempty`
+	// DeleteStaleNamespaces specifies whether or not delete stale namepaces
+	DeleteStaleNamespaces *bool `json: deleteStaleNamespaces,omitempty`
+	// DeleteAutomanangedNamespaces specifies whether or not delete namepaces after a test
+	DeleteAutomanagedNamespaces *bool `json: deleteAutomanagedNamespaces,omitempty`
 }
 
 // NamespaceRange specifies the range of namespaces [Min, Max].

--- a/clusterloader2/api/validation.go
+++ b/clusterloader2/api/validation.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"fmt"
+	"k8s.io/perf-tests/clusterloader2/pkg/errors"
+)
+
+// Validate checks and verifies the configuration parameters.
+func (conf *Config) Validate() *errors.ErrorList {
+	return conf.Namespace.Validate()
+}
+
+// Validate checks and verifies the namespace parameters.
+func (ns *NamespaceConfig) Validate() *errors.ErrorList {
+	errList := errors.NewErrorList()
+	if ns.Number <= 0 {
+		errList.Append(fmt.Errorf("number of namespaces: %d was less than 1", ns.Number))
+	}
+
+	if errList.IsEmpty() {
+		return nil
+	}
+
+	return errList
+}

--- a/clusterloader2/cmd/clusterloader.go
+++ b/clusterloader2/cmd/clusterloader.go
@@ -66,8 +66,10 @@ func initClusterFlags() {
 	flags.StringEnvVar(&clusterLoaderConfig.ClusterConfig.EtcdCertificatePath, "etcd-certificate", "ETCD_CERTIFICATE", "/etc/srv/kubernetes/pki/etcd-apiserver-server.crt", "Path to the etcd certificate on the master machine")
 	flags.StringEnvVar(&clusterLoaderConfig.ClusterConfig.EtcdKeyPath, "etcd-key", "ETCD_KEY", "/etc/srv/kubernetes/pki/etcd-apiserver-server.key", "Path to the etcd key on the master machine")
 	flags.IntEnvVar(&clusterLoaderConfig.ClusterConfig.EtcdInsecurePort, "etcd-insecure-port", "ETCD_INSECURE_PORT", 2382, "Inscure http port")
-	flags.BoolEnvVar(&clusterLoaderConfig.ClusterConfig.DeleteStaleNamespaces, "delete-stale-namespaces", "DELETE_STALE_NAMESPACES", false, "Whether to delete all stale namespaces before the test execution.")
-	flags.BoolEnvVar(&clusterLoaderConfig.ClusterConfig.DeleteAutomanagedNamespaces, "delete-automanaged-namespaces", "DELETE_AUTOMANAGED_NAMESPACES", true, "Whether to delete all automanaged namespaces after the test execution.")
+	flags.BoolEnvVar(&clusterLoaderConfig.ClusterConfig.DeleteStaleNamespaces, "delete-stale-namespaces", "DELETE_STALE_NAMESPACES", false, "DEPRECATED: Whether to delete all stale namespaces before the test execution.")
+	flags.MarkDeprecated("delete-stale-namespaces", "specify deleteStaleNamespaces in testconfig file instead.")
+	flags.BoolEnvVar(&clusterLoaderConfig.ClusterConfig.DeleteAutomanagedNamespaces, "delete-automanaged-namespaces", "DELETE_AUTOMANAGED_NAMESPACES", true, "DEPRECATED: Whether to delete all automanaged namespaces after the test execution.")
+	flags.MarkDeprecated("delete-automanaged-namespaces", "specify deleteAutomanagedNamespaces in testconfig file instead.")
 	flags.StringEnvVar(&clusterLoaderConfig.ClusterConfig.MasterName, "mastername", "MASTER_NAME", "", "Name of the masternode")
 	// TODO(#595): Change the name of the MASTER_IP and MASTER_INTERNAL_IP flags and vars to plural
 	flags.StringSliceEnvVar(&clusterLoaderConfig.ClusterConfig.MasterIPs, "masterip", "MASTER_IP", nil /*defaultValue*/, "Hostname/IP of the master node, supports multiple values when separated by commas")

--- a/clusterloader2/pkg/config/cluster.go
+++ b/clusterloader2/pkg/config/cluster.go
@@ -31,17 +31,19 @@ type ClusterLoaderConfig struct {
 
 // ClusterConfig is a structure that represents cluster description.
 type ClusterConfig struct {
-	KubeConfigPath              string
-	Nodes                       int
-	Provider                    string
-	EtcdCertificatePath         string
-	EtcdKeyPath                 string
-	EtcdInsecurePort            int
-	MasterIPs                   []string
-	MasterInternalIPs           []string
-	MasterName                  string
-	KubemarkRootKubeConfigPath  string
-	DeleteStaleNamespaces       bool
+	KubeConfigPath             string
+	Nodes                      int
+	Provider                   string
+	EtcdCertificatePath        string
+	EtcdKeyPath                string
+	EtcdInsecurePort           int
+	MasterIPs                  []string
+	MasterInternalIPs          []string
+	MasterName                 string
+	KubemarkRootKubeConfigPath string
+	// Deprecated: use NamespaceConfig.DeleteStaleNamespaces instead.
+	DeleteStaleNamespaces bool
+	// Deprecated: use NamespaceConfig.DeleteAutomanagedNamespaces instead.
 	DeleteAutomanagedNamespaces bool
 	// SSHToMasterSupported determines whether SSH access to master machines is possible.
 	// If false (impossible for many  providers), ClusterLoader will skip operations requiring it.

--- a/clusterloader2/pkg/flags/flags.go
+++ b/clusterloader2/pkg/flags/flags.go
@@ -114,6 +114,11 @@ func Parse() error {
 	return nil
 }
 
+// MarkDeprecated indicates that a flag is deprecated
+func MarkDeprecated(name string, usageMessage string) error {
+	return pflag.CommandLine.MarkDeprecated(name, usageMessage)
+}
+
 func parseEnvString(s *string, envVariable, defaultValue string) error {
 	*s = defaultValue
 	if envVariable != "" {

--- a/clusterloader2/pkg/test/test.go
+++ b/clusterloader2/pkg/test/test.go
@@ -61,5 +61,19 @@ func RunTest(clusterFramework, prometheusFramework *framework.Framework, cluster
 	if err != nil {
 		return errors.NewErrorList(fmt.Errorf("config reading error: %v", err))
 	}
+
+	// TODO: remove them after the deprecated command options are removed.
+	if testConfig.Namespace.DeleteStaleNamespaces == nil {
+		testConfig.Namespace.DeleteStaleNamespaces = &clusterFramework.GetClusterConfig().DeleteStaleNamespaces
+	}
+	if testConfig.Namespace.DeleteAutomanagedNamespaces == nil {
+		testConfig.Namespace.DeleteAutomanagedNamespaces = &clusterFramework.GetClusterConfig().DeleteAutomanagedNamespaces
+	}
+
+	testConfig.SetDefaults()
+	if err := testConfig.Validate(); err != nil {
+		return err
+	}
+
 	return Test.ExecuteTest(ctx, testConfig)
 }

--- a/clusterloader2/testing/access-tokens/config.yaml
+++ b/clusterloader2/testing/access-tokens/config.yaml
@@ -42,7 +42,8 @@
 {{$RESTART_COUNT_THRESHOLD_OVERRIDES:= DefaultParam .RESTART_COUNT_THRESHOLD_OVERRIDES ""}}
 
 name: access-tokens
-automanagedNamespaces: {{$namespaces}}
+namespace:
+  number: {{$namespaces}}
 tuningSets:
   - name: Sequence
     parallelismLimitedLoad:

--- a/clusterloader2/testing/density/config.yaml
+++ b/clusterloader2/testing/density/config.yaml
@@ -35,7 +35,8 @@
 {{$saturationDeploymentHardTimeout := MaxInt $saturationDeploymentTimeout 1200}}
 
 name: density
-automanagedNamespaces: {{$namespaces}}
+namespace:
+  number: {{$namespaces}}
 tuningSets:
 - name: Uniform5qps
   qpsLoad:

--- a/clusterloader2/testing/density/high-density-config.yaml
+++ b/clusterloader2/testing/density/high-density-config.yaml
@@ -36,7 +36,8 @@
 {{$saturationDeploymentHardTimeout := MaxInt $saturationDeploymentTimeout 1200}}
 
 name: density
-automanagedNamespaces: {{$namespaces}}
+namespace:
+  number: {{$namespaces}}
 tuningSets:
 - name: Uniform5qps
   qpsLoad:

--- a/clusterloader2/testing/density/legacy/config.yaml
+++ b/clusterloader2/testing/density/legacy/config.yaml
@@ -29,7 +29,8 @@
 {{$saturationRCHardTimeout := MaxInt $saturationRCTimeout 1200}}
 
 name: density
-automanagedNamespaces: {{$namespaces}}
+namespace:
+  number: {{$namespaces}}
 tuningSets:
 - name: Uniform5qps
   qpsLoad:

--- a/clusterloader2/testing/experimental/storage/pod-startup/config.yaml
+++ b/clusterloader2/testing/experimental/storage/pod-startup/config.yaml
@@ -29,7 +29,8 @@
 
 
 name: storage
-automanagedNamespaces: {{$namespaces}}
+namespace:
+  number: {{$namespaces}}
 tuningSets:
 - name: UniformQPS
   qpsLoad:

--- a/clusterloader2/testing/l4ilb/config.yaml
+++ b/clusterloader2/testing/l4ilb/config.yaml
@@ -11,7 +11,8 @@
 
 #Test
 name: ilbload
-automanagedNamespaces: {{$namespaces}}
+namespace:
+  number: {{$namespaces}}
 tuningSets:
 - name: ILBConstantQPS
   qpsLoad:

--- a/clusterloader2/testing/load/config.yaml
+++ b/clusterloader2/testing/load/config.yaml
@@ -44,7 +44,8 @@
 {{$bigDeploymentsPerNamespace := SubtractInt $bigDeploymentsPerNamespace 1}}
 
 name: load
-automanagedNamespaces: {{$namespaces}}
+namespace:
+  number: {{$namespaces}}
 tuningSets:
 - name: Sequence
   parallelismLimitedLoad:

--- a/clusterloader2/testing/load/experimental-config.yaml
+++ b/clusterloader2/testing/load/experimental-config.yaml
@@ -71,7 +71,8 @@
 # END pod-startup-latency section
 
 name: load
-automanagedNamespaces: {{AddInt $namespaces $schedulerThroughputNamespaces}}
+namespace:
+  number: {{AddInt $namespaces $schedulerThroughputNamespaces}}
 tuningSets:
 - name: Sequence
   parallelismLimitedLoad:

--- a/clusterloader2/testing/load/experimental/bundled_services_and_deployments.yaml
+++ b/clusterloader2/testing/load/experimental/bundled_services_and_deployments.yaml
@@ -29,7 +29,8 @@
 
 
 name: load
-automanagedNamespaces: {{$namespaces}}
+namespace:
+  number: {{$namespaces}}
 tuningSets:
 - name: RandomizedSaturationTimeLimited
   RandomizedTimeLimitedLoad:

--- a/clusterloader2/testing/load/legacy/config.yaml
+++ b/clusterloader2/testing/load/legacy/config.yaml
@@ -27,7 +27,8 @@
 
 
 name: load
-automanagedNamespaces: {{$namespaces}}
+namespace:
+  number: {{$namespaces}}
 tuningSets:
 - name: Sequence
   parallelismLimitedLoad:


### PR DESCRIPTION
This PR is to separate namespace specific configurations from cluster level configurations (e.g., kubeconfig, master-ip). The cluster configurations belong to config.ClusterConfig and are specified as the command line options while namespace configuration is a part of api.Config and deigned in the testconfig.yaml file.

1.  A new structure _NamespaceConfig_ is defined for namespace parameters as a part of api.Config and the values are specified in the testconfig yaml file.  If a parameter is not specified, a default value is used.
2. A new parameter "_Prefix_" is added to specify the prefix of auto-created namespaces. Clusterloader uses the specified prefix if set otherwise uses the default "_test-\<random string\>_".
3. Add two files _api.default.go_ and _api.validate.go_  for setting default parameters and checking the validness of namespace parameters. 
4. _"automanagedNamespaces"_  in testconfig file and _"delete-stale-namespaces"_ and _"delete-automananged-namespaces"_ in the command line can still be used with deprecate warnings. 

New structure for namespace configuration
```
// NamespaceConfig defines namespace parameters.
type NamespaceConfig struct {
        Number int32  `json: number` 
        Prefix string  `json: prefix`
        DeleteStaleNamespaces *bool `json.deleteStaleNamespaces`
        DeleteAutomanagedNamespaces *bool `json.deleteAutomanagedNamespaces`
}
```
An example namespace configuration in the testconfig file.
```
namespace:
   number: 1
   namePrefix: "test"
   EnableExistingNamespaces: false
   DeleteStaleNamespaces: false
```
An issue https://github.com/kubernetes/perf-tests/issues/1169 was opened and discussed with @wojtek-t. The support of pre-created existing namespaces will be another PR after this PR is approved and merged. 