### PR TITLE
Remove namespace field from perfdash deployment

### DIFF
--- a/perfdash/deployment.yaml
+++ b/perfdash/deployment.yaml
@@ -2,7 +2,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: perfdash
-  namespace: default
   labels:
     app: perfdash
 spec:


### PR DESCRIPTION
/cc @mm4tt 

as discussed with Matt I want to remove duplicated manifests from https://github.com/kubernetes/k8s.io/tree/master/perf-dash.k8s.io and instead use the ones from this repository and removing `namespace` gives me possibility to use the manifest from this repository with `-n perfdash` flag

Signed-off-by: Bart Smykla <bsmykla@vmware.com>