### PR TITLE
ClusterLoader: copy unexported legacy function

### DIFF
--- a/clusterloader2/pkg/measurement/common/scheduler_latency.go
+++ b/clusterloader2/pkg/measurement/common/scheduler_latency.go
@@ -30,7 +30,6 @@ import (
 	"k8s.io/klog"
 	"k8s.io/kubernetes/pkg/master/ports"
 	schedulermetric "k8s.io/kubernetes/pkg/scheduler/metrics"
-	"k8s.io/kubernetes/pkg/util/system"
 	"k8s.io/perf-tests/clusterloader2/pkg/measurement"
 	measurementutil "k8s.io/perf-tests/clusterloader2/pkg/measurement/util"
 	"k8s.io/perf-tests/clusterloader2/pkg/util"
@@ -88,7 +87,7 @@ func (s *schedulerLatencyMeasurement) Execute(config *measurement.MeasurementCon
 
 	var masterRegistered = false
 	for _, node := range nodes.Items {
-		if system.IsMasterNode(node.Name) {
+		if util.LegacyIsMasterNode(node.Name) {
 			masterRegistered = true
 		}
 	}

--- a/clusterloader2/pkg/measurement/util/gatherers/container_resource_gatherer.go
+++ b/clusterloader2/pkg/measurement/util/gatherers/container_resource_gatherer.go
@@ -27,8 +27,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/klog"
-	"k8s.io/kubernetes/pkg/util/system"
 	"k8s.io/perf-tests/clusterloader2/pkg/measurement/util"
+	pkgutil "k8s.io/perf-tests/clusterloader2/pkg/util"
 )
 
 // NodesSet is a flag defining the node set range.
@@ -105,10 +105,10 @@ func NewResourceUsageGatherer(c clientset.Interface, host string, port int, prov
 		}
 		dnsNodes := make(map[string]bool)
 		for _, pod := range pods.Items {
-			if (options.Nodes == MasterNodes) && !system.IsMasterNode(pod.Spec.NodeName) {
+			if (options.Nodes == MasterNodes) && !pkgutil.LegacyIsMasterNode(pod.Spec.NodeName) {
 				continue
 			}
-			if (options.Nodes == MasterAndDNSNodes) && !system.IsMasterNode(pod.Spec.NodeName) && pod.Labels["k8s-app"] != "kube-dns" {
+			if (options.Nodes == MasterAndDNSNodes) && !pkgutil.LegacyIsMasterNode(pod.Spec.NodeName) && pod.Labels["k8s-app"] != "kube-dns" {
 				continue
 			}
 			for _, container := range pod.Status.InitContainerStatuses {
@@ -127,10 +127,10 @@ func NewResourceUsageGatherer(c clientset.Interface, host string, port int, prov
 		}
 
 		for _, node := range nodeList.Items {
-			if options.Nodes == AllNodes || system.IsMasterNode(node.Name) || dnsNodes[node.Name] {
+			if options.Nodes == AllNodes || pkgutil.LegacyIsMasterNode(node.Name) || dnsNodes[node.Name] {
 				g.workerWg.Add(1)
 				resourceDataGatheringPeriod := options.ResourceDataGatheringPeriod
-				if system.IsMasterNode(node.Name) {
+				if pkgutil.LegacyIsMasterNode(node.Name) {
 					resourceDataGatheringPeriod = options.MasterResourceDataGatheringPeriod
 				}
 				g.workers = append(g.workers, resourceGatherWorker{

--- a/clusterloader2/pkg/prometheus/prometheus.go
+++ b/clusterloader2/pkg/prometheus/prometheus.go
@@ -31,7 +31,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog"
-	"k8s.io/kubernetes/pkg/util/system"
 	"k8s.io/perf-tests/clusterloader2/pkg/config"
 	"k8s.io/perf-tests/clusterloader2/pkg/flags"
 	"k8s.io/perf-tests/clusterloader2/pkg/framework"
@@ -263,7 +262,7 @@ func (pc *PrometheusController) runNodeExporter() error {
 	numMasters := 0
 	for _, node := range nodes {
 		node := node
-		if system.IsMasterNode(node.Name) {
+		if util.LegacyIsMasterNode(node.Name) {
 			numMasters++
 			g.Go(func() error {
 				f, err := os.Open(os.ExpandEnv(nodeExporterPod))


### PR DESCRIPTION
This function was moved to private in k8s >=1.16,
but ClusterLoader still depends on it in a few places.
Copying the function in the meantime unblocks upgrading Go,
upgrading k8s, and moving to Go modules in ClusterLoader.

Suggested in https://github.com/kubernetes/perf-tests/pull/1171#discussion_r409777034 that I do this PR first.