### PR TITLE
Add configurable timeout for probes in configs

### DIFF
--- a/clusterloader2/testing/density/config.yaml
+++ b/clusterloader2/testing/density/config.yaml
@@ -34,6 +34,9 @@
 # failure won't fail the test. See https://github.com/kubernetes/kubernetes/issues/73461#issuecomment-467338711
 {{$saturationDeploymentHardTimeout := MaxInt $saturationDeploymentTimeout 1200}}
 
+# Probe measurements shared parameter
+{{$PROBE_MEASUREMENTS_CHECK_PROBES_READY_TIMEOUT := DefaultParam .CL2_PROBE_MEASUREMENTS_CHECK_PROBES_READY_TIMEOUT "5m"}}
+
 name: density
 automanagedNamespaces: {{$namespaces}}
 tuningSets:
@@ -64,11 +67,13 @@ steps:
     Method: InClusterNetworkLatency
     Params:
       action: start
+      checkProbesReadyTimeout: {{$PROBE_MEASUREMENTS_CHECK_PROBES_READY_TIMEOUT}}
       replicasPerProbe: {{AddInt 2 (DivideInt .Nodes 100)}}
   - Identifier: DnsLookupLatency
     Method: DnsLookupLatency
     Params:
       action: start
+      checkProbesReadyTimeout: {{$PROBE_MEASUREMENTS_CHECK_PROBES_READY_TIMEOUT}}
       replicasPerProbe: {{AddInt 2 (DivideInt .Nodes 100)}}
   - Identifier: TestMetrics
     Method: TestMetrics

--- a/clusterloader2/testing/load/config.yaml
+++ b/clusterloader2/testing/load/config.yaml
@@ -43,6 +43,9 @@
 {{$mediumDeploymentsPerNamespace := SubtractInt $mediumDeploymentsPerNamespace 1}}
 {{$bigDeploymentsPerNamespace := SubtractInt $bigDeploymentsPerNamespace 1}}
 
+# Probe measurements shared parameter
+{{$PROBE_MEASUREMENTS_CHECK_PROBES_READY_TIMEOUT := DefaultParam .CL2_PROBE_MEASUREMENTS_CHECK_PROBES_READY_TIMEOUT "5m"}}
+
 name: load
 automanagedNamespaces: {{$namespaces}}
 tuningSets:
@@ -87,11 +90,13 @@ steps:
     Method: InClusterNetworkLatency
     Params:
       action: start
+      checkProbesReadyTimeout: {{$PROBE_MEASUREMENTS_CHECK_PROBES_READY_TIMEOUT}}
       replicasPerProbe: {{AddInt 2 (DivideInt .Nodes 100)}}
   - Identifier: DnsLookupLatency
     Method: DnsLookupLatency
     Params:
       action: start
+      checkProbesReadyTimeout: {{$PROBE_MEASUREMENTS_CHECK_PROBES_READY_TIMEOUT}}
       replicasPerProbe: {{AddInt 2 (DivideInt .Nodes 100)}}
   {{if $PROMETHEUS_SCRAPE_KUBE_PROXY}}
   - Identifier: NetworkProgrammingLatency

--- a/clusterloader2/testing/load/experimental-config.yaml
+++ b/clusterloader2/testing/load/experimental-config.yaml
@@ -70,6 +70,9 @@
 {{$latencyReplicas := DivideInt $totalLatencyPods $namespaces}}
 # END pod-startup-latency section
 
+# Probe measurements shared parameter
+{{$PROBE_MEASUREMENTS_CHECK_PROBES_READY_TIMEOUT := DefaultParam .CL2_PROBE_MEASUREMENTS_CHECK_PROBES_READY_TIMEOUT "5m"}}
+
 name: load
 automanagedNamespaces: {{AddInt $namespaces $schedulerThroughputNamespaces}}
 tuningSets:
@@ -123,11 +126,13 @@ steps:
     Method: InClusterNetworkLatency
     Params:
       action: start
+      checkProbesReadyTimeout: {{$PROBE_MEASUREMENTS_CHECK_PROBES_READY_TIMEOUT}}
       replicasPerProbe: {{AddInt 2 (DivideInt .Nodes 100)}}
   - Identifier: DnsLookupLatency
     Method: DnsLookupLatency
     Params:
       action: start
+      checkProbesReadyTimeout: {{$PROBE_MEASUREMENTS_CHECK_PROBES_READY_TIMEOUT}}
       replicasPerProbe: {{AddInt 2 (DivideInt .Nodes 100)}}
   {{if $PROMETHEUS_SCRAPE_KUBE_PROXY}}
   - Identifier: NetworkProgrammingLatency


### PR DESCRIPTION
Configure tests to allow custom timeout for starting probes measurements.

Ref. #1110 