### PR TITLE
Pass proper GCP project with snapshots storage to PrometheusController

### DIFF
--- a/clusterloader2/pkg/config/cluster.go
+++ b/clusterloader2/pkg/config/cluster.go
@@ -60,6 +60,7 @@ type PrometheusConfig struct {
 	ScrapeNodeExporter bool
 	ScrapeKubelets     bool
 	ScrapeKubeProxy    bool
+	SnapshotProject    string
 }
 
 // GetMasterIp returns the first master ip, added for backward compatibility.

--- a/clusterloader2/pkg/prometheus/prometheus.go
+++ b/clusterloader2/pkg/prometheus/prometheus.go
@@ -57,6 +57,7 @@ func InitFlags(p *config.PrometheusConfig) {
 	flags.BoolEnvVar(&p.ScrapeNodeExporter, "prometheus-scrape-node-exporter", "PROMETHEUS_SCRAPE_NODE_EXPORTER", false, "Whether to scrape node exporter metrics.")
 	flags.BoolEnvVar(&p.ScrapeKubelets, "prometheus-scrape-kubelets", "PROMETHEUS_SCRAPE_KUBELETS", false, "Whether to scrape kubelets. Experimental, may not work in larger clusters. Requires heapster node to be at least n1-standard-4, which needs to be provided manually.")
 	flags.BoolEnvVar(&p.ScrapeKubeProxy, "prometheus-scrape-kube-proxy", "PROMETHEUS_SCRAPE_KUBE_PROXY", true, "Whether to scrape kube proxy.")
+	flags.StringEnvVar(&p.SnapshotProject, "experimental-snapshot-project", "PROJECT", "", "GCP project used where disks and snapshots are located.")
 }
 
 // PrometheusController is a util for managing (setting up / tearing down) the prometheus stack in


### PR DESCRIPTION
When using pod-utils for SIG scalability test jobs, clusterloader was attempting to snapshot Prometheus' PDs to Prow cluster project. The proposed flag `experimental-snapshot-project` (which defaults to `PROJECT` environment variable value which is set [here](https://github.com/kubernetes/test-infra/blob/5f62df0ca89fd93fdcc3f1a7a76019bb115ffa47/kubetest/main.go#L775)) is added to be utilized by gcloud command that performs snapshotting.

/sig scalability