### PR TITLE
Bump perf-dash to 2.23

### DIFF
--- a/perfdash/Makefile
+++ b/perfdash/Makefile
@@ -1,7 +1,7 @@
 all: push
 
 # See deployment.yaml for the version currently running-- bump this ahead before rebuilding!
-TAG = 2.22
+TAG = 2.23
 
 REPO = gcr.io/k8s-testimages
 GODEP = CGO_ENABLED=0 GOOS=linux GO111MODULE=off godep

--- a/perfdash/deployment.yaml
+++ b/perfdash/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: perfdash
-        image: gcr.io/k8s-testimages/perfdash:2.22
+        image: gcr.io/k8s-testimages/perfdash:2.23
         command:
           - /perfdash
           -   --www=true


### PR DESCRIPTION
This is to include https://github.com/kubernetes/perf-tests/pull/1172