### PR TITLE
Cleanup clusterloader2 load testing experimental config file

### DIFF
--- a/clusterloader2/testing/load/experimental-config.yaml
+++ b/clusterloader2/testing/load/experimental-config.yaml
@@ -19,12 +19,7 @@
 {{$ENABLE_CHAOSMONKEY := DefaultParam .ENABLE_CHAOSMONKEY false}}
 {{$PROMETHEUS_SCRAPE_KUBE_PROXY := DefaultParam .PROMETHEUS_SCRAPE_KUBE_PROXY true}}
 {{$ENABLE_PROMETHEUS_API_RESPONSIVENESS := DefaultParam .ENABLE_PROMETHEUS_API_RESPONSIVENESS false}}
-{{$ENABLE_CONFIGMAPS := DefaultParam .CL2_ENABLE_CONFIGMAPS true}}
-{{$ENABLE_DAEMONSETS := DefaultParam .CL2_ENABLE_DAEMONSETS true}}
-{{$ENABLE_JOBS := DefaultParam .CL2_ENABLE_JOBS true}}
 {{$ENABLE_PVS := DefaultParam .CL2_ENABLE_PVS true}}
-{{$ENABLE_SECRETS := DefaultParam .CL2_ENABLE_SECRETS true}}
-{{$ENABLE_STATEFULSETS := DefaultParam .CL2_ENABLE_STATEFULSETS true}}
 {{$ENABLE_NETWORKPOLICIES := DefaultParam .CL2_ENABLE_NETWORKPOLICIES false}}
 {{$ENABLE_SYSTEM_POD_METRICS:= DefaultParam .ENABLE_SYSTEM_POD_METRICS true}}
 {{$USE_SIMPLE_LATENCY_QUERY := DefaultParam .USE_SIMPLE_LATENCY_QUERY false}}
@@ -42,13 +37,13 @@
 # smallDeployments - 1/2 of namespace pods should be in small Deployments.
 {{$smallDeploymentsPerNamespace := DivideInt $podsPerNamespace (MultiplyInt 2 $SMALL_GROUP_SIZE)}}
 # If StatefulSets are enabled reduce the number of small and medium deployments per namespace
-{{$smallDeploymentsPerNamespace := SubtractInt $smallDeploymentsPerNamespace (IfThenElse $ENABLE_STATEFULSETS $SMALL_STATEFUL_SETS_PER_NAMESPACE 0)}}
-{{$mediumDeploymentsPerNamespace := SubtractInt $mediumDeploymentsPerNamespace (IfThenElse $ENABLE_STATEFULSETS $MEDIUM_STATEFUL_SETS_PER_NAMESPACE 0)}}
+{{$smallDeploymentsPerNamespace := SubtractInt $smallDeploymentsPerNamespace $SMALL_STATEFUL_SETS_PER_NAMESPACE}}
+{{$mediumDeploymentsPerNamespace := SubtractInt $mediumDeploymentsPerNamespace $MEDIUM_STATEFUL_SETS_PER_NAMESPACE}}
 
 # If Jobs are enabled reduce the number of small, medium, big deployments per namespace.
-{{$smallDeploymentsPerNamespace := SubtractInt $smallDeploymentsPerNamespace (IfThenElse $ENABLE_JOBS 1 0)}}
-{{$mediumDeploymentsPerNamespace := SubtractInt $mediumDeploymentsPerNamespace (IfThenElse $ENABLE_JOBS 1 0)}}
-{{$bigDeploymentsPerNamespace := SubtractInt $bigDeploymentsPerNamespace (IfThenElse $ENABLE_JOBS 1 0)}}
+{{$smallDeploymentsPerNamespace := SubtractInt $smallDeploymentsPerNamespace 1}}
+{{$mediumDeploymentsPerNamespace := SubtractInt $mediumDeploymentsPerNamespace 1}}
+{{$bigDeploymentsPerNamespace := SubtractInt $bigDeploymentsPerNamespace 1}}
 
 # The minimal number of pods to be used to measure various things like
 # pod-startup-latency or scheduler-throughput. The purpose of it is to avoid
@@ -177,7 +172,6 @@ steps:
     - basename: small-service
       objectTemplatePath: service.yaml
 
-{{if $ENABLE_DAEMONSETS}}
 - name: Creating PriorityClass for DaemonSets
   phases:
   - replicasPerNamespace: 1
@@ -185,7 +179,6 @@ steps:
     objectBundle:
       - basename: daemonset-priorityclass
         objectTemplatePath: daemonset-priorityclass.yaml
-{{end}}
 
 - name: Starting measurement for waiting for pods
   measurements:
@@ -197,7 +190,6 @@ steps:
       kind: Deployment
       labelSelector: group = load
       operationTimeout: 15m
-  {{if $ENABLE_STATEFULSETS}}
   - Identifier: WaitForRunningStatefulSets
     Method: WaitForControlledPodsRunning
     Params:
@@ -206,8 +198,6 @@ steps:
       kind: StatefulSet
       labelSelector: group = load
       operationTimeout: 15m
-  {{end}}
-  {{if $ENABLE_DAEMONSETS}}
   - Identifier: WaitForRunningDaemonSets
     Method: WaitForControlledPodsRunning
     Params:
@@ -216,8 +206,6 @@ steps:
       kind: DaemonSet
       labelSelector: group = load
       operationTimeout: 15m
-  {{end}}
-  {{if $ENABLE_JOBS}}
   - Identifier: WaitForRunningJobs
     Method: WaitForControlledPodsRunning
     Params:
@@ -226,11 +214,9 @@ steps:
       kind: Job
       labelSelector: group = load
       operationTimeout: 15m
-  {{end}}
 
 - name: Creating objects
   phases:
-  {{if $ENABLE_DAEMONSETS}}
   - namespaceRange:
       min: 1
       max: 1
@@ -241,21 +227,16 @@ steps:
       objectTemplatePath: daemonset.yaml
       templateFillMap:
         Image: k8s.gcr.io/pause:3.0
-  {{end}}
   - namespaceRange:
       min: 1
       max: {{$namespaces}}
     replicasPerNamespace: {{$bigDeploymentsPerNamespace}}
     tuningSet: RandomizedSaturationTimeLimited
     objectBundle:
-    {{if $ENABLE_CONFIGMAPS}}
     - basename: big-deployment
       objectTemplatePath: configmap.yaml
-    {{end}}
-    {{if $ENABLE_SECRETS}}
     - basename: big-deployment
       objectTemplatePath: secret.yaml
-    {{end}}
     {{if $ENABLE_NETWORKPOLICIES}}
     - basename: big-deployment
       objectTemplatePath: networkpolicy.yaml
@@ -273,14 +254,10 @@ steps:
     replicasPerNamespace: {{$mediumDeploymentsPerNamespace}}
     tuningSet: RandomizedSaturationTimeLimited
     objectBundle:
-    {{if $ENABLE_CONFIGMAPS}}
     - basename: medium-deployment
       objectTemplatePath: configmap.yaml
-    {{end}}
-    {{if $ENABLE_SECRETS}}
     - basename: medium-deployment
       objectTemplatePath: secret.yaml
-    {{end}}
     {{if $ENABLE_NETWORKPOLICIES}}
     - basename: medium-deployment
       objectTemplatePath: networkpolicy.yaml
@@ -298,14 +275,10 @@ steps:
     replicasPerNamespace: {{$smallDeploymentsPerNamespace}}
     tuningSet: RandomizedSaturationTimeLimited
     objectBundle:
-    {{if $ENABLE_CONFIGMAPS}}
     - basename: small-deployment
       objectTemplatePath: configmap.yaml
-    {{end}}
-    {{if $ENABLE_SECRETS}}
     - basename: small-deployment
       objectTemplatePath: secret.yaml
-    {{end}}
     {{if $ENABLE_NETWORKPOLICIES}}
     - basename: small-deployment
       objectTemplatePath: networkpolicy.yaml
@@ -317,7 +290,6 @@ steps:
         ReplicasMax: {{$SMALL_GROUP_SIZE}}
         SvcName: small-service
         CpuRequest: 5m
-  {{if $ENABLE_STATEFULSETS}}
   - namespaceRange:
       min: 1
       max: {{$namespaces}}
@@ -344,8 +316,6 @@ steps:
         templateFillMap:
           ReplicasMin: {{$MEDIUM_GROUP_SIZE}}
           ReplicasMax: {{$MEDIUM_GROUP_SIZE}}
-  {{end}}
-  {{if $ENABLE_JOBS}}
   - namespaceRange:
       min: 1
       max: {{$namespaces}}
@@ -379,7 +349,6 @@ steps:
         templateFillMap:
           ReplicasMin: {{$BIG_GROUP_SIZE}}
           ReplicasMax: {{$BIG_GROUP_SIZE}}
-  {{end}}
 
 - name: Waiting for pods to be running
   measurements:
@@ -387,24 +356,18 @@ steps:
     Method: WaitForControlledPodsRunning
     Params:
       action: gather
-  {{if $ENABLE_STATEFULSETS}}
   - Identifier: WaitForRunningStatefulSets
     Method: WaitForControlledPodsRunning
     Params:
       action: gather
-  {{end}}
-  {{if $ENABLE_DAEMONSETS}}
   - Identifier: WaitForRunningDaemonSets
     Method: WaitForControlledPodsRunning
     Params:
       action: gather
-  {{end}}
-  {{if $ENABLE_JOBS}}
   - Identifier: WaitForRunningJobs
     Method: WaitForControlledPodsRunning
     Params:
       action: gather
-  {{end}}
 
 # BEGIN scheduler throughput
 - name: Creating scheduler throughput measurements
@@ -589,7 +552,6 @@ steps:
         ReplicasMax: {{MultiplyInt $SMALL_GROUP_SIZE 1.5}}
         SvcName: small-service
         CpuRequest: 5m
-  {{if $ENABLE_STATEFULSETS}}
   - namespaceRange:
       min: 1
       max: {{$namespaces}}
@@ -612,8 +574,6 @@ steps:
         templateFillMap:
           ReplicasMin: {{MultiplyInt $MEDIUM_GROUP_SIZE 0.5}}
           ReplicasMax: {{MultiplyInt $MEDIUM_GROUP_SIZE 1.5}}
-  {{end}}
-  {{if $ENABLE_DAEMONSETS}}
   - namespaceRange:
       min: 1
       max: 1
@@ -624,8 +584,6 @@ steps:
         objectTemplatePath: daemonset.yaml
         templateFillMap:
           Image: k8s.gcr.io/pause:3.1
-  {{end}}
-  {{if $ENABLE_JOBS}}
   - namespaceRange:
       min: 1
       max: {{$namespaces}}
@@ -659,7 +617,6 @@ steps:
         templateFillMap:
           ReplicasMin: {{MultiplyInt $BIG_GROUP_SIZE 0.5}}
           ReplicasMax: {{MultiplyInt $BIG_GROUP_SIZE 1.5}}
-  {{end}}
 
 - name: Waiting for objects to become scaled
   measurements:
@@ -667,24 +624,18 @@ steps:
     Method: WaitForControlledPodsRunning
     Params:
       action: gather
-  {{if $ENABLE_STATEFULSETS}}
   - Identifier: WaitForRunningStatefulSets
     Method: WaitForControlledPodsRunning
     Params:
       action: gather
-  {{end}}
-  {{if $ENABLE_DAEMONSETS}}
   - Identifier: WaitForRunningDaemonSets
     Method: WaitForControlledPodsRunning
     Params:
       action: gather
-  {{end}}
-  {{if $ENABLE_JOBS}}
   - Identifier: WaitForRunningJobs
     Method: WaitForControlledPodsRunning
     Params:
       action: gather
-  {{end}}
 
 - name: Deleting objects
   phases:
@@ -696,14 +647,10 @@ steps:
     objectBundle:
     - basename: big-deployment
       objectTemplatePath: deployment.yaml
-    {{if $ENABLE_CONFIGMAPS}}
     - basename: big-deployment
       objectTemplatePath: configmap.yaml
-    {{end}}
-    {{if $ENABLE_SECRETS}}
     - basename: big-deployment
       objectTemplatePath: secret.yaml
-    {{end}}
     {{if $ENABLE_NETWORKPOLICIES}}
     - basename: big-deployment
       objectTemplatePath: networkpolicy.yaml
@@ -716,14 +663,10 @@ steps:
     objectBundle:
     - basename: medium-deployment
       objectTemplatePath: deployment.yaml
-    {{if $ENABLE_CONFIGMAPS}}
     - basename: medium-deployment
       objectTemplatePath: configmap.yaml
-    {{end}}
-    {{if $ENABLE_SECRETS}}
     - basename: medium-deployment
       objectTemplatePath: secret.yaml
-    {{end}}
     {{if $ENABLE_NETWORKPOLICIES}}
     - basename: medium-deployment
       objectTemplatePath: networkpolicy.yaml
@@ -736,19 +679,14 @@ steps:
     objectBundle:
     - basename: small-deployment
       objectTemplatePath: deployment.yaml
-    {{if $ENABLE_CONFIGMAPS}}
     - basename: small-deployment
       objectTemplatePath: configmap.yaml
-    {{end}}
-    {{if $ENABLE_SECRETS}}
     - basename: small-deployment
       objectTemplatePath: secret.yaml
-    {{end}}
     {{if $ENABLE_NETWORKPOLICIES}}
     - basename: small-deployment
       objectTemplatePath: networkpolicy.yaml
     {{end}}
-  {{if $ENABLE_STATEFULSETS}}
   - namespaceRange:
       min: 1
       max: {{$namespaces}}
@@ -769,8 +707,6 @@ steps:
         objectTemplatePath: statefulset.yaml
       - basename: medium-statefulset
         objectTemplatePath: statefulset_service.yaml
-  {{end}}
-  {{if $ENABLE_DAEMONSETS}}
   - namespaceRange:
       min: 1
       max: 1
@@ -779,8 +715,6 @@ steps:
     objectBundle:
       - basename: daemonset
         objectTemplatePath: daemonset.yaml
-  {{end}}
-  {{if $ENABLE_JOBS}}
   - namespaceRange:
       min: 1
       max: {{$namespaces}}
@@ -805,9 +739,8 @@ steps:
     objectBundle:
       - basename: big-job
         objectTemplatePath: job.yaml
-  {{end}}
   # If both StatefulSets and PVs were enabled we need to delete PVs manually.
-  {{if and $ENABLE_STATEFULSETS $ENABLE_PVS}}
+  {{if $ENABLE_PVS}}
   - namespaceRange:
       min: 1
       max: {{$namespaces}}
@@ -844,25 +777,19 @@ steps:
     Method: WaitForControlledPodsRunning
     Params:
       action: gather
-  {{if $ENABLE_STATEFULSETS}}
   - Identifier: WaitForRunningStatefulSets
     Method: WaitForControlledPodsRunning
     Params:
       action: gather
-  {{end}}
-  {{if $ENABLE_DAEMONSETS}}
   - Identifier: WaitForRunningDaemonSets
     Method: WaitForControlledPodsRunning
     Params:
       action: gather
-  {{end}}
-  {{if $ENABLE_JOBS}}
   - Identifier: WaitForRunningJobs
     Method: WaitForControlledPodsRunning
     Params:
       action: gather
-  {{end}}
-  {{if and $ENABLE_STATEFULSETS $ENABLE_PVS}}
+  {{if $ENABLE_PVS}}
   - Identifier: WaitForPVCsToBeDeleted
     Method: WaitForBoundPVCs
     Params:
@@ -871,7 +798,6 @@ steps:
       timeout: 15m
   {{end}}
 
-{{if $ENABLE_DAEMONSETS}}
 - name: Deleting PriorityClass for DaemonSets
   phases:
     - replicasPerNamespace: 0
@@ -879,7 +805,6 @@ steps:
       objectBundle:
         - basename: daemonset-priorityclass
           objectTemplatePath: daemonset-priorityclass.yaml
-{{end}}
 
 - name: Deleting SVCs
   phases:


### PR DESCRIPTION
As a part of #1125, default value of the variables
ENABLE_CONFIGMAPS, ENABLE_DAEMONSETS, ENABLE_JOBS, ENABLE_SECRETS, and ENABLE_STATEFULSETS are set to true, and these values are not overriden in any of the tests. The clusterloader2 load testing  [experimental-config.yaml](https://github.com/kubernetes/perf-tests/blob/master/clusterloader2/testing/load/experimental-config.yaml) file can now be be simplified as discussed in https://github.com/kubernetes/perf-tests/issues/1036#issuecomment-617133148