### PR TITLE
Changed perfdash service type to NodePort

### DIFF
--- a/perfdash/perfdash-service.yaml
+++ b/perfdash/perfdash-service.yaml
@@ -11,4 +11,4 @@ spec:
   - name: status
     port: 80
     targetPort: status
-  type: LoadBalancer
+  type: NodePort


### PR DESCRIPTION
/cc @mm4tt 

As perfdash is currently deployed at the `aaa` cluster
at community owned infrastructure and we don't have to use
services with LoadBalancer types it's good to change it
in the source repository and then removing unnecessary
manual instructions from the k/k8s.io [repository](https://github.com/kubernetes/k8s.io/tree/master/perf-dash.k8s.io)

Signed-off-by: Bart Smykla <bsmykla@vmware.com>