### PR TITLE
Change query function to rate for etcd_network_client_grpc_sent_bytes_total metric

### DIFF
--- a/clusterloader2/pkg/prometheus/manifests/dashboards/master-dashboard.dashboard.py
+++ b/clusterloader2/pkg/prometheus/manifests/dashboards/master-dashboard.dashboard.py
@@ -103,7 +103,7 @@ ETCD_PANELS = [
     d.simple_graph("etcd leader", "etcd_server_is_leader", legend="{{instance}}"),
     d.simple_graph(
         "etcd bytes sent",
-        "irate(etcd_network_client_grpc_sent_bytes_total[1m])",
+        "rate(etcd_network_client_grpc_sent_bytes_total[1m])",
         yAxes=g.single_y_axis(format=g.BYTES_PER_SEC_FORMAT),
         legend="{{instance}}",
     ),

--- a/clusterloader2/pkg/prometheus/manifests/dashboards/master-dashboard.json
+++ b/clusterloader2/pkg/prometheus/manifests/dashboards/master-dashboard.json
@@ -1192,7 +1192,7 @@
           "targets": [
             {
               "datasource": "",
-              "expr": "irate(etcd_network_client_grpc_sent_bytes_total[1m])",
+              "expr": "rate(etcd_network_client_grpc_sent_bytes_total[1m])",
               "format": "time_series",
               "instant": false,
               "interval": "5s",


### PR DESCRIPTION
`rate` query function better reflects the change in time in case of `etcd_network_client_grpc_sent_bytes_total` metric than `irate`.