### PR TITLE
Clusterloader2: check labels additionally to decide master node

### DIFF
--- a/clusterloader2/pkg/measurement/common/scheduler_latency.go
+++ b/clusterloader2/pkg/measurement/common/scheduler_latency.go
@@ -86,7 +86,7 @@ func (s *schedulerLatencyMeasurement) Execute(config *measurement.MeasurementCon
 
 	var masterRegistered = false
 	for _, node := range nodes.Items {
-		if util.LegacyIsMasterNode(node.Name) {
+		if util.LegacyIsMasterNode(&node) {
 			masterRegistered = true
 		}
 	}

--- a/clusterloader2/pkg/prometheus/prometheus.go
+++ b/clusterloader2/pkg/prometheus/prometheus.go
@@ -263,7 +263,7 @@ func (pc *PrometheusController) runNodeExporter() error {
 	numMasters := 0
 	for _, node := range nodes {
 		node := node
-		if util.LegacyIsMasterNode(node.Name) {
+		if util.LegacyIsMasterNode(&node) {
 			numMasters++
 			g.Go(func() error {
 				f, err := os.Open(os.ExpandEnv(nodeExporterPod))


### PR DESCRIPTION
Some utils like kubeadm will label master node as
"node-role.kubernetes.io/master=''" so it would be better to check
labels as additional signal. If that label is not set, it does not
affect the existing logic.

fix #1191