### PR TITLE
[WIP] Prometheus snapshots - print error when project is not set (1.14)

### DIFF
--- a/clusterloader2/pkg/prometheus/experimental.go
+++ b/clusterloader2/pkg/prometheus/experimental.go
@@ -128,6 +128,7 @@ func (pc *PrometheusController) snapshotPrometheusDiskIfEnabled() error {
 		snapshotRetryTimeout,
 		func() (bool, error) {
 			err := pc.trySnapshotPrometheusDisk(pc.diskMetadata.name, snapshotName, pc.diskMetadata.zone)
+			klog.Error(err)
 			// Poll() stops on error so returning nil
 			return err == nil, nil
 		})
@@ -167,6 +168,7 @@ func (pc *PrometheusController) deletePrometheusDiskIfEnabled() error {
 		deleteRetryTimeout,
 		func() (bool, error) {
 			err := pc.tryDeletePrometheusDisk(pc.diskMetadata.name, pc.diskMetadata.zone)
+			klog.Error(err)
 			// Poll() stops on error so returning nil
 			return err == nil, nil
 		})


### PR DESCRIPTION
Print error explicitly when snapshotting failed due to lack of `PROJECT` variable set

/cc jkaniuk