### PR TITLE
Add custom k/release repo commit env var

### DIFF
--- a/golang/Makefile
+++ b/golang/Makefile
@@ -18,6 +18,7 @@ export GCS_BUCKET?=k8s-scale-golang-build
 export GO_COMPILER_PKG?=go1.14.2.linux-amd64.tar.gz
 export GO_COMPILER_URL?=https://dl.google.com/go/$(GO_COMPILER_PKG)
 # Additional mandatory env variables:
+# K8S_RELEASE_COMMIT
 # K8S_COMMIT
 
 all: push

--- a/golang/build-kubernetes.sh
+++ b/golang/build-kubernetes.sh
@@ -26,6 +26,8 @@ function init {
 
 function clone_release {
   git clone https://github.com/kubernetes/release.git /go/src/k8s.io/release
+  cd /go/src/k8s.io/release
+  git checkout $K8S_RELEASE_COMMIT
   # Note that you can't really move the tool itself around since it has
   # references to binaries that live relative to its GOROOT.
   # This is solved by copying the whole GOROOT directory below.


### PR DESCRIPTION
`ci-build-and-push-k8s-at-golang-tip` job fails due to the changes in kubernetes/release repo (namely in `k8s.io/release/images/build/cross` directory). The PR enables fixing the commit of kubernetes/release repo to work around this issue.

This is a short-term fix - the script will need further adjustments to its logic in the future to handle new kubernetes/release kube-cross building procedure.

/sig scalability