### PR TITLE
Fix incorrect order of apiCalls in API latency SLO measurement

### DIFF
--- a/clusterloader2/pkg/measurement/common/slos/api_responsiveness_prometheus.go
+++ b/clusterloader2/pkg/measurement/common/slos/api_responsiveness_prometheus.go
@@ -278,7 +278,7 @@ func (m *apiCallMetrics) sorted() []*apiCallMetric {
 		all = append(all, v)
 	}
 	sort.Slice(all, func(i, j int) bool {
-		return all[i].Latency.Perc99 < all[j].Latency.Perc99
+		return all[i].Latency.Perc99 > all[j].Latency.Perc99
 	})
 	return all
 }

--- a/clusterloader2/pkg/measurement/common/slos/api_responsiveness_prometheus_test.go
+++ b/clusterloader2/pkg/measurement/common/slos/api_responsiveness_prometheus_test.go
@@ -17,7 +17,9 @@ limitations under the License.
 package slos
 
 import (
+	"bytes"
 	"encoding/json"
+	"flag"
 	"fmt"
 	"strings"
 	"testing"
@@ -25,6 +27,7 @@ import (
 
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
+	"k8s.io/klog"
 	"k8s.io/perf-tests/clusterloader2/pkg/measurement"
 	measurementutil "k8s.io/perf-tests/clusterloader2/pkg/measurement/util"
 )
@@ -251,20 +254,22 @@ func TestAPIResponsivenessSLOFailures(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		executor := &fakeQueryExecutor{samples: tc.samples}
-		gatherer := &apiResponsivenessGatherer{}
-		config := &measurement.Config{
-			Params: map[string]interface{}{
-				"useSimpleLatencyQuery": tc.useSimple,
-			},
-		}
+		t.Run(tc.name, func(t *testing.T) {
+			executor := &fakeQueryExecutor{samples: tc.samples}
+			gatherer := &apiResponsivenessGatherer{}
+			config := &measurement.Config{
+				Params: map[string]interface{}{
+					"useSimpleLatencyQuery": tc.useSimple,
+				},
+			}
 
-		_, err := gatherer.Gather(executor, time.Now(), config)
-		if tc.hasError {
-			assert.NotNil(t, err, "%s: wanted error, but got none", tc.name)
-		} else {
-			assert.Nil(t, err, "%s: wanted no error, but got %v", tc.name, err)
-		}
+			_, err := gatherer.Gather(executor, time.Now(), config)
+			if tc.hasError {
+				assert.NotNil(t, err, "wanted error, but got none")
+			} else {
+				assert.Nil(t, err, "wanted no error, but got %v", err)
+			}
+		})
 	}
 }
 
@@ -298,16 +303,18 @@ func TestAPIResponsivenessSummary(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		executor := &fakeQueryExecutor{samples: tc.samples}
-		gatherer := &apiResponsivenessGatherer{}
-		config := &measurement.Config{}
+		t.Run(tc.name, func(t *testing.T) {
+			executor := &fakeQueryExecutor{samples: tc.samples}
+			gatherer := &apiResponsivenessGatherer{}
+			config := &measurement.Config{}
 
-		summaries, _ := gatherer.Gather(executor, time.Now(), config)
-		checkSummary(t, tc.name, summaries, tc.summary)
+			summaries, _ := gatherer.Gather(executor, time.Now(), config)
+			checkSummary(t, summaries, tc.summary)
+		})
 	}
 }
 
-func checkSummary(t *testing.T, tc string, got []measurement.Summary, wanted []*summaryEntry) {
+func checkSummary(t *testing.T, got []measurement.Summary, wanted []*summaryEntry) {
 	assert.Lenf(t, got, 1, "wanted single summary, got %d", len(got))
 	var perfData measurementutil.PerfData
 	if err := json.Unmarshal([]byte(got[0].SummaryContent()), &perfData); err != nil {
@@ -333,7 +340,7 @@ func checkSummary(t *testing.T, tc string, got []measurement.Summary, wanted []*
 	for _, entry := range wanted {
 		item, ok := items[toKey(entry.resource, entry.subresource, entry.verb, entry.scope)]
 		if !ok {
-			t.Errorf("%s, %s in %s: %s %s wanted, but not found", tc, entry.verb, entry.scope, entry.resource, entry.subresource)
+			t.Errorf("%s in %s: %s %s wanted, but not found", entry.verb, entry.scope, entry.resource, entry.subresource)
 			continue
 		}
 		assert.Equal(t, "ms", item.Unit)
@@ -341,5 +348,136 @@ func checkSummary(t *testing.T, tc string, got []measurement.Summary, wanted []*
 		assert.Equal(t, entry.p90, item.Data["Perc90"])
 		assert.Equal(t, entry.p99, item.Data["Perc99"])
 		assert.Equal(t, entry.count, item.Labels["Count"])
+	}
+}
+
+func TestLogging(t *testing.T) {
+	cases := []struct {
+		name               string
+		samples            []*sample
+		expectedMessages   []string
+		unexpectedMessages []string
+	}{
+		{
+			name: "print_5_warnings",
+			samples: []*sample{
+				{
+					resource: "r1",
+					verb:     "POST",
+					latency:  1.2,
+				},
+				{
+					resource: "r2",
+					verb:     "POST",
+					latency:  .9,
+				},
+				{
+					resource: "r3",
+					verb:     "POST",
+					latency:  .8,
+				},
+				{
+					resource: "r4",
+					verb:     "POST",
+					latency:  .7,
+				},
+				{
+					resource: "r5",
+					verb:     "POST",
+					latency:  .6,
+				},
+				{
+					resource: "r6",
+					verb:     "POST",
+					latency:  .5,
+				},
+			},
+			expectedMessages: []string{
+				": WARNING Top latency metric: {Resource:r1",
+				": Top latency metric: {Resource:r2",
+				": Top latency metric: {Resource:r3",
+				": Top latency metric: {Resource:r4",
+				": Top latency metric: {Resource:r5",
+			},
+			unexpectedMessages: []string{
+				"Resource:r6",
+			},
+		},
+		{
+			name: "print_all_violations",
+			samples: []*sample{
+				{
+					resource: "r1",
+					verb:     "POST",
+					latency:  1.2,
+				},
+				{
+					resource: "r2",
+					verb:     "POST",
+					latency:  1.9,
+				},
+				{
+					resource: "r3",
+					verb:     "POST",
+					latency:  1.8,
+				},
+				{
+					resource: "r4",
+					verb:     "POST",
+					latency:  1.7,
+				},
+				{
+					resource: "r5",
+					verb:     "POST",
+					latency:  1.6,
+				},
+				{
+					resource: "r6",
+					verb:     "POST",
+					latency:  1.5,
+				},
+				{
+					resource: "r7",
+					verb:     "POST",
+					latency:  .5,
+				},
+			},
+			expectedMessages: []string{
+				": WARNING Top latency metric: {Resource:r1",
+				": WARNING Top latency metric: {Resource:r2",
+				": WARNING Top latency metric: {Resource:r3",
+				": WARNING Top latency metric: {Resource:r4",
+				": WARNING Top latency metric: {Resource:r5",
+				": WARNING Top latency metric: {Resource:r6",
+			},
+			unexpectedMessages: []string{
+				"Resource:r7",
+			},
+		},
+	}
+
+	klog.InitFlags(nil)
+	flag.Set("logtostderr", "false")
+	flag.Parse()
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			buf := bytes.NewBuffer(nil)
+			klog.SetOutput(buf)
+
+			executor := &fakeQueryExecutor{samples: tc.samples}
+			gatherer := &apiResponsivenessGatherer{}
+			config := &measurement.Config{}
+
+			gatherer.Gather(executor, time.Now(), config)
+			klog.Flush()
+
+			for _, msg := range tc.expectedMessages {
+				assert.Contains(t, buf.String(), msg)
+			}
+			for _, msg := range tc.unexpectedMessages {
+				assert.NotContains(t, buf.String(), msg)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Add test to verify log statements (they are on of the interfaces for this
measurement). Also take advantage of t.Run method in tests.

/assign @wojtek-t 