### PR TITLE
Clusterloader2: add a warning message for no matching manifest file

### DIFF
--- a/clusterloader2/pkg/framework/framework.go
+++ b/clusterloader2/pkg/framework/framework.go
@@ -232,6 +232,9 @@ func (f *Framework) ApplyTemplatedManifests(manifestGlob string, templateMapping
 	if err != nil {
 		return err
 	}
+	if manifests == nil {
+		klog.Warningf("There is no matching file for pattern %v.\n", manifestGlob)
+	}
 	for _, manifest := range manifests {
 		klog.Infof("Applying %s\n", manifest)
 		obj, err := templateProvider.TemplateToObject(filepath.Base(manifest), templateMapping)


### PR DESCRIPTION
When there is no manifest file matching a provided pattern, Clusterloader does not report any errors or warnings, which makes debugging difficult. For example, the prometheus manifest path is relative to `$GOPATH`. If the path is mis-configured, the matching manifest files will be empty and Clusterloader will fail to create the objects silently. It is very hard to capture such a configuration issue without a warning message. A specific example is that `$GOPATH` will not be expanded properly if a user runs Clusterloader as a sudo user but forgot to set the flag `-E` or` --preserve-env=GOPATH`.

This PR generates a warning message if there is no matching manifest file.