### PR TITLE
Clusterloader2: make the prometheus manifest path configurable

### DIFF
--- a/clusterloader2/cmd/clusterloader.go
+++ b/clusterloader2/cmd/clusterloader.go
@@ -18,10 +18,11 @@ package main
 
 import (
 	"fmt"
-	"k8s.io/kubernetes/pkg/master/ports"
 	"os"
 	"path"
 	"time"
+
+	"k8s.io/kubernetes/pkg/master/ports"
 
 	ginkgoconfig "github.com/onsi/ginkgo/config"
 	ginkgoreporters "github.com/onsi/ginkgo/reporters"
@@ -157,6 +158,7 @@ func completeConfig(m *framework.MultiClientSet) error {
 	if clusterLoaderConfig.ClusterConfig.Provider == "aks" {
 		clusterLoaderConfig.ClusterConfig.APIServerPprofByClientEnabled = false
 	}
+	prometheus.CompleteConfig(&clusterLoaderConfig.PrometheusConfig)
 	return nil
 }
 

--- a/clusterloader2/pkg/config/cluster.go
+++ b/clusterloader2/pkg/config/cluster.go
@@ -56,13 +56,18 @@ type ClusterConfig struct {
 
 // PrometheusConfig represents all flags used by prometheus.
 type PrometheusConfig struct {
-	EnableServer       bool
-	TearDownServer     bool
-	ScrapeEtcd         bool
-	ScrapeNodeExporter bool
-	ScrapeKubelets     bool
-	ScrapeKubeProxy    bool
-	SnapshotProject    string
+	EnableServer            bool
+	TearDownServer          bool
+	ScrapeEtcd              bool
+	ScrapeNodeExporter      bool
+	ScrapeKubelets          bool
+	ScrapeKubeProxy         bool
+	SnapshotProject         string
+	ManifestPath            string
+	CoreManifests           string
+	DefaultServiceMonitors  string
+	MasterIPServiceMonitors string
+	NodeExporterPod         string
 }
 
 // GetMasterIP returns the first master ip, added for backward compatibility.

--- a/clusterloader2/pkg/prometheus/prometheus.go
+++ b/clusterloader2/pkg/prometheus/prometheus.go
@@ -41,13 +41,9 @@ import (
 const (
 	namespace                    = "monitoring"
 	storageClass                 = "ssd"
-	coreManifests                = "$GOPATH/src/k8s.io/perf-tests/clusterloader2/pkg/prometheus/manifests/*.yaml"
-	defaultServiceMonitors       = "$GOPATH/src/k8s.io/perf-tests/clusterloader2/pkg/prometheus/manifests/default/*.yaml"
-	masterIPServiceMonitors      = "$GOPATH/src/k8s.io/perf-tests/clusterloader2/pkg/prometheus/manifests/master-ip/*.yaml"
 	checkPrometheusReadyInterval = 30 * time.Second
 	checkPrometheusReadyTimeout  = 15 * time.Minute
 	numK8sClients                = 1
-	nodeExporterPod              = "$GOPATH/src/k8s.io/perf-tests/clusterloader2/pkg/prometheus/manifests/exporters/node-exporter.yaml"
 )
 
 // InitFlags initializes prometheus flags.
@@ -59,6 +55,7 @@ func InitFlags(p *config.PrometheusConfig) {
 	flags.BoolEnvVar(&p.ScrapeKubelets, "prometheus-scrape-kubelets", "PROMETHEUS_SCRAPE_KUBELETS", false, "Whether to scrape kubelets. Experimental, may not work in larger clusters. Requires heapster node to be at least n1-standard-4, which needs to be provided manually.")
 	flags.BoolEnvVar(&p.ScrapeKubeProxy, "prometheus-scrape-kube-proxy", "PROMETHEUS_SCRAPE_KUBE_PROXY", true, "Whether to scrape kube proxy.")
 	flags.StringEnvVar(&p.SnapshotProject, "experimental-snapshot-project", "PROJECT", "", "GCP project used where disks and snapshots are located.")
+	flags.StringEnvVar(&p.ManifestPath, "prometheus-manifest-path", "PROMETHEUS_MANIFEST_PATH", "$GOPATH/src/k8s.io/perf-tests/clusterloader2/pkg/prometheus/manifests", "Path to the prometheus manifest files.")
 }
 
 // Controller is a util for managing (setting up / tearing down) the prometheus stack in
@@ -76,6 +73,14 @@ type Controller struct {
 	diskMetadata prometheusDiskMetadata
 	// ssh executor to run commands in cluster nodes via ssh
 	ssh util.SSHExecutor
+}
+
+// CompleteConfig completes Prometheus manifest file path config
+func CompleteConfig(p *config.PrometheusConfig) {
+	p.CoreManifests = p.ManifestPath + "/*.yaml"
+	p.DefaultServiceMonitors = p.ManifestPath + "/default/*.yaml"
+	p.MasterIPServiceMonitors = p.ManifestPath + "/master-ip/*.yaml"
+	p.NodeExporterPod = p.ManifestPath + "/exporters/node-exporter.yaml"
 }
 
 // NewController creates a new instance of Controller for the given config.
@@ -151,7 +156,7 @@ func (pc *Controller) SetUpPrometheusStack() error {
 	if err := client.DeleteStorageClass(k8sClient, storageClass); err != nil {
 		return err
 	}
-	if err := pc.applyManifests(coreManifests); err != nil {
+	if err := pc.applyManifests(pc.clusterLoaderConfig.PrometheusConfig.CoreManifests); err != nil {
 		return err
 	}
 	if pc.clusterLoaderConfig.PrometheusConfig.ScrapeNodeExporter {
@@ -160,7 +165,7 @@ func (pc *Controller) SetUpPrometheusStack() error {
 		}
 	}
 	if !pc.isKubemark() {
-		if err := pc.applyManifests(defaultServiceMonitors); err != nil {
+		if err := pc.applyManifests(pc.clusterLoaderConfig.PrometheusConfig.DefaultServiceMonitors); err != nil {
 			return err
 		}
 	}
@@ -169,7 +174,7 @@ func (pc *Controller) SetUpPrometheusStack() error {
 		if err := pc.exposeAPIServerMetrics(); err != nil {
 			return err
 		}
-		if err := pc.applyManifests(masterIPServiceMonitors); err != nil {
+		if err := pc.applyManifests(pc.clusterLoaderConfig.PrometheusConfig.MasterIPServiceMonitors); err != nil {
 			return err
 		}
 	}
@@ -280,7 +285,7 @@ func (pc *Controller) runNodeExporter() error {
 		if util.LegacyIsMasterNode(&node) {
 			numMasters++
 			g.Go(func() error {
-				f, err := os.Open(os.ExpandEnv(nodeExporterPod))
+				f, err := os.Open(os.ExpandEnv(pc.clusterLoaderConfig.PrometheusConfig.NodeExporterPod))
 				if err != nil {
 					return fmt.Errorf("Unable to open manifest file: %v", err)
 				}


### PR DESCRIPTION
In the current implementation, the prometheus manifest file path is relative to` $GOPATH`. This PR enables to configure the path prefix through a new command line flag `--prometheus-manifest-path`. If not specified, the default value `$GOPATH` is used.  The prometheus manifest file path parameters are changed to PrometheusConfig's fields. 