### PR TITLE
using port report by node instead of from config

### DIFF
--- a/clusterloader2/pkg/measurement/util/gatherers/container_resource_gatherer.go
+++ b/clusterloader2/pkg/measurement/util/gatherers/container_resource_gatherer.go
@@ -154,7 +154,8 @@ func NewResourceUsageGatherer(c clientset.Interface, host string, port int, prov
 					inKubemark:                  false,
 					resourceDataGatheringPeriod: resourceDataGatheringPeriod,
 					printVerboseLogs:            options.PrintVerboseLogs,
-					port:                        port,
+					//port:                        port,
+					port:                        int(node.Status.DaemonEndpoints.KubeletEndpoint.Port),
 				})
 				if options.Nodes == MasterNodes {
 					break


### PR DESCRIPTION
in some cases, kubemark may use different ports, the origin code uses static port, which can not connect some kubemark daemons