### PR TITLE
Fix segfault in GetNumObjectsMatchingSelector

### DIFF
--- a/clusterloader2/pkg/measurement/util/runtimeobjects/runtimeobjects.go
+++ b/clusterloader2/pkg/measurement/util/runtimeobjects/runtimeobjects.go
@@ -431,8 +431,11 @@ func GetNumObjectsMatchingSelector(c dynamic.Interface, namespace string, resour
 	var numObjects int
 	listFunc := func() error {
 		list, err := c.Resource(resource).Namespace(namespace).List(metav1.ListOptions{LabelSelector: labelSelector.String()})
+		if err != nil {
+			return err
+		}
 		numObjects = len(list.Items)
-		return err
+		return nil
 	}
 	err := client.RetryWithExponentialBackOff(client.RetryFunction(listFunc))
 	return numObjects, err


### PR DESCRIPTION
If the List method returns error the list object is nil and accessing list.Items results in segfault.

Ref. https://github.com/kubernetes/perf-tests/issues/1248

(cherry picked from commit 5b365e5bfb6624bece619551fb95d0520d050dfd)