### PR TITLE
Add flag --skip-steps (1.18)

### DIFF
--- a/clusterloader2/cmd/clusterloader.go
+++ b/clusterloader2/cmd/clusterloader.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"fmt"
+	"k8s.io/perf-tests/clusterloader2/pkg/modifier"
 	"os"
 	"path"
 	"time"
@@ -91,6 +92,7 @@ func initFlags() {
 	flags.StringArrayVar(&testOverridePaths, "testoverrides", []string{}, "Paths to the config overrides file. The latter overrides take precedence over changes in former files.")
 	flags.StringVar(&testSuiteConfigPath, "testsuite", "", "Path to the test suite config file")
 	initClusterFlags()
+	modifier.InitFlags(&clusterLoaderConfig.ModifierConfig)
 	prometheus.InitFlags(&clusterLoaderConfig.PrometheusConfig)
 }
 

--- a/clusterloader2/pkg/config/cluster.go
+++ b/clusterloader2/pkg/config/cluster.go
@@ -26,6 +26,7 @@ type ClusterLoaderConfig struct {
 	ReportDir         string
 	EnableExecService bool
 	TestScenario      api.TestScenario
+	ModifierConfig    ModifierConfig
 	PrometheusConfig  PrometheusConfig
 }
 
@@ -39,6 +40,12 @@ type ClusterConfig struct {
 	MasterInternalIPs          []string
 	MasterName                 string
 	KubemarkRootKubeConfigPath string
+}
+
+// ModifierConfig represent all flags used by test modification
+type ModifierConfig struct {
+	// A list of names of steps that should be ignored when executing test run
+	SkipSteps []string
 }
 
 // PrometheusConfig represents all flags used by prometheus.

--- a/clusterloader2/pkg/modifier/modifier.go
+++ b/clusterloader2/pkg/modifier/modifier.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package modifier
+
+import (
+	"k8s.io/perf-tests/clusterloader2/api"
+	"k8s.io/perf-tests/clusterloader2/pkg/config"
+	"k8s.io/perf-tests/clusterloader2/pkg/flags"
+)
+
+// Modifier mutates provided test
+type Modifier interface {
+	ChangeTest(*api.Config)
+}
+
+// InitFlags allows setting configuration with flags
+func InitFlags(m *config.ModifierConfig) {
+	flags.StringArrayVar(&m.SkipSteps, "skip-steps", []string{}, "Name of steps to skip in test")
+}
+
+// NewModifier creates new Modifier according to provided configuration
+func NewModifier(m *config.ModifierConfig) Modifier {
+	return &simpleModifier{skipSteps: m.SkipSteps}
+}
+
+type simpleModifier struct {
+	skipSteps []string
+}
+
+// Ensuring that simpleModifier implements Modifier interface
+var _ Modifier = &simpleModifier{}
+
+func (m *simpleModifier) ChangeTest(c *api.Config) {
+	steps := c.Steps
+	c.Steps = []api.Step{}
+	for _, s := range steps {
+		ignored := false
+		for _, i := range m.skipSteps {
+			if i == s.Name {
+				ignored = true
+				break
+			}
+		}
+		if !ignored {
+			c.Steps = append(c.Steps, s)
+		}
+	}
+}

--- a/clusterloader2/pkg/modifier/modifier_test.go
+++ b/clusterloader2/pkg/modifier/modifier_test.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package modifier
+
+import (
+	"k8s.io/perf-tests/clusterloader2/api"
+	"testing"
+)
+
+func defaultConfig() *api.Config {
+	return &api.Config{
+		Name: "test-modifier",
+		Steps: []api.Step{{
+			Name: "eternal",
+		}},
+	}
+}
+
+func TestModifier(t *testing.T) {
+	m := &simpleModifier{skipSteps: []string{"skip-me", "skip me"}}
+	testCase := [][]string{{}, {"skip-me"}, {"skip-me", "skip me"}}
+	for _, d := range testCase {
+		c := defaultConfig()
+		for _, s := range d {
+			c.Steps = append(c.Steps, api.Step{Name: s})
+		}
+		m.ChangeTest(c)
+		if len(c.Steps) != 1 {
+			t.Errorf("For test case %v: Changed test config in unexpected way, expected to have 1 step, but was %d steps", d, len(c.Steps))
+		}
+		if c.Steps[0].Name != "eternal" {
+			t.Errorf("For test case %v: Changed test in unexpected way, expected to have 1 step with name 'eternal', but was %s", d, c.Steps[0].Name)
+		}
+	}
+
+}

--- a/clusterloader2/pkg/test/test.go
+++ b/clusterloader2/pkg/test/test.go
@@ -18,6 +18,7 @@ package test
 
 import (
 	"fmt"
+	"k8s.io/perf-tests/clusterloader2/pkg/modifier"
 	"path/filepath"
 
 	"k8s.io/perf-tests/clusterloader2/pkg/config"
@@ -61,5 +62,8 @@ func RunTest(clusterFramework, prometheusFramework *framework.Framework, cluster
 	if err != nil {
 		return errors.NewErrorList(fmt.Errorf("config reading error: %v", err))
 	}
+
+	modifier.NewModifier(&clusterLoaderConfig.ModifierConfig).ChangeTest(testConfig)
+
 	return Test.ExecuteTest(ctx, testConfig)
 }


### PR DESCRIPTION
This change enables runetime test config change - skipping any number of
steps without a need to modify config file.

Cherry-pick from master, commit f4b2903b