### PR TITLE
Fix cherry-picking k8s commit in golang tests

### DIFF
--- a/golang/build-kubernetes.sh
+++ b/golang/build-kubernetes.sh
@@ -67,7 +67,7 @@ function build_kubernetes {
   # The git cherry-pick command below takes a commit from k8s v1.19 that
   # artifically increases Kubemark cluster nodes objects.
   # TODO: Get rid of this cherry-pick once we start testing aginst k8s v1.19+.
-  git cherry-pick fc2c410a5a37aba7ab0a3635c6b1195245b77e2b
+  git cherry-pick -m 1 fc2c410a5a37aba7ab0a3635c6b1195245b77e2b
 
   # Change the base image of kube-build to our own kube-cross image.
   sed -i 's#FROM .*#FROM gcr.io/k8s-testimages/kube-cross-amd64:'"$TAG"'#' Dockerfile


### PR DESCRIPTION
The command was cherry-picking a merge commit and it didn't know relative to which of its parents should the diff be taken against, hence `ci-build-and-push-k8s-at-golang-tip` job was [failing](https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/ci-build-and-push-k8s-at-golang-tip/1261187637507526656). `-m 1` is equivalent to taking the first parent of the aforementioned merge commit (the one that is of interest for us - Kubemark cluster nodes objects increase).

/sig scalability
/cc mm4tt