### PR TITLE
Parse envs first as numbers before parsing them as booleans

### DIFF
--- a/clusterloader2/pkg/config/template_provider.go
+++ b/clusterloader2/pkg/config/template_provider.go
@@ -247,13 +247,13 @@ func LoadCL2Envs() (map[string]interface{}, error) {
 }
 
 func unpackStringValue(str string) interface{} {
-	if v, err := strconv.ParseBool(str); err == nil {
-		return v
-	}
 	if v, err := strconv.ParseInt(str, 10, 64); err == nil {
 		return v
 	}
 	if v, err := strconv.ParseFloat(str, 64); err == nil {
+		return v
+	}
+	if v, err := strconv.ParseBool(str); err == nil {
 		return v
 	}
 	return str

--- a/clusterloader2/pkg/config/template_provider_test.go
+++ b/clusterloader2/pkg/config/template_provider_test.go
@@ -90,12 +90,14 @@ func TestLoadCL2Envs(t *testing.T) {
 				"CL2_MY_PARAM2": "true",
 				"CL2_MY_PARAM3": "99.99",
 				"CL2_MY_PARAM4": "XXX",
+				"CL2_MY_PARAM5": "1",
 			},
 			wantedMapping: map[string]interface{}{
 				"CL2_MY_PARAM1": int64(100),
 				"CL2_MY_PARAM2": true,
 				"CL2_MY_PARAM3": 99.99,
 				"CL2_MY_PARAM4": "XXX",
+				"CL2_MY_PARAM5": int64(1),
 			},
 		},
 		{


### PR DESCRIPTION
This is to fix issues when `1` is parsed as `true`, e.g. failing presubmit in https://github.com/kubernetes/perf-tests/pull/1262