### PR TITLE
ref to [Fix TLS Config in load test clients](https://github.com/kuber…

### DIFF
--- a/clusterloader2/pkg/framework/config/client_config.go
+++ b/clusterloader2/pkg/framework/config/client_config.go
@@ -90,9 +90,13 @@ func initializeWithDefaults(config *restclient.Config) error {
 			KeepAlive: 30 * time.Second,
 		}).DialContext,
 	})
+	config.WrapTransport = transportConfig.WrapTransport
+	config.Dial = transportConfig.Dial
 	// Overwrite TLS-related fields from config to avoid collision with
 	// Transport field.
 	config.TLSClientConfig = restclient.TLSClientConfig{}
+	config.AuthProvider = nil
+	config.ExecProvider = nil
 
 	return nil
 }


### PR DESCRIPTION
…netes/kubernetes/pull/73500)

This PR will allow to run against EKS clusters. Similar to https://github.com/kubernetes/kubernetes/pull/73500

Otherwise, 
```
git checkout master
cd clusterloader2
go run cmd/clusterloader.go --kubeconfig=<kubeconfigfilePath> --testconfig=<configfilePath>
go: downloading k8s.io/kubernetes v1.18.0
go: downloading k8s.io/api v0.18.0
go: downloading github.com/onsi/ginkgo v1.11.0
go: downloading golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
go: downloading k8s.io/apiserver v0.18.0
go: downloading github.com/onsi/gomega v1.7.0
go: downloading k8s.io/cri-api v0.18.0
go: downloading k8s.io/kubectl v0.18.0
go: downloading github.com/pkg/errors v0.8.1
go: downloading k8s.io/cloud-provider v0.18.0
go: downloading google.golang.org/grpc v1.26.0
go: downloading sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.7
go: downloading google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55
F0518 15:10:22.970051   62061 clusterloader.go:230] Client creation error: creating clientset failed: using a custom transport with TLS certificate options or the insecure flag is not allowed
exit status 1
```
/cc shyamjvs