### PR TITLE
Clusterloader: customize logging levels

### DIFF
--- a/clusterloader2/pkg/measurement/util/phase_latency.go
+++ b/clusterloader2/pkg/measurement/util/phase_latency.go
@@ -119,7 +119,7 @@ func (o *ObjectTransitionTimes) printLatencies(latencies []LatencyData, header s
 	if index < 0 {
 		index = 0
 	}
-	klog.Infof("%s: %d %s: %v", o.name, len(latencies)-index, header, latencies[index:])
+	klog.V(2).Infof("%s: %d %s: %v", o.name, len(latencies)-index, header, latencies[index:])
 	var thresholdString string
 	if threshold != time.Duration(0) {
 		thresholdString = fmt.Sprintf("; threshold %v", threshold)

--- a/clusterloader2/pkg/measurement/util/wait_for_nodes.go
+++ b/clusterloader2/pkg/measurement/util/wait_for_nodes.go
@@ -54,7 +54,7 @@ func WaitForNodes(clientSet clientset.Interface, stopCh <-chan struct{}, options
 		case <-time.After(options.WaitForNodesInterval):
 			nodeCount = getNumReadyNodes(ps.List())
 			if options.EnableLogging {
-				klog.Infof("%s: node count (selector = %v): %d", options.CallerName, options.Selector.String(), nodeCount)
+				klog.V(2).Infof("%s: node count (selector = %v): %d", options.CallerName, options.Selector.String(), nodeCount)
 			}
 			if options.MinDesiredNodeCount <= nodeCount && nodeCount <= options.MaxDesiredNodeCount {
 				return nil

--- a/clusterloader2/pkg/measurement/util/wait_for_pods.go
+++ b/clusterloader2/pkg/measurement/util/wait_for_pods.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/klog"
 )
@@ -89,7 +89,7 @@ func WaitForPods(clientSet clientset.Interface, stopCh <-chan struct{}, options 
 				klog.Errorf("%s: %s: %d pods appeared: %v", options.CallerName, options.Selector.String(), len(addedPods), strings.Join(addedPods, ", "))
 			}
 			if options.EnableLogging {
-				klog.Infof("%s: %s: %s", options.CallerName, options.Selector.String(), podsStatus.String())
+				klog.V(2).Infof("%s: %s: %s", options.CallerName, options.Selector.String(), podsStatus.String())
 			}
 			// We allow inactive pods (e.g. eviction happened).
 			// We wait until there is a desired number of pods running and all other pods are inactive.

--- a/clusterloader2/pkg/measurement/util/wait_for_pvcs.go
+++ b/clusterloader2/pkg/measurement/util/wait_for_pvcs.go
@@ -76,7 +76,7 @@ func WaitForPVCs(clientSet clientset.Interface, stopCh <-chan struct{}, options 
 				klog.Errorf("%s: %s: %d PVCs appeared: %v", options.CallerName, options.Selector.String(), len(deletedPVCs), strings.Join(deletedPVCs, ", "))
 			}
 			if options.EnableLogging {
-				klog.Infof("%s: %s: %s", options.CallerName, options.Selector.String(), pvcsStatus.String())
+				klog.V(2).Infof("%s: %s: %s", options.CallerName, options.Selector.String(), pvcsStatus.String())
 			}
 			// We wait until there is a desired number of PVCs bound and all other PVCs are pending.
 			if len(pvcs) == (pvcsStatus.Bound+pvcsStatus.Pending) && pvcsStatus.Bound == options.DesiredPVCCount {

--- a/clusterloader2/pkg/measurement/util/wait_for_pvs.go
+++ b/clusterloader2/pkg/measurement/util/wait_for_pvs.go
@@ -76,7 +76,7 @@ func WaitForPVs(clientSet clientset.Interface, stopCh <-chan struct{}, options *
 				klog.Errorf("%s: %s: %d PVs appeared: %v", options.CallerName, options.Selector.String(), len(deletedPVs), strings.Join(deletedPVs, ", "))
 			}
 			if options.EnableLogging {
-				klog.Infof("%s: %s: %s", options.CallerName, options.Selector.String(), pvStatus.String())
+				klog.V(2).Infof("%s: %s: %s", options.CallerName, options.Selector.String(), pvStatus.String())
 			}
 			// We wait until there is a desired number of PVs provisioned and all other PVs are pending.
 			if len(pvs) == (pvStatus.Bound+pvStatus.Available+pvStatus.Pending) && pvStatus.Bound+pvStatus.Available == options.DesiredPVCount {

--- a/clusterloader2/pkg/util/cluster.go
+++ b/clusterloader2/pkg/util/cluster.go
@@ -67,7 +67,7 @@ func LogClusterNodes(c clientset.Interface) error {
 				externalIP = address.Address
 			}
 		}
-		klog.Infof("Name: %v, clusterIP: %v, externalIP: %v, isSchedulable: %v", nodeList[i].ObjectMeta.Name, internalIP, externalIP, isSchedulable)
+		klog.V(2).Infof("Name: %v, clusterIP: %v, externalIP: %v, isSchedulable: %v", nodeList[i].ObjectMeta.Name, internalIP, externalIP, isSchedulable)
 	}
 	return nil
 }


### PR DESCRIPTION
Clusterloader generates a lot of output on the console. The information is helpful but the large amount of very detailed runtime measurement data can be overwhelming and may hide some desired and  important information. This PR changes the detailed runtime measurement logs to V(2). 