### PR TITLE
Clusterloader:  enable/disable measurement logging

### DIFF
--- a/clusterloader2/cmd/clusterloader.go
+++ b/clusterloader2/cmd/clusterloader.go
@@ -18,10 +18,11 @@ package main
 
 import (
 	"fmt"
-	"k8s.io/perf-tests/clusterloader2/pkg/modifier"
 	"os"
 	"path"
 	"time"
+
+	"k8s.io/perf-tests/clusterloader2/pkg/modifier"
 
 	"k8s.io/kubernetes/pkg/master/ports"
 
@@ -79,6 +80,7 @@ func initClusterFlags() {
 	flags.StringEnvVar(&clusterLoaderConfig.ClusterConfig.KubemarkRootKubeConfigPath, "kubemark-root-kubeconfig", "KUBEMARK_ROOT_KUBECONFIG", "",
 		"Path the to kubemark root kubeconfig file, i.e. kubeconfig of the cluster where kubemark cluster is run. Ignored if provider != kubemark")
 	flags.BoolEnvVar(&clusterLoaderConfig.ClusterConfig.APIServerPprofByClientEnabled, "apiserver-pprof-by-client-enabled", "APISERVER_PPROF_BY_CLIENT_ENABLED", true, "Whether apiserver pprof endpoint can be accessed by Kubernetes client.")
+	flags.BoolEnvVar(&clusterLoaderConfig.ClusterConfig.EnableMeasurementLogging, "enable-measurement-logging", "ENABLE_MEASUREMENT_LOGGING", true, "Whether to enable detailed measurement logging.")
 }
 
 func validateClusterFlags() *errors.ErrorList {

--- a/clusterloader2/pkg/config/cluster.go
+++ b/clusterloader2/pkg/config/cluster.go
@@ -53,6 +53,7 @@ type ClusterConfig struct {
 	// using kubernetes client. If false, clusterloader will avoid collecting kube-apiserver profiles.
 	APIServerPprofByClientEnabled bool
 	KubeletPort                   int
+	EnableMeasurementLogging      bool
 }
 
 // ModifierConfig represent all flags used by test modification

--- a/clusterloader2/pkg/measurement/common/wait_for_controlled_pods.go
+++ b/clusterloader2/pkg/measurement/common/wait_for_controlled_pods.go
@@ -22,7 +22,7 @@ import (
 	"sync"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -481,6 +481,7 @@ func (w *waitForControlledPodsRunningMeasurement) waitForRuntimeObject(obj runti
 	o := newObjectChecker(key)
 	o.lock.Lock()
 	defer o.lock.Unlock()
+	enableLogging := w.clusterFramework.GetClusterConfig().EnableMeasurementLogging
 	w.handlingGroup.Start(func() {
 		options := &measurementutil.WaitForPodOptions{
 			Selector: &measurementutil.ObjectSelector{
@@ -489,7 +490,7 @@ func (w *waitForControlledPodsRunningMeasurement) waitForRuntimeObject(obj runti
 				FieldSelector: "",
 			},
 			DesiredPodCount:     int(runtimeObjectReplicas),
-			EnableLogging:       true,
+			EnableLogging:       enableLogging,
 			CallerName:          w.String(),
 			WaitForPodsInterval: defaultWaitForPodsInterval,
 			IsPodUpdated:        isPodUpdated,

--- a/clusterloader2/pkg/measurement/common/wait_for_nodes.go
+++ b/clusterloader2/pkg/measurement/common/wait_for_nodes.go
@@ -70,7 +70,7 @@ func (w *waitForNodesMeasurement) Execute(config *measurement.Config) ([]measure
 		Selector:             selector,
 		MinDesiredNodeCount:  minNodeCount,
 		MaxDesiredNodeCount:  maxNodeCount,
-		EnableLogging:        true,
+		EnableLogging:        config.ClusterLoaderConfig.ClusterConfig.EnableMeasurementLogging,
 		CallerName:           w.String(),
 		WaitForNodesInterval: defaultWaitForNodesInterval,
 	}

--- a/clusterloader2/pkg/measurement/common/wait_for_pods.go
+++ b/clusterloader2/pkg/measurement/common/wait_for_pods.go
@@ -67,7 +67,7 @@ func (w *waitForRunningPodsMeasurement) Execute(config *measurement.Config) ([]m
 	options := &measurementutil.WaitForPodOptions{
 		Selector:            selector,
 		DesiredPodCount:     desiredPodCount,
-		EnableLogging:       true,
+		EnableLogging:       config.ClusterLoaderConfig.ClusterConfig.EnableMeasurementLogging,
 		CallerName:          w.String(),
 		WaitForPodsInterval: defaultWaitForPodsInterval,
 	}

--- a/clusterloader2/pkg/measurement/common/wait_for_pvcs.go
+++ b/clusterloader2/pkg/measurement/common/wait_for_pvcs.go
@@ -67,7 +67,7 @@ func (w *waitForBoundPVCsMeasurement) Execute(config *measurement.Config) ([]mea
 	options := &measurementutil.WaitForPVCOptions{
 		Selector:            selector,
 		DesiredPVCCount:     desiredPVCCount,
-		EnableLogging:       true,
+		EnableLogging:       config.ClusterLoaderConfig.ClusterConfig.EnableMeasurementLogging,
 		CallerName:          w.String(),
 		WaitForPVCsInterval: defaultWaitForPVCsInterval,
 	}

--- a/clusterloader2/pkg/measurement/common/wait_for_pvs.go
+++ b/clusterloader2/pkg/measurement/common/wait_for_pvs.go
@@ -66,7 +66,7 @@ func (w *waitForAvailablePVsMeasurement) Execute(config *measurement.Config) ([]
 	options := &measurementutil.WaitForPVOptions{
 		Selector:           selector,
 		DesiredPVCount:     desiredPVCount,
-		EnableLogging:      true,
+		EnableLogging:      config.ClusterLoaderConfig.ClusterConfig.EnableMeasurementLogging,
 		CallerName:         w.String(),
 		WaitForPVsInterval: defaultWaitForPVsInterval,
 	}


### PR DESCRIPTION
This PR supports custom measurement logging. A new command line flag "--enable-measurement-logging" is added for enable and disable the detailed measurement logging. The default is true. 

It's a re-implementation of the previous PR #1270 .  which was merged and then reverted.  Please refer to #1270  and #1271. 