### PR TITLE
Add namespace configuration to test configs

### DIFF
--- a/clusterloader2/testing/access-tokens/config.yaml
+++ b/clusterloader2/testing/access-tokens/config.yaml
@@ -41,8 +41,17 @@
 {{$ENABLE_RESTART_COUNT_CHECK := DefaultParam .ENABLE_RESTART_COUNT_CHECK false}}
 {{$RESTART_COUNT_THRESHOLD_OVERRIDES:= DefaultParam .RESTART_COUNT_THRESHOLD_OVERRIDES ""}}
 
+# Check if custom namespace prefix is set
+{{$NAMESPACE_PREFIX := DefaultParam .CL2_NAMESPACE_PREFIX ""}}
+
 name: access-tokens
 namespace:
+{{if $NAMESPACE_PREFIX}}
+  deleteStaleNamespaces: false
+  deleteAutomanagedNamespaces: false
+  enableExistingNamespaces: true
+  prefix: {{$NAMESPACE_PREFIX}}
+{{end}}
   number: {{$namespaces}}
 tuningSets:
   - name: Sequence

--- a/clusterloader2/testing/density/config.yaml
+++ b/clusterloader2/testing/density/config.yaml
@@ -38,8 +38,17 @@
 # Probe measurements shared parameter
 {{$PROBE_MEASUREMENTS_CHECK_PROBES_READY_TIMEOUT := DefaultParam .CL2_PROBE_MEASUREMENTS_CHECK_PROBES_READY_TIMEOUT "5m"}}
 
+# Check if custom namespace prefix is set
+{{$NAMESPACE_PREFIX := DefaultParam .CL2_NAMESPACE_PREFIX ""}}
+
 name: density
 namespace:
+{{if $NAMESPACE_PREFIX}}
+  deleteStaleNamespaces: false
+  deleteAutomanagedNamespaces: false
+  enableExistingNamespaces: true
+  prefix: {{$NAMESPACE_PREFIX}}
+{{end}}
   number: {{$namespaces}}
 tuningSets:
 - name: Uniform5qps

--- a/clusterloader2/testing/load/config.yaml
+++ b/clusterloader2/testing/load/config.yaml
@@ -47,8 +47,17 @@
 # Probe measurements shared parameter
 {{$PROBE_MEASUREMENTS_CHECK_PROBES_READY_TIMEOUT := DefaultParam .CL2_PROBE_MEASUREMENTS_CHECK_PROBES_READY_TIMEOUT "5m"}}
 
+# Check if custom namespace prefix is set
+{{$NAMESPACE_PREFIX := DefaultParam .CL2_NAMESPACE_PREFIX ""}}
+
 name: load
 namespace:
+{{if $NAMESPACE_PREFIX}}
+  deleteStaleNamespaces: false
+  deleteAutomanagedNamespaces: false
+  enableExistingNamespaces: true
+  prefix: {{$NAMESPACE_PREFIX}}
+{{end}}
   number: {{$namespaces}}
 tuningSets:
 - name: Sequence

--- a/clusterloader2/testing/load/experimental-config.yaml
+++ b/clusterloader2/testing/load/experimental-config.yaml
@@ -68,8 +68,17 @@
 # Probe measurements shared parameter
 {{$PROBE_MEASUREMENTS_CHECK_PROBES_READY_TIMEOUT := DefaultParam .CL2_PROBE_MEASUREMENTS_CHECK_PROBES_READY_TIMEOUT "5m"}}
 
+# Check if custom namespace prefix is set
+{{$NAMESPACE_PREFIX := DefaultParam .CL2_NAMESPACE_PREFIX ""}}
+
 name: load
 namespace:
+{{if $NAMESPACE_PREFIX}}
+  deleteStaleNamespaces: false
+  deleteAutomanagedNamespaces: false
+  enableExistingNamespaces: true
+  prefix: {{$NAMESPACE_PREFIX}}
+{{end}}
   number: {{AddInt $namespaces $schedulerThroughputNamespaces}}
 tuningSets:
 - name: Sequence


### PR DESCRIPTION
This PR enables changes from #1181 and #1173 as a environment variable.

When setting custom namespace prefix, additionally this namespace will not be deleted and we are accepting situation if it's already created. With this variable, one can easily run  tests divided over different CL2 runs over the same namespace.

/assign @mborsz 
/cc @wojtek-t  