### PR TITLE
Remove SlowCount from labels

### DIFF
--- a/perfdash/parser.go
+++ b/perfdash/parser.go
@@ -34,6 +34,7 @@ import (
 
 func stripCount(data *perftype.DataItem) {
 	delete(data.Labels, "Count")
+	delete(data.Labels, "SlowCount")
 }
 
 func createRequestCountData(data *perftype.DataItem) error {


### PR DESCRIPTION
perf-dash by default adds all labels to available selectors and does breakdown by that label. See https://github.com/kubernetes/perf-tests/issues/1285
