### PR TITLE
Change node-exporter image origin

### DIFF
--- a/clusterloader2/pkg/prometheus/manifests/exporters/node-exporter.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/exporters/node-exporter.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   containers:
     - name: prometheus-node-exporter
-      image: quay.io/prometheus/node-exporter:v0.18.1
+      image: gcr.io/k8s-testimages/quay.io/prometheus/node-exporter:v0.18.1
       imagePullPolicy: "IfNotPresent"
       args:
         - --path.procfs=/host/proc


### PR DESCRIPTION
`quay.io` is down, hence pulling this image is not going to succeed in this pod.