### PR TITLE
Rename storageUrl to storageURL

### DIFF
--- a/perfdash/www/script.js
+++ b/perfdash/www/script.js
@@ -43,7 +43,7 @@ PerfDashApp.prototype.onClickInternal_ = function(data, evt, chart) {
     this.setURLParameters();
     this.http.get("config")
             .success(function(config) {
-                     window.open(config["storageUrl"] + "/" +
+                     window.open(config["storageURL"] + "/" +
                               config["logsBucket"]  + "/" +
                               config["logsPath"] + "/" +
                               this.job + "/" +


### PR DESCRIPTION
It got renamed in https://github.com/kubernetes/perf-tests/commit/5d15f0f796e371284b47a1831a5d06b73afb6bc4#diff-824455981b31a867d75ca77e17833a13L43

I think it's the only place, so we should be good to simply rename here instead of revert of that change.