### PR TITLE
ClusterLoader2: use verbosity to customize measurement logging

### DIFF
--- a/clusterloader2/pkg/execservice/exec_service.go
+++ b/clusterloader2/pkg/execservice/exec_service.go
@@ -86,7 +86,6 @@ func SetUpExecService(f *framework.Framework) error {
 	options := &measurementutil.WaitForPodOptions{
 		Selector:            selector,
 		DesiredPodCount:     execPodReplicas,
-		EnableLogging:       true,
 		CallerName:          execServiceName,
 		WaitForPodsInterval: execPodCheckInterval,
 	}

--- a/clusterloader2/pkg/measurement/common/wait_for_controlled_pods.go
+++ b/clusterloader2/pkg/measurement/common/wait_for_controlled_pods.go
@@ -22,7 +22,7 @@ import (
 	"sync"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -489,7 +489,6 @@ func (w *waitForControlledPodsRunningMeasurement) waitForRuntimeObject(obj runti
 				FieldSelector: "",
 			},
 			DesiredPodCount:     int(runtimeObjectReplicas),
-			EnableLogging:       true,
 			CallerName:          w.String(),
 			WaitForPodsInterval: defaultWaitForPodsInterval,
 			IsPodUpdated:        isPodUpdated,

--- a/clusterloader2/pkg/measurement/common/wait_for_nodes.go
+++ b/clusterloader2/pkg/measurement/common/wait_for_nodes.go
@@ -70,7 +70,6 @@ func (w *waitForNodesMeasurement) Execute(config *measurement.Config) ([]measure
 		Selector:             selector,
 		MinDesiredNodeCount:  minNodeCount,
 		MaxDesiredNodeCount:  maxNodeCount,
-		EnableLogging:        true,
 		CallerName:           w.String(),
 		WaitForNodesInterval: defaultWaitForNodesInterval,
 	}

--- a/clusterloader2/pkg/measurement/common/wait_for_pods.go
+++ b/clusterloader2/pkg/measurement/common/wait_for_pods.go
@@ -67,7 +67,6 @@ func (w *waitForRunningPodsMeasurement) Execute(config *measurement.Config) ([]m
 	options := &measurementutil.WaitForPodOptions{
 		Selector:            selector,
 		DesiredPodCount:     desiredPodCount,
-		EnableLogging:       true,
 		CallerName:          w.String(),
 		WaitForPodsInterval: defaultWaitForPodsInterval,
 	}

--- a/clusterloader2/pkg/measurement/common/wait_for_pvcs.go
+++ b/clusterloader2/pkg/measurement/common/wait_for_pvcs.go
@@ -67,7 +67,6 @@ func (w *waitForBoundPVCsMeasurement) Execute(config *measurement.Config) ([]mea
 	options := &measurementutil.WaitForPVCOptions{
 		Selector:            selector,
 		DesiredPVCCount:     desiredPVCCount,
-		EnableLogging:       true,
 		CallerName:          w.String(),
 		WaitForPVCsInterval: defaultWaitForPVCsInterval,
 	}

--- a/clusterloader2/pkg/measurement/common/wait_for_pvs.go
+++ b/clusterloader2/pkg/measurement/common/wait_for_pvs.go
@@ -66,7 +66,6 @@ func (w *waitForAvailablePVsMeasurement) Execute(config *measurement.Config) ([]
 	options := &measurementutil.WaitForPVOptions{
 		Selector:           selector,
 		DesiredPVCount:     desiredPVCount,
-		EnableLogging:      true,
 		CallerName:         w.String(),
 		WaitForPVsInterval: defaultWaitForPVsInterval,
 	}

--- a/clusterloader2/pkg/measurement/util/gatherers/resource_gather_worker.go
+++ b/clusterloader2/pkg/measurement/util/gatherers/resource_gather_worker.go
@@ -77,7 +77,7 @@ func (w *resourceGatherWorker) singleProbe() {
 func (w *resourceGatherWorker) gather(initialSleep time.Duration) {
 	defer utilruntime.HandleCrash()
 	defer w.wg.Done()
-	defer klog.Infof("Closing worker for %v", w.nodeName)
+	defer klog.V(2).Infof("Closing worker for %v", w.nodeName)
 	defer func() { w.finished = true }()
 	select {
 	case <-time.After(initialSleep):

--- a/clusterloader2/pkg/measurement/util/phase_latency.go
+++ b/clusterloader2/pkg/measurement/util/phase_latency.go
@@ -119,7 +119,7 @@ func (o *ObjectTransitionTimes) printLatencies(latencies []LatencyData, header s
 	if index < 0 {
 		index = 0
 	}
-	klog.Infof("%s: %d %s: %v", o.name, len(latencies)-index, header, latencies[index:])
+	klog.V(2).Infof("%s: %d %s: %v", o.name, len(latencies)-index, header, latencies[index:])
 	var thresholdString string
 	if threshold != time.Duration(0) {
 		thresholdString = fmt.Sprintf("; threshold %v", threshold)

--- a/clusterloader2/pkg/measurement/util/wait_for_nodes.go
+++ b/clusterloader2/pkg/measurement/util/wait_for_nodes.go
@@ -31,7 +31,6 @@ type WaitForNodeOptions struct {
 	Selector             *ObjectSelector
 	MinDesiredNodeCount  int
 	MaxDesiredNodeCount  int
-	EnableLogging        bool
 	CallerName           string
 	WaitForNodesInterval time.Duration
 }
@@ -53,9 +52,7 @@ func WaitForNodes(clientSet clientset.Interface, stopCh <-chan struct{}, options
 				options.MinDesiredNodeCount, options.MaxDesiredNodeCount, options.Selector.String(), nodeCount)
 		case <-time.After(options.WaitForNodesInterval):
 			nodeCount = getNumReadyNodes(ps.List())
-			if options.EnableLogging {
-				klog.Infof("%s: node count (selector = %v): %d", options.CallerName, options.Selector.String(), nodeCount)
-			}
+			klog.V(2).Infof("%s: node count (selector = %v): %d", options.CallerName, options.Selector.String(), nodeCount)
 			if options.MinDesiredNodeCount <= nodeCount && nodeCount <= options.MaxDesiredNodeCount {
 				return nil
 			}

--- a/clusterloader2/pkg/measurement/util/wait_for_pods.go
+++ b/clusterloader2/pkg/measurement/util/wait_for_pods.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/klog"
 )
@@ -37,7 +37,6 @@ const (
 type WaitForPodOptions struct {
 	Selector            *ObjectSelector
 	DesiredPodCount     int
-	EnableLogging       bool
 	CallerName          string
 	WaitForPodsInterval time.Duration
 
@@ -88,9 +87,7 @@ func WaitForPods(clientSet clientset.Interface, stopCh <-chan struct{}, options 
 			if scaling != up && len(addedPods) > 0 {
 				klog.Errorf("%s: %s: %d pods appeared: %v", options.CallerName, options.Selector.String(), len(addedPods), strings.Join(addedPods, ", "))
 			}
-			if options.EnableLogging {
-				klog.Infof("%s: %s: %s", options.CallerName, options.Selector.String(), podsStatus.String())
-			}
+			klog.V(2).Infof("%s: %s: %s", options.CallerName, options.Selector.String(), podsStatus.String())
 			// We allow inactive pods (e.g. eviction happened).
 			// We wait until there is a desired number of pods running and all other pods are inactive.
 			if len(pods) == (podsStatus.Running+podsStatus.Inactive) && podsStatus.Running == podsStatus.RunningUpdated && podsStatus.RunningUpdated == options.DesiredPodCount {

--- a/clusterloader2/pkg/measurement/util/wait_for_pvcs.go
+++ b/clusterloader2/pkg/measurement/util/wait_for_pvcs.go
@@ -29,7 +29,6 @@ import (
 type WaitForPVCOptions struct {
 	Selector            *ObjectSelector
 	DesiredPVCCount     int
-	EnableLogging       bool
 	CallerName          string
 	WaitForPVCsInterval time.Duration
 }
@@ -75,9 +74,7 @@ func WaitForPVCs(clientSet clientset.Interface, stopCh <-chan struct{}, options 
 			if scaling != up && len(addedPVCs) > 0 {
 				klog.Errorf("%s: %s: %d PVCs appeared: %v", options.CallerName, options.Selector.String(), len(deletedPVCs), strings.Join(deletedPVCs, ", "))
 			}
-			if options.EnableLogging {
-				klog.Infof("%s: %s: %s", options.CallerName, options.Selector.String(), pvcsStatus.String())
-			}
+			klog.V(2).Infof("%s: %s: %s", options.CallerName, options.Selector.String(), pvcsStatus.String())
 			// We wait until there is a desired number of PVCs bound and all other PVCs are pending.
 			if len(pvcs) == (pvcsStatus.Bound+pvcsStatus.Pending) && pvcsStatus.Bound == options.DesiredPVCCount {
 				return nil

--- a/clusterloader2/pkg/measurement/util/wait_for_pvs.go
+++ b/clusterloader2/pkg/measurement/util/wait_for_pvs.go
@@ -29,7 +29,6 @@ import (
 type WaitForPVOptions struct {
 	Selector           *ObjectSelector
 	DesiredPVCount     int
-	EnableLogging      bool
 	CallerName         string
 	WaitForPVsInterval time.Duration
 }
@@ -75,9 +74,7 @@ func WaitForPVs(clientSet clientset.Interface, stopCh <-chan struct{}, options *
 			if scaling != up && len(addedPVs) > 0 {
 				klog.Errorf("%s: %s: %d PVs appeared: %v", options.CallerName, options.Selector.String(), len(deletedPVs), strings.Join(deletedPVs, ", "))
 			}
-			if options.EnableLogging {
-				klog.Infof("%s: %s: %s", options.CallerName, options.Selector.String(), pvStatus.String())
-			}
+			klog.V(2).Infof("%s: %s: %s", options.CallerName, options.Selector.String(), pvStatus.String())
 			// We wait until there is a desired number of PVs provisioned and all other PVs are pending.
 			if len(pvs) == (pvStatus.Bound+pvStatus.Available+pvStatus.Pending) && pvStatus.Bound+pvStatus.Available == options.DesiredPVCount {
 				return nil

--- a/clusterloader2/pkg/util/cluster.go
+++ b/clusterloader2/pkg/util/cluster.go
@@ -55,7 +55,7 @@ func LogClusterNodes(c clientset.Interface) error {
 	if err != nil {
 		return err
 	}
-	klog.Infof("Listing cluster nodes:")
+	klog.V(2).Infof("Listing cluster nodes:")
 	for i := range nodeList {
 		var internalIP, externalIP string
 		isSchedulable := isNodeSchedulable(&nodeList[i]) && isNodeUntainted(&nodeList[i])
@@ -67,7 +67,7 @@ func LogClusterNodes(c clientset.Interface) error {
 				externalIP = address.Address
 			}
 		}
-		klog.Infof("Name: %v, clusterIP: %v, externalIP: %v, isSchedulable: %v", nodeList[i].ObjectMeta.Name, internalIP, externalIP, isSchedulable)
+		klog.V(2).Infof("Name: %v, clusterIP: %v, externalIP: %v, isSchedulable: %v", nodeList[i].ObjectMeta.Name, internalIP, externalIP, isSchedulable)
 	}
 	return nil
 }

--- a/clusterloader2/run-e2e.sh
+++ b/clusterloader2/run-e2e.sh
@@ -34,4 +34,4 @@ if [[ "${DEPLOY_GCI_DRIVER:-false}" == "true" ]]; then
 fi
 
 cd ${CLUSTERLOADER_ROOT}/ && go build -o clusterloader './cmd/'
-./clusterloader --alsologtostderr "$@"
+./clusterloader --alsologtostderr --v=2 "$@"


### PR DESCRIPTION
1. Remove _EnableLogging_ flag and use the verbosity level to customize the detailed measurement logging instead.  
2. Address the issue of #1270 by setting the default v level v(2) in  _run-e2e.sh_.