### PR TITLE
Add HTTP method to connect to scheduler

### DIFF
--- a/clusterloader2/pkg/measurement/common/scheduler_latency.go
+++ b/clusterloader2/pkg/measurement/common/scheduler_latency.go
@@ -270,7 +270,7 @@ func (s *schedulerLatencyMeasurement) sendRequestToScheduler(c clientset.Interfa
                 }
                 resp, err := client.Do(req)
                 if err != nil {
-                        return "", fmt.Errorf("unexpected error in http connection to master: %#v", err)
+                        return "", fmt.Errorf("unexpected error in http connection to scheduler master: %#v", err)
                 }
                 defer resp.Body.Close()
                 body, _ := ioutil.ReadAll(resp.Body)


### PR DESCRIPTION
Add HTTP method to connect o scheduler to retrieve metrics. In some secure clusters, ssh to its master node is not allowed. With http connection method, user can run ClusterLoader test on a node within the cluster or on master node.