### PR TITLE
ClusterLoader: remove PrintVerboseLogs flags and use V levels

### DIFF
--- a/clusterloader2/pkg/measurement/common/resource_usage.go
+++ b/clusterloader2/pkg/measurement/common/resource_usage.go
@@ -112,7 +112,6 @@ func (e *resourceUsageMetricMeasurement) Execute(config *measurement.Config) ([]
 				Nodes:                             nodesSet,
 				ResourceDataGatheringPeriod:       60 * time.Second,
 				MasterResourceDataGatheringPeriod: 10 * time.Second,
-				PrintVerboseLogs:                  false,
 			}, nil)
 		if err != nil {
 			return nil, err

--- a/clusterloader2/pkg/measurement/util/gatherers/container_resource_gatherer.go
+++ b/clusterloader2/pkg/measurement/util/gatherers/container_resource_gatherer.go
@@ -72,7 +72,6 @@ type ResourceGathererOptions struct {
 	Nodes                             NodesSet
 	ResourceDataGatheringPeriod       time.Duration
 	MasterResourceDataGatheringPeriod time.Duration
-	PrintVerboseLogs                  bool
 }
 
 func isDaemonPod(pod *corev1.Pod) bool {
@@ -102,7 +101,6 @@ func NewResourceUsageGatherer(c clientset.Interface, host string, port int, prov
 			wg:                          &g.workerWg,
 			finished:                    false,
 			resourceDataGatheringPeriod: options.ResourceDataGatheringPeriod,
-			printVerboseLogs:            options.PrintVerboseLogs,
 			host:                        host,
 			port:                        port,
 			provider:                    provider,
@@ -167,7 +165,6 @@ func NewResourceUsageGatherer(c clientset.Interface, host string, port int, prov
 					finished:                    false,
 					inKubemark:                  false,
 					resourceDataGatheringPeriod: resourceDataGatheringPeriod,
-					printVerboseLogs:            options.PrintVerboseLogs,
 					port:                        port,
 				})
 			}

--- a/clusterloader2/pkg/measurement/util/gatherers/resource_gather_worker.go
+++ b/clusterloader2/pkg/measurement/util/gatherers/resource_gather_worker.go
@@ -38,7 +38,6 @@ type resourceGatherWorker struct {
 	finished                    bool
 	inKubemark                  bool
 	resourceDataGatheringPeriod time.Duration
-	printVerboseLogs            bool
 	host                        string
 	port                        int
 	provider                    string
@@ -66,9 +65,7 @@ func (w *resourceGatherWorker) singleProbe() {
 		}
 		for k, v := range nodeUsage {
 			data[k] = v
-			if w.printVerboseLogs {
-				klog.Infof("Get container %v usage on node %v. CPUUsageInCores: %v, MemoryUsageInBytes: %v, MemoryWorkingSetInBytes: %v", k, w.nodeName, v.CPUUsageInCores, v.MemoryUsageInBytes, v.MemoryWorkingSetInBytes)
-			}
+			klog.V(3).Infof("Get container %v usage on node %v. CPUUsageInCores: %v, MemoryUsageInBytes: %v, MemoryWorkingSetInBytes: %v", k, w.nodeName, v.CPUUsageInCores, v.MemoryUsageInBytes, v.MemoryWorkingSetInBytes)
 		}
 	}
 	w.dataSeries = append(w.dataSeries, data)


### PR DESCRIPTION
Delete two flags printVerboseLogs and PrintVerboseLogs in measurement/util/gathers and use the verbosity level --v to control the logging levels. Please refer to #1298.