### PR TITLE
Add modifier to overwrite test configuration by flags

### DIFF
--- a/clusterloader2/pkg/config/cluster.go
+++ b/clusterloader2/pkg/config/cluster.go
@@ -58,6 +58,8 @@ type ClusterConfig struct {
 
 // ModifierConfig represent all flags used by test modification
 type ModifierConfig struct {
+	// A list of overwrites applied to each test config
+	OverwriteTestConfig []string
 	// A list of names of steps that should be ignored when executing test run
 	SkipSteps []string
 }

--- a/clusterloader2/pkg/modifier/modifier.go
+++ b/clusterloader2/pkg/modifier/modifier.go
@@ -17,34 +17,48 @@ limitations under the License.
 package modifier
 
 import (
+	"errors"
+	"fmt"
+	"k8s.io/klog"
 	"k8s.io/perf-tests/clusterloader2/api"
 	"k8s.io/perf-tests/clusterloader2/pkg/config"
 	"k8s.io/perf-tests/clusterloader2/pkg/flags"
+	"reflect"
+	"strconv"
+	"strings"
 )
 
 // Modifier mutates provided test
 type Modifier interface {
-	ChangeTest(*api.Config)
+	ChangeTest(*api.Config) error
 }
 
 // InitFlags allows setting configuration with flags
 func InitFlags(m *config.ModifierConfig) {
+	flags.StringArrayVar(&m.OverwriteTestConfig, "overwrite-test-config", []string{}, "Overwrite test config with specific value, used as parameter1.parameter2=value, for example 'Namespace.Prefix=custom-prefix'")
 	flags.StringArrayVar(&m.SkipSteps, "skip-steps", []string{}, "Name of steps to skip in test")
 }
 
 // NewModifier creates new Modifier according to provided configuration
 func NewModifier(m *config.ModifierConfig) Modifier {
-	return &simpleModifier{skipSteps: m.SkipSteps}
+	return &simpleModifier{overwriteTestConfig: m.OverwriteTestConfig, skipSteps: m.SkipSteps}
 }
 
 type simpleModifier struct {
-	skipSteps []string
+	overwriteTestConfig []string
+	skipSteps           []string
 }
 
 // Ensuring that simpleModifier implements Modifier interface
 var _ Modifier = &simpleModifier{}
 
-func (m *simpleModifier) ChangeTest(c *api.Config) {
+func (m *simpleModifier) ChangeTest(c *api.Config) error {
+	m.modifySkipSteps(c)
+	err := m.modifyOverwrite(c)
+	return err
+}
+
+func (m *simpleModifier) modifySkipSteps(c *api.Config) {
 	steps := c.Steps
 	c.Steps = []api.Step{}
 	for _, s := range steps {
@@ -52,6 +66,7 @@ func (m *simpleModifier) ChangeTest(c *api.Config) {
 		for _, i := range m.skipSteps {
 			if i == s.Name {
 				ignored = true
+				klog.Infof("Ignoring step %s", s.Name)
 				break
 			}
 		}
@@ -59,4 +74,70 @@ func (m *simpleModifier) ChangeTest(c *api.Config) {
 			c.Steps = append(c.Steps, s)
 		}
 	}
+}
+
+func (m *simpleModifier) modifyOverwrite(c *api.Config) error {
+	for _, o := range m.overwriteTestConfig {
+		kv := strings.Split(o, "=")
+		if len(kv) != 2 {
+			errMsg := fmt.Sprintf("Not a key=value pair: %s", o)
+			klog.Error(errMsg)
+			return errors.New(errMsg)
+		}
+		k, v := kv[0], kv[1]
+
+		parameterPath := strings.Split(k, ".")
+		curValue := reflect.ValueOf(c).Elem()
+		for _, p := range parameterPath {
+			curValue = curValue.FieldByName(p)
+			if !curValue.IsValid() {
+				return fmt.Errorf("cannot overwrite config for key '%s'. Path does not exist", k)
+			}
+			// We want to dereference pointers if any happen along the way
+			if curValue.Kind() == reflect.Ptr {
+				// If path came across ptr to nil, we need to create zero value before dereferencing
+				if curValue.IsNil() {
+					expectedType := curValue.Type().Elem()
+					pointerToZeroValue := reflect.New(expectedType)
+					curValue.Set(pointerToZeroValue)
+				}
+				curValue = curValue.Elem()
+			}
+		}
+		e := m.overwriteValue(curValue, v, k)
+		if e != nil {
+			return e
+		}
+	}
+	return nil
+}
+
+func (m *simpleModifier) overwriteValue(node reflect.Value, v, k string) error {
+	switch node.Kind() {
+	case reflect.Bool:
+		boolV, err := strconv.ParseBool(v)
+		if err != nil {
+			errMsg := fmt.Sprintf("test config overwrite error: Cannot parse '%s' for key '%s' to bool: %v", v, k, err)
+			klog.Error(errMsg)
+			return errors.New(errMsg)
+		}
+		klog.Infof("Setting bool value '%t' for key '%s'", boolV, k)
+		node.SetBool(boolV)
+	case reflect.String:
+		klog.Infof("Setting string value '%s' for key '%s'", v, k)
+		node.SetString(v)
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		intV, err := strconv.ParseInt(v, 10, 64)
+		if err != nil {
+			errMsg := fmt.Sprintf("test config overwrite error: Cannot parse '%s' for key '%s' to int: %v", v, k, err)
+			klog.Error(errMsg)
+			return errors.New(errMsg)
+		}
+		klog.Infof("Setting int value '%d' for key '%s'", intV, k)
+	default:
+		errMsg := fmt.Sprintf("Unsupported kind: %v for key %s", node.Kind(), k)
+		klog.Error(errMsg)
+		return errors.New(errMsg)
+	}
+	return nil
 }

--- a/clusterloader2/pkg/modifier/modifier_test.go
+++ b/clusterloader2/pkg/modifier/modifier_test.go
@@ -18,6 +18,7 @@ package modifier
 
 import (
 	"k8s.io/perf-tests/clusterloader2/api"
+	"reflect"
 	"testing"
 )
 
@@ -30,7 +31,7 @@ func defaultConfig() *api.Config {
 	}
 }
 
-func TestModifier(t *testing.T) {
+func TestModifySkipSteps(t *testing.T) {
 	m := &simpleModifier{skipSteps: []string{"skip-me", "skip me"}}
 	testCase := [][]string{{}, {"skip-me"}, {"skip-me", "skip me"}}
 	for _, d := range testCase {
@@ -38,7 +39,7 @@ func TestModifier(t *testing.T) {
 		for _, s := range d {
 			c.Steps = append(c.Steps, api.Step{Name: s})
 		}
-		m.ChangeTest(c)
+		m.modifySkipSteps(c)
 		if len(c.Steps) != 1 {
 			t.Errorf("For test case %v: Changed test config in unexpected way, expected to have 1 step, but was %d steps", d, len(c.Steps))
 		}
@@ -46,5 +47,61 @@ func TestModifier(t *testing.T) {
 			t.Errorf("For test case %v: Changed test in unexpected way, expected to have 1 step with name 'eternal', but was %s", d, c.Steps[0].Name)
 		}
 	}
+}
 
+func TestModifyOverwrite(t *testing.T) {
+	testCase := []struct {
+		overwrite []string
+		expected  *api.Config
+		err       string
+	}{
+		{overwrite: []string{}, expected: defaultConfig()},
+		{
+			overwrite: []string{"Namespace.Prefix=overwritten-prefix"},
+			expected: &api.Config{
+				Name: "test-modifier",
+				Steps: []api.Step{{
+					Name: "eternal",
+				}},
+				Namespace: api.NamespaceConfig{
+					Prefix: "overwritten-prefix",
+				}},
+		},
+		{
+			overwrite: []string{"Namespace.EnableExistingNamespaces=true"},
+			expected: &api.Config{
+				Name: "test-modifier",
+				Steps: []api.Step{{
+					Name: "eternal",
+				}},
+				Namespace: api.NamespaceConfig{
+					// Golang does not allow to take a pointer to '&true'
+					EnableExistingNamespaces: &[]bool{true}[0],
+				}},
+		},
+		{
+			overwrite: []string{"NotExistingParameter=123"},
+			err:       "cannot overwrite config for key 'NotExistingParameter'. Path does not exist",
+		},
+	}
+	for _, d := range testCase {
+		m := &simpleModifier{overwriteTestConfig: d.overwrite}
+		c := defaultConfig()
+		err := m.modifyOverwrite(c)
+		if d.expected != nil {
+			if err != nil {
+				t.Errorf("For test case %v: Expected succes, however error %v happened", d.overwrite, err)
+			}
+			if !reflect.DeepEqual(c, d.expected) {
+				t.Errorf("For test case %v: Changed test in unexpected way, was '%v' but expected '%v'", d.overwrite, c, d.expected)
+			}
+		} else {
+			if err == nil {
+				t.Errorf("For test case %v: Expected error, however it did not happen", d.overwrite)
+			}
+			if err.Error() != d.err {
+				t.Errorf("For test case %v: Returned unexpected error '%s', expected error '%s'", d.overwrite, err, d.err)
+			}
+		}
+	}
 }

--- a/clusterloader2/pkg/test/test.go
+++ b/clusterloader2/pkg/test/test.go
@@ -62,7 +62,10 @@ func RunTest(clusterFramework, prometheusFramework *framework.Framework, cluster
 	if err != nil {
 		return errors.NewErrorList(fmt.Errorf("config reading error: %v", err))
 	}
-	modifier.NewModifier(&clusterLoaderConfig.ModifierConfig).ChangeTest(testConfig)
+
+	if err := modifier.NewModifier(&clusterLoaderConfig.ModifierConfig).ChangeTest(testConfig); err != nil {
+		return errors.NewErrorList(fmt.Errorf("config mutation error: %v", err))
+	}
 
 	// TODO: remove them after the deprecated command options are removed.
 	if testConfig.Namespace.DeleteStaleNamespaces == nil {


### PR DESCRIPTION
Flag level allowing configuration of config for ClusterLoader2

It solves problem for #1282 and little more.

It does not support slices on parameter path, but this feature is currently not needed.

/assign @mm4tt 
/cc @wojtek-t 
