### PR TITLE
Add cluster OOMs tracking in clusterloader2

### DIFF
--- a/clusterloader2/docs/oom_detection.md
+++ b/clusterloader2/docs/oom_detection.md
@@ -1,0 +1,51 @@
+# Clusterloader2 - tracking OOMs
+
+In order to track pods OOMs (out of memory) during clusterloader2 tests
+execution, TestMetrics has been augmented with `ClusterOOMsTracker` measurement.
+This outputs an appropriate summary containing basic information regarding OOMs
+inside the cluster like the PID of OOMing process or the name of a node where
+the OOM happened.
+
+Given that `ClusterOOMsTracker` is based on Kubernetes events and events are
+best effort by their nature, the reported summary is not guaranteed to
+accurately describe what really happened - some of the OOMs may be missed.
+
+## Enabling OOMs tracking
+
+Firstly, ensure that the `TestMetrics` measurement is added to `Starting
+measurements` and `Collecting measurements` steps of your test config. Next,
+add `clusterOOMsTrackerEnabled` parameter and set it to `true` in both steps
+configuration.
+
+Sample configuration in `Starting measurements` step:
+
+```yaml
+- name: Starting measurements
+  measurements:
+    ...
+    - Identifier: TestMetrics
+      Method: TestMetrics
+      Params:
+        action: start
+        clusterOOMsTrackerEnabled: true
+```
+
+Sample configuration in `Collecting measurements` step:
+
+```yaml
+- name: Collecting measurements
+  measurements:
+    ...
+    - Identifier: TestMetrics
+      Method: TestMetrics
+      Params:
+        action: gather
+        clusterOOMsTrackerEnabled: true
+```
+
+## Further debugging steps
+
+`ClusterOOMsTracker` watches for events emitted by `node-problem-detector` when
+an OOM occurs. Such events contain only a fraction of information that may be
+useful for debugging - for more, check `systemd.log` files of an appropriate
+node for the name of OOMing pod/container or the container's memory limit.

--- a/clusterloader2/pkg/measurement/common/bundle/test_metrics.go
+++ b/clusterloader2/pkg/measurement/common/bundle/test_metrics.go
@@ -81,6 +81,9 @@ func createTestMetricsMeasurement() measurement.Measurement {
 	if metrics.systemPodMetrics, err = measurement.CreateMeasurement("SystemPodMetrics"); err != nil {
 		klog.Errorf("%v: systemPodMetrics creation error: %v", metrics, err)
 	}
+	if metrics.clusterOOMsTracker, err = measurement.CreateMeasurement("ClusterOOMsTracker"); err != nil {
+		klog.Errorf("%v: clusterOOMsTracker creation error: %v", metrics, err)
+	}
 	return &metrics
 }
 
@@ -99,6 +102,7 @@ type testMetrics struct {
 	controllerManagerCPUProfile    measurement.Measurement
 	controllerManagerMemoryProfile measurement.Measurement
 	systemPodMetrics               measurement.Measurement
+	clusterOOMsTracker             measurement.Measurement
 }
 
 // Execute supports two actions. start - which sets up all metrics.
@@ -181,6 +185,8 @@ func (t *testMetrics) Execute(config *measurement.Config) ([]measurement.Summary
 		appendResults(&summaries, errList, summary, executeError(t.controllerManagerMemoryProfile.String(), action, err))
 		summary, err = execute(t.systemPodMetrics, config)
 		appendResults(&summaries, errList, summary, executeError(t.systemPodMetrics.String(), action, err))
+		summary, err = execute(t.clusterOOMsTracker, config)
+		appendResults(&summaries, errList, summary, executeError(t.clusterOOMsTracker.String(), action, err))
 	case "gather":
 		summary, err := execute(t.etcdMetrics, actionGatherConfig)
 		appendResults(&summaries, errList, summary, executeError(t.etcdMetrics.String(), action, err))
@@ -210,6 +216,8 @@ func (t *testMetrics) Execute(config *measurement.Config) ([]measurement.Summary
 		appendResults(&summaries, errList, summary, executeError(t.controllerManagerMemoryProfile.String(), action, err))
 		summary, err = execute(t.systemPodMetrics, config)
 		appendResults(&summaries, errList, summary, executeError(t.systemPodMetrics.String(), action, err))
+		summary, err = execute(t.clusterOOMsTracker, config)
+		appendResults(&summaries, errList, summary, executeError(t.clusterOOMsTracker.String(), action, err))
 	default:
 		return summaries, fmt.Errorf("unknown action %v", action)
 	}

--- a/clusterloader2/pkg/measurement/common/ooms_tracker.go
+++ b/clusterloader2/pkg/measurement/common/ooms_tracker.go
@@ -1,0 +1,214 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"fmt"
+	"regexp"
+	"sync"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/klog"
+	"k8s.io/perf-tests/clusterloader2/pkg/measurement"
+	measurementutil "k8s.io/perf-tests/clusterloader2/pkg/measurement/util"
+	"k8s.io/perf-tests/clusterloader2/pkg/measurement/util/informer"
+	"k8s.io/perf-tests/clusterloader2/pkg/util"
+)
+
+const (
+	clusterOOMsTrackerEnabledParamName = "clusterOOMsTrackerEnabled"
+	clusterOOMsTrackerName             = "ClusterOOMsTracker"
+	informerTimeout                    = time.Minute
+	oomEventReason                     = "OOMKilling"
+)
+
+var (
+	oomEventMsgRegex = regexp.MustCompile(`Kill process (\d+) \((.+)\) score \d+ or sacrifice child\nKilled process \d+ .+ total-vm:(\d+kB), anon-rss:\d+kB, file-rss:\d+kB.*`)
+)
+
+func init() {
+	if err := measurement.Register(clusterOOMsTrackerName, createClusterOOMsTrackerMeasurement); err != nil {
+		klog.Fatalf("Cannot register %s: %v", clusterOOMsTrackerName, err)
+	}
+}
+
+func createClusterOOMsTrackerMeasurement() measurement.Measurement {
+	return &clusterOOMsTrackerMeasurement{}
+}
+
+type clusterOOMsTrackerMeasurement struct {
+	selector  *measurementutil.ObjectSelector
+	msgRegex  *regexp.Regexp
+	isRunning bool
+	stopCh    chan struct{}
+	oomsLock  sync.Mutex
+	ooms      []oomEvent
+}
+
+// TODO: Reevaluate if we can add new fields here when node-problem-detector
+// starts using new events.
+type oomEvent struct {
+	Node          string    `json:"node"`
+	Process       string    `json:"process"`
+	ProcessMemory string    `json:"memory"`
+	ProcessID     string    `json:"pid"`
+	Time          time.Time `json:"time"`
+}
+
+func (m *clusterOOMsTrackerMeasurement) Execute(config *measurement.Config) ([]measurement.Summary, error) {
+	clusterOOMsTrackerEnabled, err := util.GetBoolOrDefault(config.Params, clusterOOMsTrackerEnabledParamName, false)
+	if err != nil {
+		return nil, fmt.Errorf("problem with getting %s param: %w", clusterOOMsTrackerEnabledParamName, err)
+	}
+	if !clusterOOMsTrackerEnabled {
+		klog.Info("skipping tracking of OOMs in the cluster")
+		return nil, nil
+	}
+
+	action, err := util.GetString(config.Params, "action")
+	if err != nil {
+		return nil, fmt.Errorf("problem with getting %s param: %w", "action", err)
+	}
+
+	switch action {
+	case "start":
+		if err = m.start(config.ClusterFramework.GetClientSets().GetClient()); err != nil {
+			return nil, fmt.Errorf("starting cluster OOMs measurement problem: %w", err)
+		}
+		return nil, nil
+	case "gather":
+		m.oomsLock.Lock()
+		defer m.oomsLock.Unlock()
+		summary, err := m.gather()
+		if err != nil {
+			return nil, fmt.Errorf("gathering cluster OOMs measurement problem: %w", err)
+		}
+		return summary, m.validate()
+	default:
+		return nil, fmt.Errorf("unknown action %v", action)
+	}
+}
+
+func (m *clusterOOMsTrackerMeasurement) Dispose() {
+	m.stop()
+}
+
+func (m *clusterOOMsTrackerMeasurement) String() string {
+	return clusterOOMsTrackerName
+}
+
+func (m *clusterOOMsTrackerMeasurement) start(c clientset.Interface) error {
+	if m.isRunning {
+		klog.Infof("%s: cluster OOMs tracking measurement already running", m)
+		return nil
+	}
+	klog.Infof("%s: starting cluster OOMs tracking measurement...", m)
+	m.initFields()
+	// Watching for OOM events from node-problem-detector below.
+	i := informer.NewInformer(
+		c,
+		"events",
+		m.selector,
+		m.handleOOMEvent,
+	)
+	if err := informer.StartAndSync(i, m.stopCh, informerTimeout); err != nil {
+		return fmt.Errorf("problem with OOM events informer starting: %w", err)
+	}
+	return nil
+}
+
+func (m *clusterOOMsTrackerMeasurement) initFields() {
+	m.isRunning = true
+	m.stopCh = make(chan struct{})
+	m.ooms = make([]oomEvent, 0)
+	m.selector = &measurementutil.ObjectSelector{
+		FieldSelector: fields.Set{"reason": oomEventReason}.AsSelector().String(),
+		Namespace:     metav1.NamespaceAll,
+	}
+	m.msgRegex = oomEventMsgRegex
+}
+
+func (m *clusterOOMsTrackerMeasurement) stop() {
+	if m.isRunning {
+		m.isRunning = false
+		close(m.stopCh)
+	}
+}
+
+func (m *clusterOOMsTrackerMeasurement) gather() ([]measurement.Summary, error) {
+	klog.Infof("%s: gathering cluster OOMs tracking measurement", clusterOOMsTrackerName)
+	if !m.isRunning {
+		return nil, fmt.Errorf("measurement %s has not been started", clusterOOMsTrackerName)
+	}
+
+	m.stop()
+
+	content, err := util.PrettyPrintJSON(struct {
+		Ooms []oomEvent `json:"ooms"`
+	}{
+		Ooms: m.ooms,
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("OOMs PrettyPrintJSON problem: %w", err)
+	}
+
+	summary := measurement.CreateSummary(clusterOOMsTrackerName, "json", content)
+	return []measurement.Summary{summary}, nil
+}
+
+func (m *clusterOOMsTrackerMeasurement) validate() error {
+	if len(m.ooms) == 0 {
+		return nil
+	}
+	return fmt.Errorf("OOMs recorded: %+v", m.ooms)
+}
+
+func (m *clusterOOMsTrackerMeasurement) handleOOMEvent(_, obj interface{}) {
+	if obj == nil {
+		return
+	}
+	event, ok := obj.(*corev1.Event)
+	if !ok {
+		return
+	}
+
+	oom := oomEvent{
+		Node: event.InvolvedObject.Name,
+	}
+	if !event.EventTime.IsZero() {
+		oom.Time = event.EventTime.Time
+	} else {
+		oom.Time = event.FirstTimestamp.Time
+	}
+
+	if match := m.msgRegex.FindStringSubmatch(event.Message); len(match) == 4 {
+		oom.ProcessID = match[1]
+		oom.Process = match[2]
+		oom.ProcessMemory = match[3]
+	} else {
+		klog.Warningf(`unrecognized OOM event message pattern; event message contents: "%v"`, event.Message)
+	}
+
+	m.oomsLock.Lock()
+	defer m.oomsLock.Unlock()
+	m.ooms = append(m.ooms, oom)
+}

--- a/clusterloader2/testing/density/config.yaml
+++ b/clusterloader2/testing/density/config.yaml
@@ -20,6 +20,7 @@
 {{$ENABLE_CHAOSMONKEY := DefaultParam .ENABLE_CHAOSMONKEY false}}
 {{$ENABLE_PROMETHEUS_API_RESPONSIVENESS := DefaultParam .ENABLE_PROMETHEUS_API_RESPONSIVENESS false}}
 {{$ENABLE_SYSTEM_POD_METRICS:= DefaultParam .ENABLE_SYSTEM_POD_METRICS true}}
+{{$ENABLE_CLUSTER_OOMS_TRACKER := DefaultParam .CL2_ENABLE_CLUSTER_OOMS_TRACKER false}}
 {{$USE_SIMPLE_LATENCY_QUERY := DefaultParam .USE_SIMPLE_LATENCY_QUERY false}}
 {{$ENABLE_RESTART_COUNT_CHECK := DefaultParam .ENABLE_RESTART_COUNT_CHECK false}}
 {{$RESTART_COUNT_THRESHOLD_OVERRIDES:= DefaultParam .RESTART_COUNT_THRESHOLD_OVERRIDES ""}}
@@ -84,6 +85,7 @@ steps:
       nodeMode: {{$NODE_MODE}}
       resourceConstraints: {{$DENSITY_RESOURCE_CONSTRAINTS_FILE}}
       systemPodMetricsEnabled: {{$ENABLE_SYSTEM_POD_METRICS}}
+      clusterOOMsTrackerEnabled: {{$ENABLE_CLUSTER_OOMS_TRACKER}}
       restartCountThresholdOverrides: {{YamlQuote $RESTART_COUNT_THRESHOLD_OVERRIDES 4}}
       enableRestartCountCheck: {{$ENABLE_RESTART_COUNT_CHECK}}
 
@@ -255,5 +257,6 @@ steps:
     Params:
       action: gather
       systemPodMetricsEnabled: {{$ENABLE_SYSTEM_POD_METRICS}}
+      clusterOOMsTrackerEnabled: {{$ENABLE_CLUSTER_OOMS_TRACKER}}
       restartCountThresholdOverrides: {{YamlQuote $RESTART_COUNT_THRESHOLD_OVERRIDES 4}}
       enableRestartCountCheck: {{$ENABLE_RESTART_COUNT_CHECK}}

--- a/clusterloader2/testing/load/config.yaml
+++ b/clusterloader2/testing/load/config.yaml
@@ -20,6 +20,7 @@
 {{$ENABLE_PVS := DefaultParam .CL2_ENABLE_PVS true}}
 {{$ENABLE_NETWORKPOLICIES := DefaultParam .CL2_ENABLE_NETWORKPOLICIES false}}
 {{$ENABLE_SYSTEM_POD_METRICS:= DefaultParam .ENABLE_SYSTEM_POD_METRICS true}}
+{{$ENABLE_CLUSTER_OOMS_TRACKER := DefaultParam .CL2_ENABLE_CLUSTER_OOMS_TRACKER false}}
 {{$USE_SIMPLE_LATENCY_QUERY := DefaultParam .USE_SIMPLE_LATENCY_QUERY false}}
 {{$ENABLE_RESTART_COUNT_CHECK := DefaultParam .ENABLE_RESTART_COUNT_CHECK false}}
 {{$RESTART_COUNT_THRESHOLD_OVERRIDES:= DefaultParam .RESTART_COUNT_THRESHOLD_OVERRIDES ""}}
@@ -114,6 +115,7 @@ steps:
       action: start
       nodeMode: {{$NODE_MODE}}
       systemPodMetricsEnabled: {{$ENABLE_SYSTEM_POD_METRICS}}
+      clusterOOMsTrackerEnabled: {{$ENABLE_CLUSTER_OOMS_TRACKER}}
       restartCountThresholdOverrides: {{YamlQuote $RESTART_COUNT_THRESHOLD_OVERRIDES 4}}
       enableRestartCountCheck: {{$ENABLE_RESTART_COUNT_CHECK}}
 
@@ -699,5 +701,6 @@ steps:
     Params:
       action: gather
       systemPodMetricsEnabled: {{$ENABLE_SYSTEM_POD_METRICS}}
+      clusterOOMsTrackerEnabled: {{$ENABLE_CLUSTER_OOMS_TRACKER}}
       restartCountThresholdOverrides: {{YamlQuote $RESTART_COUNT_THRESHOLD_OVERRIDES 4}}
       enableRestartCountCheck: {{$ENABLE_RESTART_COUNT_CHECK}}


### PR DESCRIPTION
This PR adds a measurement tracking OOM events in clusterloader2 emitted by `node-problem-detector` and enables it in density and load tests.

Confirmation that it works: [cl2 presubmit job results](https://prow.k8s.io/view/gcs/kubernetes-jenkins/pr-logs/pull/perf-tests/1309/pull-perf-tests-clusterloader2/1268900097278611456/) (there was a deployment with an OOMing container in the PR version of this presubmit).