### PR TITLE
remove metrics reset. Use get to obtain initial metrics values

### DIFF
--- a/clusterloader2/pkg/measurement/common/scheduler_latency.go
+++ b/clusterloader2/pkg/measurement/common/scheduler_latency.go
@@ -143,6 +143,13 @@ func (*schedulerLatencyMeasurement) String() string {
 }
 
 func (s *schedulerLatencyMeasurement) resetSchedulerMetrics(c clientset.Interface, host, provider, masterName string, masterRegistered bool) error {
+	s.e2eSchedulingDurationInitHist = measurementutil.NewHistogram(nil)
+	s.schedulingAlgorithmDurationInitHist = measurementutil.NewHistogram(nil)
+	s.preemptionEvaluationInitHist = measurementutil.NewHistogram(nil)
+	s.frameworkExtensionPointDurationInitHist = make(map[string]*measurementutil.Histogram)
+	for _, ePoint := range extentionsPoints {
+		s.frameworkExtensionPointDurationInitHist[ePoint] = measurementutil.NewHistogram(nil)
+	}
 	_, err := s.sendRequestToScheduler(c, "DELETE", host, provider, masterName, masterRegistered)
 	if err != nil {
 		return err

--- a/clusterloader2/pkg/measurement/common/scheduler_latency.go
+++ b/clusterloader2/pkg/measurement/common/scheduler_latency.go
@@ -146,7 +146,7 @@ func (*schedulerLatencyMeasurement) String() string {
 	return schedulerLatencyMetricName
 }
 
-// Helper function to substract two histograms
+// histogramSub is a helper function to substract two histograms
 func histogramSub(finalHist, initialHist *measurementutil.Histogram) *measurementutil.Histogram {
 	for k := range finalHist.Buckets {
 		finalHist.Buckets[k] = finalHist.Buckets[k] - initialHist.Buckets[k]
@@ -198,7 +198,7 @@ func (s *schedulerLatencyMeasurement) setQuantiles(metrics schedulerLatencyMetri
 	return result, nil
 }
 
-// Retrieves scheduler latency metrics.
+// getSchedulingLatency retrieves scheduler latency metrics.
 func (s *schedulerLatencyMeasurement) getSchedulingLatency(c clientset.Interface, host, provider, masterName string, masterRegistered bool) ([]measurement.Summary, error) {
 	schedulerMetrics, err := s.getSchedulingMetrics(c, host, provider, masterName, masterRegistered)
 	if err != nil {
@@ -217,7 +217,7 @@ func (s *schedulerLatencyMeasurement) getSchedulingLatency(c clientset.Interface
 	return []measurement.Summary{summary}, nil
 }
 
-// Retrieves initial values of scheduler latency metrics
+// getSchedulingInitialLatency retrieves initial values of scheduler latency metrics
 func (s *schedulerLatencyMeasurement) getSchedulingInitialLatency(c clientset.Interface, host, provider, masterName string, masterRegistered bool) error {
 	var err error
 	s.initialLatency, err = s.getSchedulingMetrics(c, host, provider, masterName, masterRegistered)
@@ -227,7 +227,7 @@ func (s *schedulerLatencyMeasurement) getSchedulingInitialLatency(c clientset.In
 	return nil
 }
 
-// Get scheduler latency metrics
+// getSchedulingMetrics gets scheduler latency metrics
 func (s *schedulerLatencyMeasurement) getSchedulingMetrics(c clientset.Interface, host, provider, masterName string, masterRegistered bool) (schedulerLatencyMetrics, error) {
 	e2eSchedulingDurationHist := measurementutil.NewHistogram(nil)
 	schedulingAlgorithmDurationHist := measurementutil.NewHistogram(nil)
@@ -270,7 +270,7 @@ func (s *schedulerLatencyMeasurement) getSchedulingMetrics(c clientset.Interface
 	return latencyMetrics, nil
 }
 
-// Set quantile of LatencyMetric from Histogram
+// setQuantileFromHistogram sets quantile of LatencyMetric from Histogram
 func (s *schedulerLatencyMeasurement) setQuantileFromHistogram(metric *measurementutil.LatencyMetric, hist *measurementutil.Histogram) error {
 	quantiles := []float64{0.5, 0.9, 0.99}
 	for _, quantile := range quantiles {
@@ -288,7 +288,7 @@ func (s *schedulerLatencyMeasurement) setQuantileFromHistogram(metric *measureme
 	return nil
 }
 
-// Sends request to kube scheduler metrics
+// sendRequestToScheduler sends request to kube scheduler metrics
 func (s *schedulerLatencyMeasurement) sendRequestToScheduler(c clientset.Interface, op, host, provider, masterName string, masterRegistered bool) (string, error) {
 	opUpper := strings.ToUpper(op)
 	if opUpper != "GET" && opUpper != "DELETE" {

--- a/clusterloader2/pkg/measurement/common/scheduler_latency.go
+++ b/clusterloader2/pkg/measurement/common/scheduler_latency.go
@@ -120,9 +120,12 @@ func (s *schedulerLatencyMeasurement) Execute(config *measurement.Config) ([]mea
 	}
 
 	switch action {
+	case "start":
+		klog.Infof("%s: start collecting latency metrics in scheduler...", s)
+		return nil, s.getSchedulingInitialLatency(config.ClusterFramework.GetClientSets().GetClient(), masterIP, provider, masterName, masterRegistered)
 	case "reset":
 		klog.Infof("%s: resetting latency metrics in scheduler...", s)
-		return nil, s.getSchedulingInitialLatency(config.ClusterFramework.GetClientSets().GetClient(), masterIP, provider, masterName, masterRegistered)
+		return nil, s.resetSchedulerMetrics(config.ClusterFramework.GetClientSets().GetClient(), masterIP, provider, masterName, masterRegistered)
 	case "gather":
 		klog.Infof("%s: gathering latency metrics in scheduler...", s)
 		return s.getSchedulingLatency(config.ClusterFramework.GetClientSets().GetClient(), masterIP, provider, masterName, masterRegistered)

--- a/clusterloader2/pkg/measurement/common/scheduler_latency.go
+++ b/clusterloader2/pkg/measurement/common/scheduler_latency.go
@@ -199,7 +199,7 @@ func (s *schedulerLatencyMeasurement) getSchedulingLatency(c clientset.Interface
 	return []measurement.Summary{summary}, nil
 }
 
-// Retrieves initial values of scheduler latency
+// Retrieves initial values of scheduler latency metrics
 func (s *schedulerLatencyMeasurement) getSchedulingInitialLatency(c clientset.Interface, host, provider, masterName string, masterRegistered bool) error {
 	var err error
 	s.initialLatency, err = s.getSchedulingMetrics(c, host, provider, masterName, masterRegistered)


### PR DESCRIPTION
Using reset to change scheduler metrics has 2 issues: 
1) Reset scheduler metrics that are shared with prometheus may disrupt time series stored in prometheus. 
2) Reset operation are often forbidden in production cluster.

Use get to retrieve and store initial value instead of reset. At gather stage, subtract the data from the initial data.