### PR TITLE
Exec command in the middle of performance test.

### DIFF
--- a/clusterloader2/pkg/measurement/common/exec.go
+++ b/clusterloader2/pkg/measurement/common/exec.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"time"
+
+	"k8s.io/klog"
+
+	"k8s.io/perf-tests/clusterloader2/pkg/measurement"
+	"k8s.io/perf-tests/clusterloader2/pkg/util"
+)
+
+const (
+	execName             = "Exec"
+	defaultTimeoutString = "1h"
+)
+
+func init() {
+	if err := measurement.Register(execName, createExecMeasurement); err != nil {
+		klog.Fatalf("Cannot register %s: %v", execName, err)
+	}
+}
+
+func createExecMeasurement() measurement.Measurement {
+	return &execMeasurement{}
+}
+
+type execMeasurement struct{}
+
+func (e *execMeasurement) Execute(config *measurement.Config) ([]measurement.Summary, error) {
+	timeoutStr, err := util.GetStringOrDefault(config.Params, "timeout", defaultTimeoutString)
+	if err != nil {
+		return nil, err
+	}
+	timeout, err := time.ParseDuration(timeoutStr)
+	if err != nil {
+		return nil, err
+	}
+	command, err := util.GetStringArray(config.Params, "command")
+	if err != nil {
+		return nil, err
+	}
+	if len(command) == 0 {
+		return nil, fmt.Errorf("command is a required argument. Got empty slice instead")
+	}
+
+	// Make a copy of command, to avoid overriding a slice we don't own.
+	command = append([]string{}, command...)
+	for i := range command {
+		command[i] = os.ExpandEnv(command[i])
+	}
+	klog.Infof("Running %v with timeout %v", command, timeout)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, command[0], command[1:]...)
+	out, err := cmd.CombinedOutput()
+	klog.Infof("output: %v", string(out))
+	if err != nil {
+		return nil, fmt.Errorf("command %v failed: %v", command, err)
+	}
+	return nil, nil
+}
+
+func (e *execMeasurement) Dispose() {}
+
+func (e *execMeasurement) String() string { return execName }

--- a/clusterloader2/pkg/util/util.go
+++ b/clusterloader2/pkg/util/util.go
@@ -71,6 +71,11 @@ func GetMap(dict map[string]interface{}, key string) (map[string]interface{}, er
 	return getMap(dict, key)
 }
 
+// GetStringArray tries to return value from map of type map. If value doesn't exist, error is returned.
+func GetStringArray(dict map[string]interface{}, key string) ([]string, error) {
+	return getStringArray(dict, key)
+}
+
 // GetStringOrDefault tries to return value from map cast to string type. If value doesn't exist default value is used.
 func GetStringOrDefault(dict map[string]interface{}, key string, defaultValue string) (string, error) {
 	value, err := getString(dict, key)
@@ -127,6 +132,28 @@ func getMap(dict map[string]interface{}, key string) (map[string]interface{}, er
 		return nil, fmt.Errorf("type assertion error: %v is not a string", value)
 	}
 	return mapValue, nil
+}
+
+func getStringArray(dict map[string]interface{}, key string) ([]string, error) {
+	value, exists := dict[key]
+	if !exists || value == nil {
+		return nil, &ErrKeyNotFound{key}
+	}
+
+	sliceValue, ok := value.([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("type assertion error: %v (%T) is not a []string", value, value)
+	}
+
+	var res []string
+	for _, val := range sliceValue {
+		valStr, ok := val.(string)
+		if !ok {
+			return nil, fmt.Errorf("type assertion error: %v is not a string", val)
+		}
+		res = append(res, valStr)
+	}
+	return res, nil
 }
 
 func getString(dict map[string]interface{}, key string) (string, error) {

--- a/clusterloader2/testing/load/config.yaml
+++ b/clusterloader2/testing/load/config.yaml
@@ -50,6 +50,9 @@
 # Probe measurements shared parameter
 {{$PROBE_MEASUREMENTS_CHECK_PROBES_READY_TIMEOUT := DefaultParam .CL2_PROBE_MEASUREMENTS_CHECK_PROBES_READY_TIMEOUT "5m"}}
 
+# Command to be executed
+{{$EXEC_COMMAND := DefaultParam .CL2_EXEC_COMMAND nil}}
+
 name: load
 namespace:
   number: {{$namespaces}}
@@ -339,6 +342,18 @@ steps:
     Method: WaitForControlledPodsRunning
     Params:
       action: gather
+
+{{if $EXEC_COMMAND}}
+- name: Exec command
+  measurements:
+  - Identifier: ExecCommand
+    Method: Exec
+    Params:
+      command:
+      {{range $EXEC_COMMAND}}
+      - {{.}}
+      {{end}}
+{{end}}
 
 - name: Scaling and updating objects
   phases:


### PR DESCRIPTION
This can be used to e.g. test cluster-wide operations like rolling update or dumping some debug info.

/assign @wojtek-t 