### PR TITLE
consolidate provider related logic into a single place

### DIFF
--- a/clusterloader2/pkg/provider/aks.go
+++ b/clusterloader2/pkg/provider/aks.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provider
+
+type AKSProvider struct {
+	features Features
+}
+
+func NewAKSProvider(_ map[string]string) Provider {
+	return &AKSProvider{
+		features: Features{
+			SupportProbe:                        true,
+			SupportImagePreload:                 true,
+			SupportGrabMetricsFromKubelets:      true,
+			ShouldPrometheusScrapeApiserverOnly: true,
+		},
+	}
+}
+
+func (p *AKSProvider) Name() string {
+	return AKSName
+}
+
+func (p *AKSProvider) Features() *Features {
+	return &p.features
+}
+
+func (p *AKSProvider) GetComponentProtocolAndPort(componentName string) (string, int, error) {
+	return getComponentProtocolAndPort(componentName)
+}
+
+func (p *AKSProvider) GetConfig() Config {
+	return Config{}
+}
+
+func (p *AKSProvider) RunSSHCommand(cmd, host string) (string, string, int, error) {
+	return runSSHCommand(cmd, host)
+}

--- a/clusterloader2/pkg/provider/aws.go
+++ b/clusterloader2/pkg/provider/aws.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provider
+
+import (
+	sshutil "k8s.io/kubernetes/pkg/ssh"
+)
+
+type AWSProvider struct {
+	features Features
+}
+
+func NewAWSProvider(_ map[string]string) Provider {
+	return &AWSProvider{
+		features: Features{
+			SupportProbe:                        true,
+			SupportImagePreload:                 true,
+			SupportSSHToMaster:                  true,
+			SupportEnablePrometheusServer:       true,
+			SupportGrabMetricsFromKubelets:      true,
+			SupportAccessAPIServerPprofEndpoint: true,
+		},
+	}
+}
+
+func (p *AWSProvider) Name() string {
+	return AWSName
+}
+
+func (p *AWSProvider) Features() *Features {
+	return &p.features
+}
+
+func (p *AWSProvider) GetComponentProtocolAndPort(componentName string) (string, int, error) {
+	return getComponentProtocolAndPort(componentName)
+}
+
+func (p *AWSProvider) GetConfig() Config {
+	return Config{}
+}
+
+func (p *AWSProvider) RunSSHCommand(cmd, host string) (string, string, int, error) {
+	signer, err := sshSignerFromKeyFile("AWS_SSH_KEY", "kube_aws_rsa")
+	if err != nil {
+		return "", "", 0, err
+	}
+	user := defaultSSHUser()
+	return sshutil.RunSSHCommand(cmd, user, host, signer)
+}

--- a/clusterloader2/pkg/provider/constants.go
+++ b/clusterloader2/pkg/provider/constants.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provider
+
+const (
+	AKSName      = "aks"
+	AWSName      = "aws"
+	EKSName      = "eks"
+	GCEName      = "gce"
+	GKEName      = "gke"
+	KubemarkName = "kubemark"
+	LocalName    = "local"
+	SkeletonName = "skeleton"
+	VsphereName  = "vsphere"
+)
+
+const (
+	RootKubeConfigKey = "ROOT_KUBECONFIG"
+)

--- a/clusterloader2/pkg/provider/eks.go
+++ b/clusterloader2/pkg/provider/eks.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provider
+
+import (
+	sshutil "k8s.io/kubernetes/pkg/ssh"
+)
+
+type EKSProvider struct {
+	features Features
+}
+
+func NewEKSProvider(_ map[string]string) Provider {
+	return &EKSProvider{
+		features: Features{
+			SupportProbe:                        true,
+			SupportImagePreload:                 true,
+			SupportEnablePrometheusServer:       true,
+			SupportGrabMetricsFromKubelets:      true,
+			SupportAccessAPIServerPprofEndpoint: true,
+		},
+	}
+}
+
+func (p *EKSProvider) Name() string {
+	return EKSName
+}
+
+func (p *EKSProvider) Features() *Features {
+	return &p.features
+}
+
+func (p *EKSProvider) GetComponentProtocolAndPort(componentName string) (string, int, error) {
+	return getComponentProtocolAndPort(componentName)
+}
+
+func (p *EKSProvider) GetConfig() Config {
+	return Config{}
+}
+
+func (p *EKSProvider) RunSSHCommand(cmd, host string) (string, string, int, error) {
+	signer, err := sshSignerFromKeyFile("AWS_SSH_KEY", "kube_aws_rsa")
+	if err != nil {
+		return "", "", 0, err
+	}
+	user := defaultSSHUser()
+	return sshutil.RunSSHCommand(cmd, user, host, signer)
+}

--- a/clusterloader2/pkg/provider/gce.go
+++ b/clusterloader2/pkg/provider/gce.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provider
+
+import (
+	sshutil "k8s.io/kubernetes/pkg/ssh"
+)
+
+type GCEProvider struct {
+	features Features
+}
+
+func NewGCEProvider(_ map[string]string) Provider {
+	return &GCEProvider{
+		features: Features{
+			SupportWindowsNodeScraping:          true,
+			SupportProbe:                        true,
+			SupportSSHToMaster:                  true,
+			SupportImagePreload:                 true,
+			SupportSnapshotPrometheusDisk:       true,
+			SupportNodeKiller:                   true,
+			SupportEnablePrometheusServer:       true,
+			SupportGrabMetricsFromKubelets:      true,
+			SupportAccessAPIServerPprofEndpoint: true,
+		},
+	}
+}
+
+func (p *GCEProvider) Name() string {
+	return GCEName
+}
+
+func (p *GCEProvider) Features() *Features {
+	return &p.features
+}
+
+func (p *GCEProvider) GetComponentProtocolAndPort(componentName string) (string, int, error) {
+	return getComponentProtocolAndPort(componentName)
+}
+
+func (p *GCEProvider) GetConfig() Config {
+	return Config{}
+}
+
+func (p *GCEProvider) RunSSHCommand(cmd, host string) (string, string, int, error) {
+	signer, err := sshSignerFromKeyFile("GCE_SSH_KEY", "google_compute_engine")
+	if err != nil {
+		return "", "", 0, err
+	}
+	user := defaultSSHUser()
+	return sshutil.RunSSHCommand(cmd, user, host, signer)
+}

--- a/clusterloader2/pkg/provider/gke.go
+++ b/clusterloader2/pkg/provider/gke.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provider
+
+import (
+	sshutil "k8s.io/kubernetes/pkg/ssh"
+)
+
+type GKEProvider struct {
+	features Features
+}
+
+func NewGKEProvider(_ map[string]string) Provider {
+	return &GKEProvider{
+		features: Features{
+			SupportProbe:                        true,
+			SupportImagePreload:                 true,
+			SupportSnapshotPrometheusDisk:       true,
+			SupportEnablePrometheusServer:       true,
+			SupportGrabMetricsFromKubelets:      true,
+			SupportAccessAPIServerPprofEndpoint: true,
+			SupportNodeKiller:                   true,
+			ShouldPrometheusScrapeApiserverOnly: true,
+		},
+	}
+}
+
+func (p *GKEProvider) Name() string {
+	return GKEName
+}
+
+func (p *GKEProvider) Features() *Features {
+	return &p.features
+}
+
+func (p *GKEProvider) GetComponentProtocolAndPort(componentName string) (string, int, error) {
+	return getComponentProtocolAndPort(componentName)
+}
+
+func (p *GKEProvider) GetConfig() Config {
+	return Config{}
+}
+
+func (p *GKEProvider) RunSSHCommand(cmd, host string) (string, string, int, error) {
+	signer, err := sshSignerFromKeyFile("GCE_SSH_KEY", "google_compute_engine")
+	if err != nil {
+		return "", "", 0, err
+	}
+	user := defaultSSHUser()
+	return sshutil.RunSSHCommand(cmd, user, host, signer)
+}

--- a/clusterloader2/pkg/provider/kubemark.go
+++ b/clusterloader2/pkg/provider/kubemark.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provider
+
+import (
+	"k8s.io/klog"
+	sshutil "k8s.io/kubernetes/pkg/ssh"
+)
+
+type KubemarkProvider struct {
+	features Features
+	config   Config
+}
+
+func NewKubemarkProvider(config map[string]string) *KubemarkProvider {
+	supportEnablePrometheusServer := true
+	if config[RootKubeConfigKey] == "" {
+		klog.Warningf("no kubemark-root-kubeconfig path specified. SupportEnablePrometheusServer will be false.")
+		supportEnablePrometheusServer = false
+	}
+	return &KubemarkProvider{
+		features: Features{
+			SupportSSHToMaster:                  true,
+			SupportEnablePrometheusServer:       supportEnablePrometheusServer,
+			SupportAccessAPIServerPprofEndpoint: true,
+			SupportSnapshotPrometheusDisk:       true,
+		},
+		config: config,
+	}
+}
+
+func (p *KubemarkProvider) Name() string {
+	return KubemarkName
+}
+
+func (p *KubemarkProvider) Features() *Features {
+	return &p.features
+}
+
+func (p *KubemarkProvider) GetComponentProtocolAndPort(componentName string) (string, int, error) {
+	return getComponentProtocolAndPort(componentName)
+}
+
+func (p *KubemarkProvider) GetConfig() Config {
+	return p.config
+}
+
+func (p *KubemarkProvider) RunSSHCommand(cmd, host string) (string, string, int, error) {
+	signer, err := sshSignerFromKeyFile("KUBEMARK_SSH_KEY", "google_compute_engine")
+	if err != nil {
+		return "", "", 0, err
+	}
+	user := defaultSSHUser()
+	return sshutil.RunSSHCommand(cmd, user, host, signer)
+}

--- a/clusterloader2/pkg/provider/local.go
+++ b/clusterloader2/pkg/provider/local.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provider
+
+import (
+	sshutil "k8s.io/kubernetes/pkg/ssh"
+)
+
+type LocalProvider struct {
+	features Features
+}
+
+func NewLocalProvider(_ map[string]string) Provider {
+	return &LocalProvider{
+		features: Features{
+			SupportProbe:                        true,
+			SupportSSHToMaster:                  true,
+			SupportImagePreload:                 true,
+			SupportEnablePrometheusServer:       true,
+			SupportGrabMetricsFromKubelets:      true,
+			SupportAccessAPIServerPprofEndpoint: true,
+		},
+	}
+}
+
+func (p *LocalProvider) Name() string {
+	return LocalName
+}
+
+func (p *LocalProvider) Features() *Features {
+	return &p.features
+}
+
+func (p *LocalProvider) GetComponentProtocolAndPort(componentName string) (string, int, error) {
+	return getComponentProtocolAndPort(componentName)
+}
+
+func (p *LocalProvider) GetConfig() Config {
+	return Config{}
+}
+
+func (p *LocalProvider) RunSSHCommand(cmd, host string) (string, string, int, error) {
+	signer, err := sshSignerFromKeyFile("LOCAL_SSH_KEY", "id_rsa")
+	if err != nil {
+		return "", "", 0, err
+	}
+	user := defaultSSHUser()
+	return sshutil.RunSSHCommand(cmd, user, host, signer)
+}

--- a/clusterloader2/pkg/provider/provider.go
+++ b/clusterloader2/pkg/provider/provider.go
@@ -1,0 +1,122 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provider
+
+import (
+	"fmt"
+	"strings"
+)
+
+// InitOptions encapsulates the fields needed to init provider.
+type InitOptions struct {
+	// TODO(#1361) remove this and use providerConfigs.
+	KubemarkRootKubeConfigPath string
+	ProviderName               string
+	ProviderConfigs            []string
+}
+
+// Features represents all features supported by this provider.
+type Features struct {
+	// SupportWindowsNodeScraping determines wheter scraping windows node in supported.
+	SupportWindowsNodeScraping bool
+	// SupportProbe determines whether probe is supported.
+	SupportProbe bool
+	// SupportImagePreload determines whether image preloading is supported.
+	SupportImagePreload bool
+	// SupportEnablePrometheusServer determines whether enabling prometheus server is possible.
+	SupportEnablePrometheusServer bool
+	// SupportSSHToMaster determines whether SSH access to master machines is possible.
+	// If false (impossible for many  providers), ClusterLoader will skip operations requiring it.
+	SupportSSHToMaster bool
+	// SupportAccessAPIServerPprofEndpoint determines whether accessing api server pprof endpoint is possible.
+	SupportAccessAPIServerPprofEndpoint bool
+	// SupportSnapshotPrometheusDisk determines whether snapshot prometheus disk is supported.
+	SupportSnapshotPrometheusDisk bool
+	// SupportNodeKiller determines whether node killer is supported.
+	SupportNodeKiller bool
+	// SupportGrabMetricsFromKubelets determines whether getting metrics from kubelet is supported.
+	SupportGrabMetricsFromKubelets bool
+
+	// ShouldPrometheusScrapeApiserverOnly determines if we should set PROMETHEUS_SCRAPE_APISERVER_ONLY by default.
+	ShouldPrometheusScrapeApiserverOnly bool
+}
+
+// Config is the config of the provider.
+type Config map[string]string
+
+// RootFrameworkKubeConfigOverride returns the KubeConfig override for Root Framewor.
+func (c Config) RootFrameworkKubeConfigOverride() string {
+	return c[RootKubeConfigKey]
+}
+
+// Provider is the interface for
+type Provider interface {
+	// Name returns name of this provider. It should used only in logs.
+	Name() string
+	// Features returns the feature supported by this provider.
+	Features() *Features
+
+	GetConfig() Config
+
+	// GetComponentProtocolAndPort returns the protocol and port for the control plane components.
+	GetComponentProtocolAndPort(componentName string) (string, int, error)
+
+	RunSSHCommand(cmd, host string) (string, string, int, error)
+}
+
+// NewProvider creates a new provider from init options. It will return an error if provider name is not supported.
+func NewProvider(initOptions *InitOptions) (Provider, error) {
+	configs := parseConfigs(initOptions.ProviderConfigs)
+	if initOptions.KubemarkRootKubeConfigPath != "" {
+		configs[RootKubeConfigKey] = initOptions.KubemarkRootKubeConfigPath
+	}
+	switch initOptions.ProviderName {
+	case AKSName:
+		return NewAKSProvider(configs), nil
+	case AWSName:
+		return NewAWSProvider(configs), nil
+	case EKSName:
+		return NewEKSProvider(configs), nil
+	case GCEName:
+		return NewGCEProvider(configs), nil
+	case GKEName:
+		return NewGKEProvider(configs), nil
+	case KubemarkName:
+		return NewKubemarkProvider(configs), nil
+	case LocalName:
+		return NewLocalProvider(configs), nil
+	case SkeletonName:
+		return NewSkeletonProvider(configs), nil
+	case VsphereName:
+		return NewVsphereProvider(configs), nil
+	default:
+		return nil, fmt.Errorf("unsupported provider name: %s", initOptions.ProviderName)
+	}
+}
+
+func parseConfigs(configs []string) map[string]string {
+	cfgMap := map[string]string{}
+
+	for _, c := range configs {
+		pair := strings.Split(c, "=")
+		if len(pair) != 2 {
+			fmt.Println("error: unused provider config:", c)
+		}
+		cfgMap[pair[0]] = pair[1]
+	}
+	return cfgMap
+}

--- a/clusterloader2/pkg/provider/skeleton.go
+++ b/clusterloader2/pkg/provider/skeleton.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provider
+
+import (
+	sshutil "k8s.io/kubernetes/pkg/ssh"
+)
+
+type SkeletonProvider struct {
+	features Features
+}
+
+func NewSkeletonProvider(_ map[string]string) Provider {
+	return &SkeletonProvider{
+		features: Features{
+			SupportProbe:                        true,
+			SupportSSHToMaster:                  true,
+			SupportImagePreload:                 true,
+			SupportEnablePrometheusServer:       true,
+			SupportGrabMetricsFromKubelets:      true,
+			SupportAccessAPIServerPprofEndpoint: true,
+		},
+	}
+}
+
+func (p *SkeletonProvider) Name() string {
+	return SkeletonName
+}
+
+func (p *SkeletonProvider) Features() *Features {
+	return &p.features
+}
+
+func (p *SkeletonProvider) GetComponentProtocolAndPort(componentName string) (string, int, error) {
+	return getComponentProtocolAndPort(componentName)
+}
+
+func (p *SkeletonProvider) GetConfig() Config {
+	return Config{}
+}
+
+func (p *SkeletonProvider) GetRootFrameworkKubeConfigOverride() string {
+	return ""
+}
+
+func (p *SkeletonProvider) RunSSHCommand(cmd, host string) (string, string, int, error) {
+	signer, err := sshSignerFromKeyFile("KUBE_SSH_KEY", "id_rsa")
+	if err != nil {
+		return "", "", 0, err
+	}
+	user := defaultSSHUser()
+	return sshutil.RunSSHCommand(cmd, user, host, signer)
+}

--- a/clusterloader2/pkg/provider/util.go
+++ b/clusterloader2/pkg/provider/util.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provider
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"golang.org/x/crypto/ssh"
+	sshutil "k8s.io/kubernetes/pkg/ssh"
+)
+
+func getComponentProtocolAndPort(componentName string) (string, int, error) {
+	switch componentName {
+	case "etcd":
+		return "https://", 2379, nil
+	case "kube-apiserver":
+		return "https://", 443, nil
+	case "kube-controller-manager":
+		return "http://", 10252, nil
+	case "kube-scheduler":
+		return "http://", 10251, nil
+	}
+	return "", -1, fmt.Errorf("port for component %v unknown", componentName)
+}
+
+func runSSHCommand(cmd, host string) (string, string, int, error) {
+	signer, err := defaultSSHSigner()
+	if err != nil {
+		return "", "", 0, err
+	}
+	if signer == nil {
+		return "", "", 0, fmt.Errorf("Cannot find sshkey")
+	}
+
+	user := defaultSSHUser()
+	return sshutil.RunSSHCommand(cmd, user, host, signer)
+}
+
+func defaultSSHUser() string {
+	// RunSSHCommand will default to Getenv("USER") if user == "", but we're
+	// defaulting here as well for logging clarity.
+	user := os.Getenv("KUBE_SSH_USER")
+	if user == "" {
+		user = os.Getenv("USER")
+	}
+	return user
+}
+
+func defaultSSHSigner() (ssh.Signer, error) {
+	if path := os.Getenv("KUBE_SSH_KEY_PATH"); len(path) > 0 {
+		return sshutil.MakePrivateKeySignerFromFile(path)
+	}
+	return nil, nil
+}
+
+func sshSignerFromKeyFile(KeyPathEnv string, defaultKeyPath string) (ssh.Signer, error) {
+	// honor a consistent SSH key across all providers
+	signer, err := defaultSSHSigner()
+	if signer != nil || err != nil {
+		return signer, err
+	}
+
+	keyfile := os.Getenv(KeyPathEnv)
+	if keyfile == "" {
+		keyfile = defaultKeyPath
+	}
+
+	// Respect absolute paths for keys given by user, fallback to assuming
+	// relative paths are in ~/.ssh
+	if !filepath.IsAbs(keyfile) {
+		keydir := filepath.Join(os.Getenv("HOME"), ".ssh")
+		keyfile = filepath.Join(keydir, keyfile)
+	}
+
+	if keyfile == "" {
+		return nil, fmt.Errorf("Cannot find ssh key file")
+	}
+
+	return sshutil.MakePrivateKeySignerFromFile(keyfile)
+}

--- a/clusterloader2/pkg/provider/vsphere.go
+++ b/clusterloader2/pkg/provider/vsphere.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provider
+
+import (
+	sshutil "k8s.io/kubernetes/pkg/ssh"
+)
+
+type VsphereProvider struct {
+	features Features
+}
+
+func NewVsphereProvider(_ map[string]string) Provider {
+	return &VsphereProvider{
+		features: Features{
+			SupportProbe:                        true,
+			SupportSSHToMaster:                  true,
+			SupportImagePreload:                 true,
+			SupportEnablePrometheusServer:       true,
+			SupportGrabMetricsFromKubelets:      true,
+			SupportAccessAPIServerPprofEndpoint: true,
+		},
+	}
+}
+
+func (p *VsphereProvider) Name() string {
+	return VsphereName
+}
+
+func (p *VsphereProvider) Features() *Features {
+	return &p.features
+}
+
+func (p *VsphereProvider) GetComponentProtocolAndPort(componentName string) (string, int, error) {
+	return getComponentProtocolAndPort(componentName)
+}
+
+func (p *VsphereProvider) GetConfig() Config {
+	return Config{}
+}
+
+func (p *VsphereProvider) RunSSHCommand(cmd, host string) (string, string, int, error) {
+	signer, err := sshSignerFromKeyFile("KUBE_SSH_KEY", "id_rsa")
+	if err != nil {
+		return "", "", 0, err
+	}
+	user := defaultSSHUser()
+	return sshutil.RunSSHCommand(cmd, user, host, signer)
+}


### PR DESCRIPTION
Ref https://github.com/kubernetes/perf-tests/issues/238

Provider specific logic has been scattered around the code. Making it
hard to support a new provider. This change moves provider related code
into provider pacakge. Other packages should depend on provider
interface rather than provider name.