### PR TITLE
Start DnsLookupLatency measurement despite timing out

### DIFF
--- a/clusterloader2/pkg/measurement/common/probes/probes.go
+++ b/clusterloader2/pkg/measurement/common/probes/probes.go
@@ -173,6 +173,13 @@ func (p *probesMeasurement) start(config *measurement.Config) error {
 		return err
 	}
 	if err := p.waitForProbesReady(config); err != nil {
+		if err.Error() == wait.ErrWaitTimeout.Error() {
+			// Start the measurement nonetheless as timing out during waiting for
+			// probe pods to be ready is almost always because of a small fraction
+			// of pods not visible via Prometheus.
+			p.startTime = time.Now()
+			return fmt.Errorf("%w (most probable reason: not all probe pods are visible via Prometheus)", err)
+		}
 		return err
 	}
 	p.startTime = time.Now()


### PR DESCRIPTION
Scale tests flake from time to time because of timing out during starting prober pods in `DnsLookupLatency` measurement, as mentioned in https://github.com/kubernetes/kubernetes/issues/87143#issuecomment-573746949. This PR will start the measurement in such scenarios and make `DnsLookupLatency` measurement `gather` step not report a second error (`measurement call DnsLookupLatency - DnsLookupLatency error: measurement DnsLookupLatency has not been started`).

/sig scalability
/cc jkaniuk
/cc wojtek-t
/cc mm4tt