### PR TITLE
use provider across clusterloader2.

### DIFF
--- a/clusterloader2/pkg/chaos/monkey.go
+++ b/clusterloader2/pkg/chaos/monkey.go
@@ -23,17 +23,18 @@ import (
 
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/perf-tests/clusterloader2/api"
+	"k8s.io/perf-tests/clusterloader2/pkg/provider"
 )
 
 // Monkey simulates kubernetes component failures
 type Monkey struct {
 	client     clientset.Interface
-	provider   string
+	provider   provider.Provider
 	nodeKiller *NodeKiller
 }
 
 // NewMonkey constructs a new Monkey object.
-func NewMonkey(client clientset.Interface, provider string) *Monkey {
+func NewMonkey(client clientset.Interface, provider provider.Provider) *Monkey {
 	return &Monkey{client: client, provider: provider}
 }
 

--- a/clusterloader2/pkg/config/cluster.go
+++ b/clusterloader2/pkg/config/cluster.go
@@ -18,6 +18,7 @@ package config
 
 import (
 	"k8s.io/perf-tests/clusterloader2/api"
+	"k8s.io/perf-tests/clusterloader2/pkg/provider"
 )
 
 // ClusterLoaderConfig represents all single test run parameters used by CLusterLoader.
@@ -32,24 +33,20 @@ type ClusterLoaderConfig struct {
 
 // ClusterConfig is a structure that represents cluster description.
 type ClusterConfig struct {
-	KubeConfigPath             string
-	RunFromCluster             bool
-	Nodes                      int
-	Provider                   string
-	EtcdCertificatePath        string
-	EtcdKeyPath                string
-	EtcdInsecurePort           int
-	MasterIPs                  []string
-	MasterInternalIPs          []string
-	MasterName                 string
-	KubemarkRootKubeConfigPath string
+	KubeConfigPath      string
+	RunFromCluster      bool
+	Nodes               int
+	Provider            provider.Provider
+	EtcdCertificatePath string
+	EtcdKeyPath         string
+	EtcdInsecurePort    int
+	MasterIPs           []string
+	MasterInternalIPs   []string
+	MasterName          string
 	// Deprecated: use NamespaceConfig.DeleteStaleNamespaces instead.
 	DeleteStaleNamespaces bool
 	// Deprecated: use NamespaceConfig.DeleteAutomanagedNamespaces instead.
 	DeleteAutomanagedNamespaces bool
-	// SSHToMasterSupported determines whether SSH access to master machines is possible.
-	// If false (impossible for many  providers), ClusterLoader will skip operations requiring it.
-	SSHToMasterSupported bool
 	// APIServerPprofByClientEnabled determines whether kube-apiserver pprof endpoint can be accessed
 	// using kubernetes client. If false, clusterloader will avoid collecting kube-apiserver profiles.
 	APIServerPprofByClientEnabled bool

--- a/clusterloader2/pkg/framework/framework.go
+++ b/clusterloader2/pkg/framework/framework.go
@@ -55,8 +55,8 @@ func NewFramework(clusterConfig *config.ClusterConfig, clientsNumber int) (*Fram
 // For clusters other than kubemark there is no difference between NewRootFramework and NewFramework.
 func NewRootFramework(clusterConfig *config.ClusterConfig, clientsNumber int) (*Framework, error) {
 	kubeConfigPath := clusterConfig.KubeConfigPath
-	if clusterConfig.Provider == "kubemark" {
-		kubeConfigPath = clusterConfig.KubemarkRootKubeConfigPath
+	if override := clusterConfig.Provider.GetConfig().RootFrameworkKubeConfigOverride(); override != "" {
+		kubeConfigPath = override
 	}
 	return newFramework(clusterConfig, clientsNumber, kubeConfigPath)
 }

--- a/clusterloader2/pkg/imagepreload/imagepreload.go
+++ b/clusterloader2/pkg/imagepreload/imagepreload.go
@@ -86,8 +86,8 @@ func (c *controller) PreloadImages() error {
 		klog.Warning("No images specified. Skipping image preloading")
 		return nil
 	}
-	if c.config.ClusterConfig.Provider == "kubemark" {
-		klog.Warning("Image preloading is disabled in kubemark")
+	if !c.config.ClusterConfig.Provider.Features().SupportImagePreload {
+		klog.Warningf("Image preloading is disabled in provider: %s", c.config.ClusterConfig.Provider.Name())
 		return nil
 	}
 

--- a/clusterloader2/pkg/measurement/common/metrics_for_e2e.go
+++ b/clusterloader2/pkg/measurement/common/metrics_for_e2e.go
@@ -18,7 +18,6 @@ package common
 
 import (
 	"fmt"
-	"strings"
 
 	"k8s.io/klog"
 	"k8s.io/kubernetes/test/e2e/framework/metrics"
@@ -55,16 +54,13 @@ type metricsForE2EMeasurement struct{}
 
 // Execute gathers and prints e2e metrics data.
 func (m *metricsForE2EMeasurement) Execute(config *measurement.Config) ([]measurement.Summary, error) {
-	provider, err := util.GetStringOrDefault(config.Params, "provider", config.ClusterFramework.GetClusterConfig().Provider)
-	if err != nil {
-		return nil, err
-	}
+	provider := config.ClusterFramework.GetClusterConfig().Provider
 
 	grabMetricsFromKubelets, err := util.GetBoolOrDefault(config.Params, "gatherKubeletsMetrics", false)
 	if err != nil {
 		return nil, err
 	}
-	grabMetricsFromKubelets = grabMetricsFromKubelets && strings.ToLower(provider) != "kubemark"
+	grabMetricsFromKubelets = grabMetricsFromKubelets && provider.Features().SupportGrabMetricsFromKubelets
 
 	grabber, err := metrics.NewMetricsGrabber(
 		config.ClusterFramework.GetClientSets().GetClient(),

--- a/clusterloader2/pkg/measurement/common/probes/probes.go
+++ b/clusterloader2/pkg/measurement/common/probes/probes.go
@@ -98,8 +98,8 @@ type probesMeasurement struct {
 // - start - starts probes and sets up monitoring
 // - gather - Gathers and prints metrics.
 func (p *probesMeasurement) Execute(config *measurement.Config) ([]measurement.Summary, error) {
-	if config.CloudProvider == "kubemark" {
-		klog.Infof("%s: Probes cannot work in Kubemark, skipping the measurement!", p)
+	if !config.CloudProvider.Features().SupportProbe {
+		klog.Infof("%s: Probes cannot work in %s, skipping the measurement!", p, config.CloudProvider.Name())
 		return nil, nil
 	}
 	if config.PrometheusFramework == nil {

--- a/clusterloader2/pkg/measurement/common/resource_usage.go
+++ b/clusterloader2/pkg/measurement/common/resource_usage.go
@@ -62,10 +62,7 @@ func (e *resourceUsageMetricMeasurement) Execute(config *measurement.Config) ([]
 
 	switch action {
 	case "start":
-		provider, err := util.GetStringOrDefault(config.Params, "provider", config.ClusterFramework.GetClusterConfig().Provider)
-		if err != nil {
-			return nil, err
-		}
+		provider := config.ClusterFramework.GetClusterConfig().Provider
 		host, err := util.GetStringOrDefault(config.Params, "host", config.ClusterFramework.GetClusterConfig().GetMasterIP())
 		if err != nil {
 			return nil, err
@@ -112,7 +109,7 @@ func (e *resourceUsageMetricMeasurement) Execute(config *measurement.Config) ([]
 		klog.Infof("%s: starting resource usage collecting...", e)
 		e.gatherer, err = gatherers.NewResourceUsageGatherer(config.ClusterFramework.GetClientSets().GetClient(), host, config.ClusterFramework.GetClusterConfig().KubeletPort,
 			provider, gatherers.ResourceGathererOptions{
-				InKubemark:                        strings.ToLower(provider) == "kubemark",
+				InKubemark:                        provider.Name() == "kubemark",
 				Nodes:                             nodesSet,
 				ResourceDataGatheringPeriod:       60 * time.Second,
 				MasterResourceDataGatheringPeriod: 10 * time.Second,

--- a/clusterloader2/pkg/measurement/common/slos/network_programming.go
+++ b/clusterloader2/pkg/measurement/common/slos/network_programming.go
@@ -52,7 +52,8 @@ func (n *netProgGatherer) IsEnabled(config *measurement.Config) bool {
 	if !config.ClusterLoaderConfig.PrometheusConfig.ScrapeKubeProxy {
 		return false
 	}
-	return config.CloudProvider != "kubemark"
+	// TODO(#1399): remove the dependency of provider name.
+	return config.CloudProvider.Name() != "kubemark"
 }
 
 func (n *netProgGatherer) Gather(executor QueryExecutor, startTime time.Time, config *measurement.Config) ([]measurement.Summary, error) {

--- a/clusterloader2/pkg/measurement/interface.go
+++ b/clusterloader2/pkg/measurement/interface.go
@@ -21,6 +21,7 @@ import (
 
 	"k8s.io/perf-tests/clusterloader2/pkg/config"
 	"k8s.io/perf-tests/clusterloader2/pkg/framework"
+	"k8s.io/perf-tests/clusterloader2/pkg/provider"
 )
 
 // Config provides client and parameters required for the measurement execution.
@@ -38,7 +39,7 @@ type Config struct {
 
 	// Identifier identifies this instance of measurement.
 	Identifier    string
-	CloudProvider string
+	CloudProvider provider.Provider
 }
 
 // Measurement is an common interface for all measurements methods. It should be implemented by the user to

--- a/clusterloader2/pkg/measurement/util/gatherers/container_resource_gatherer.go
+++ b/clusterloader2/pkg/measurement/util/gatherers/container_resource_gatherer.go
@@ -30,6 +30,7 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/klog"
 	"k8s.io/perf-tests/clusterloader2/pkg/measurement/util"
+	"k8s.io/perf-tests/clusterloader2/pkg/provider"
 	pkgutil "k8s.io/perf-tests/clusterloader2/pkg/util"
 )
 
@@ -84,7 +85,7 @@ func isDaemonPod(pod *corev1.Pod) bool {
 }
 
 // NewResourceUsageGatherer creates new instance of ContainerResourceGatherer
-func NewResourceUsageGatherer(c clientset.Interface, host string, port int, provider string, options ResourceGathererOptions, namespace string) (*ContainerResourceGatherer, error) {
+func NewResourceUsageGatherer(c clientset.Interface, host string, port int, provider provider.Provider, options ResourceGathererOptions, namespace string) (*ContainerResourceGatherer, error) {
 	g := ContainerResourceGatherer{
 		client:       c,
 		isRunning:    true,

--- a/clusterloader2/pkg/measurement/util/gatherers/resource_gather_worker.go
+++ b/clusterloader2/pkg/measurement/util/gatherers/resource_gather_worker.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/perf-tests/clusterloader2/pkg/measurement/util"
 	"k8s.io/perf-tests/clusterloader2/pkg/measurement/util/kubelet"
 	"k8s.io/perf-tests/clusterloader2/pkg/measurement/util/kubemark"
+	"k8s.io/perf-tests/clusterloader2/pkg/provider"
 )
 
 type resourceGatherWorker struct {
@@ -40,7 +41,7 @@ type resourceGatherWorker struct {
 	resourceDataGatheringPeriod time.Duration
 	host                        string
 	port                        int
-	provider                    string
+	provider                    provider.Provider
 }
 
 func (w *resourceGatherWorker) singleProbe() {

--- a/clusterloader2/pkg/measurement/util/kubemark/kubemark.go
+++ b/clusterloader2/pkg/measurement/util/kubemark/kubemark.go
@@ -23,6 +23,7 @@ import (
 
 	"k8s.io/klog"
 	"k8s.io/perf-tests/clusterloader2/pkg/measurement/util"
+	"k8s.io/perf-tests/clusterloader2/pkg/provider"
 )
 
 // ResourceUsage represents resources used by the kubemark.
@@ -32,7 +33,7 @@ type ResourceUsage struct {
 	CPUUsageInCores         float64
 }
 
-func getMasterUsageByPrefix(host, provider, prefix string) (string, error) {
+func getMasterUsageByPrefix(host string, provider provider.Provider, prefix string) (string, error) {
 	sshResult, err := util.SSH(fmt.Sprintf("ps ax -o %%cpu,rss,command | tail -n +2 | grep %v | sed 's/\\s+/ /g'", prefix), host+":22", provider)
 	if err != nil {
 		return "", err
@@ -42,7 +43,7 @@ func getMasterUsageByPrefix(host, provider, prefix string) (string, error) {
 
 // GetKubemarkMasterComponentsResourceUsage returns resource usage of the kubemark components.
 // TODO: figure out how to move this to kubemark directory (need to factor test SSH out of e2e framework)
-func GetKubemarkMasterComponentsResourceUsage(host, provider string) map[string]*ResourceUsage {
+func GetKubemarkMasterComponentsResourceUsage(host string, provider provider.Provider) map[string]*ResourceUsage {
 	result := make(map[string]*ResourceUsage)
 	// Get kubernetes component resource usage
 	sshResult, err := getMasterUsageByPrefix(host, provider, "kube")

--- a/clusterloader2/pkg/measurement/util/ssh.go
+++ b/clusterloader2/pkg/measurement/util/ssh.go
@@ -17,13 +17,8 @@ limitations under the License.
 package util
 
 import (
-	"fmt"
+	"k8s.io/perf-tests/clusterloader2/pkg/provider"
 	"net/url"
-	"os"
-	"path/filepath"
-
-	"golang.org/x/crypto/ssh"
-	sshutil "k8s.io/kubernetes/pkg/ssh"
 )
 
 // GetMasterHost turns host name (without prefix and port).
@@ -46,78 +41,12 @@ type SSHResult struct {
 }
 
 // SSH runs command on given host using ssh.
-func SSH(cmd, host, provider string) (SSHResult, error) {
+func SSH(cmd, host string, provider provider.Provider) (SSHResult, error) {
 	result := SSHResult{Host: host, Cmd: cmd}
-
-	// Get a signer for the provider.
-	signer, err := getSigner(provider)
-	if err != nil {
-		return result, fmt.Errorf("error getting signer for provider %s: '%v'", provider, err)
-	}
-
-	// RunSSHCommand will default to Getenv("USER") if user == "", but we're
-	// defaulting here as well for logging clarity.
-	result.User = os.Getenv("KUBE_SSH_USER")
-	if result.User == "" {
-		result.User = os.Getenv("USER")
-	}
-
-	stdout, stderr, code, err := sshutil.RunSSHCommand(cmd, result.User, host, signer)
+	stdout, stderr, code, err := provider.RunSSHCommand(cmd, host)
 	result.Stdout = stdout
 	result.Stderr = stderr
 	result.Code = code
 
 	return result, err
-}
-
-// getSigner returns an ssh.Signer for the provider ("gce", etc.) that can be
-// used to SSH to their nodes.
-func getSigner(provider string) (ssh.Signer, error) {
-	// honor a consistent SSH key across all providers
-	if path := os.Getenv("KUBE_SSH_KEY_PATH"); len(path) > 0 {
-		return sshutil.MakePrivateKeySignerFromFile(path)
-	}
-
-	// Select the key itself to use. When implementing more providers here,
-	// please also add them to any SSH tests that are disabled because of signer
-	// support.
-	keyfile := ""
-	switch provider {
-	case "gce", "gke":
-		keyfile = os.Getenv("GCE_SSH_KEY")
-		if keyfile == "" {
-			keyfile = "google_compute_engine"
-		}
-	case "kubemark":
-		keyfile = os.Getenv("KUBEMARK_SSH_KEY")
-		if keyfile == "" {
-			keyfile = "google_compute_engine"
-		}
-	case "aws", "eks":
-		keyfile := os.Getenv("AWS_SSH_KEY")
-		if keyfile == "" {
-			keyfile = "kube_aws_rsa"
-		}
-	case "local", "vsphere":
-		keyfile = os.Getenv("LOCAL_SSH_KEY")
-		if keyfile == "" {
-			keyfile = "id_rsa"
-		}
-	case "skeleton":
-		keyfile = os.Getenv("KUBE_SSH_KEY")
-		if keyfile == "" {
-			keyfile = "id_rsa"
-		}
-	default:
-		return nil, fmt.Errorf("GetSigner(...) not implemented for %s", provider)
-	}
-
-	// Respect absolute paths for keys given by user, fallback to assuming
-	// relative paths are in ~/.ssh
-	if !filepath.IsAbs(keyfile) {
-		keydir := filepath.Join(os.Getenv("HOME"), ".ssh")
-		keyfile = filepath.Join(keydir, keyfile)
-	}
-
-	return sshutil.MakePrivateKeySignerFromFile(keyfile)
 }

--- a/clusterloader2/pkg/prometheus/experimental.go
+++ b/clusterloader2/pkg/prometheus/experimental.go
@@ -50,9 +50,9 @@ func (pc *Controller) isEnabled() (bool, error) {
 	if !*shouldSnapshotPrometheusDisk {
 		return false, nil
 	}
-	if pc.provider != "gce" && pc.provider != "gke" && pc.provider != "kubemark" {
+	if !pc.provider.Features().SupportSnapshotPrometheusDisk {
 		return false, fmt.Errorf(
-			"snapshotting Prometheus' disk only available for GCP providers (gce, gke, kubemark), provider is: %s", pc.provider)
+			"snapshotting Prometheus' disk only available for GCP providers (gce, gke, kubemark), provider is: %s", pc.provider.Name())
 	}
 	return true, nil
 }

--- a/clusterloader2/pkg/prometheus/gce_windows_util.go
+++ b/clusterloader2/pkg/prometheus/gce_windows_util.go
@@ -53,7 +53,7 @@ func setUpWindowsNodeAndTemplate(k8sClient kubernetes.Interface, mapping map[str
 }
 
 func isWindowsNodeScrapingEnabled(mapping map[string]interface{}, clusterLoaderConfig *config.ClusterLoaderConfig) bool {
-	if windowsNodeTest, exists := mapping["WINDOWS_NODE_TEST"]; exists && windowsNodeTest.(bool) && clusterLoaderConfig.ClusterConfig.Provider == "gce" {
+	if windowsNodeTest, exists := mapping["WINDOWS_NODE_TEST"]; exists && windowsNodeTest.(bool) && clusterLoaderConfig.ClusterConfig.Provider.Features().SupportWindowsNodeScraping {
 		return true
 	}
 	return false


### PR DESCRIPTION
Provider specific logic has been scattered around the code. Making it
hard to support a new provider. This change moves provider related code
into provider pacakge. Other packages should depend on provider
interface rather than provider name.