### PR TITLE
Slow API calls - backport #1262, #1258, #1213, #1229 and #1209 (release-1.18)

### DIFF
--- a/clusterloader2/pkg/measurement/common/slos/api_responsiveness_prometheus.go
+++ b/clusterloader2/pkg/measurement/common/slos/api_responsiveness_prometheus.go
@@ -276,7 +276,7 @@ func (m *apiCallMetrics) sorted() []*apiCallMetric {
 		all = append(all, v)
 	}
 	sort.Slice(all, func(i, j int) bool {
-		return all[i].Latency.Perc99 < all[j].Latency.Perc99
+		return all[i].Latency.Perc99 > all[j].Latency.Perc99
 	})
 	return all
 }

--- a/clusterloader2/pkg/measurement/common/slos/api_responsiveness_prometheus.go
+++ b/clusterloader2/pkg/measurement/common/slos/api_responsiveness_prometheus.go
@@ -14,10 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-/*
-TODO(krzysied): This measurement should replace api_responsiveness.go.
-*/
-
 package slos
 
 import (
@@ -47,8 +43,7 @@ const (
 
 	currentAPICallMetricsVersion = "v1"
 
-	// TODO(krzysied): figure out why we're getting non-capitalized proxy and fix this
-	filters = `resource!="events", verb!~"WATCH|WATCHLIST|PROXY|proxy|CONNECT"`
+	filters = `resource!="events", verb!~"WATCH|WATCHLIST|PROXY|CONNECT"`
 
 	// latencyQuery matches description of the API call latency SLI and measure 99th percentaile over 5m windows
 	//
@@ -77,25 +72,18 @@ func init() {
 	}
 }
 
-type apiCall struct {
+type apiCallMetric struct {
 	Resource    string                        `json:"resource"`
 	Subresource string                        `json:"subresource"`
 	Verb        string                        `json:"verb"`
 	Scope       string                        `json:"scope"`
 	Latency     measurementutil.LatencyMetric `json:"latency"`
 	Count       int                           `json:"count"`
+	FailedCount int                           `json:"failedCount"`
 }
 
-type apiResponsiveness struct {
-	APICalls []apiCall `json:"apicalls"`
-}
-
-func (a *apiResponsiveness) Len() int { return len(a.APICalls) }
-func (a *apiResponsiveness) Swap(i, j int) {
-	a.APICalls[i], a.APICalls[j] = a.APICalls[j], a.APICalls[i]
-}
-func (a *apiResponsiveness) Less(i, j int) bool {
-	return a.APICalls[i].Latency.Perc99 < a.APICalls[j].Latency.Perc99
+type apiCallMetrics struct {
+	metrics map[string]*apiCallMetric
 }
 
 type apiResponsivenessGatherer struct{}
@@ -103,29 +91,24 @@ type apiResponsivenessGatherer struct{}
 func (a *apiResponsivenessGatherer) Gather(executor QueryExecutor, startTime time.Time, config *measurement.MeasurementConfig) (measurement.Summary, error) {
 	apiCalls, err := a.gatherAPICalls(executor, startTime, config)
 	if err != nil {
-		klog.Errorf("%s: samples gathering error: %v", config.Identifier, err)
 		return nil, err
 	}
 
-	metrics := &apiResponsiveness{APICalls: apiCalls}
-
-	badMetrics := validateAPICalls(config.Identifier, metrics)
-
-	content, err := util.PrettyPrintJSON(apiCallToPerfData(metrics))
+	content, err := util.PrettyPrintJSON(apiCalls.ToPerfData())
 	if err != nil {
 		return nil, err
 	}
-
-	summaryName, err := util.GetStringOrDefault(config.Params, "summaryName", apiResponsivenessPrometheusMeasurementName)
+	summaryName, err := util.GetStringOrDefault(config.Params, "summaryName", a.String())
 	if err != nil {
 		return nil, err
 	}
-
 	summary := measurement.CreateSummary(summaryName, "json", content)
+
+	badMetrics := a.validateAPICalls(config.Identifier, apiCalls)
 	if len(badMetrics) > 0 {
-		return summary, errors.NewMetricViolationError("top latency metric", fmt.Sprintf("there should be no high-latency requests, but: %v", badMetrics))
+		err = errors.NewMetricViolationError("top latency metric", fmt.Sprintf("there should be no high-latency requests, but: %v", badMetrics))
 	}
-	return summary, nil
+	return summary, err
 }
 
 func (a *apiResponsivenessGatherer) String() string {
@@ -136,7 +119,7 @@ func (a *apiResponsivenessGatherer) IsEnabled(config *measurement.MeasurementCon
 	return true
 }
 
-func (a *apiResponsivenessGatherer) gatherAPICalls(executor QueryExecutor, startTime time.Time, config *measurement.MeasurementConfig) ([]apiCall, error) {
+func (a *apiResponsivenessGatherer) gatherAPICalls(executor QueryExecutor, startTime time.Time, config *measurement.MeasurementConfig) (*apiCallMetrics, error) {
 	measurementEnd := time.Now()
 	measurementDuration := measurementEnd.Sub(startTime)
 
@@ -182,11 +165,32 @@ func (a *apiResponsivenessGatherer) gatherAPICalls(executor QueryExecutor, start
 	if err != nil {
 		return nil, err
 	}
-	return a.convertToAPICalls(latencySamples, countSamples)
+	return newFromSamples(latencySamples, countSamples)
 }
 
-func (a *apiResponsivenessGatherer) convertToAPICalls(latencySamples, countSamples []*model.Sample) ([]apiCall, error) {
-	apiCalls := make(map[string]*apiCall)
+func (a *apiResponsivenessGatherer) validateAPICalls(identifier string, metrics *apiCallMetrics) []error {
+	badMetrics := make([]error, 0)
+	top := topToPrint
+
+	for _, apiCall := range metrics.sorted() {
+		var err error
+		if err = apiCall.Validate(); err != nil {
+			badMetrics = append(badMetrics, err)
+		}
+		if top > 0 || err != nil {
+			top--
+			prefix := ""
+			if err != nil {
+				prefix = "WARNING "
+			}
+			klog.Infof("%s: %vTop latency metric: %v", identifier, prefix, apiCall)
+		}
+	}
+	return badMetrics
+}
+
+func newFromSamples(latencySamples, countSamples []*model.Sample) (*apiCallMetrics, error) {
+	m := &apiCallMetrics{metrics: make(map[string]*apiCallMetric)}
 
 	for _, sample := range latencySamples {
 		resource := string(sample.Metric["resource"])
@@ -199,7 +203,7 @@ func (a *apiResponsivenessGatherer) convertToAPICalls(latencySamples, countSampl
 		}
 
 		latency := time.Duration(float64(sample.Value) * float64(time.Second))
-		addLatency(apiCalls, resource, subresource, verb, scope, quantile, latency)
+		m.SetLatency(resource, subresource, verb, scope, quantile, latency)
 	}
 
 	for _, sample := range countSamples {
@@ -209,86 +213,43 @@ func (a *apiResponsivenessGatherer) convertToAPICalls(latencySamples, countSampl
 		scope := string(sample.Metric["scope"])
 
 		count := int(math.Round(float64(sample.Value)))
-		addCount(apiCalls, resource, subresource, verb, scope, count)
+		m.SetCount(resource, subresource, verb, scope, count)
 	}
 
-	var result []apiCall
-	for _, call := range apiCalls {
-		result = append(result, *call)
-	}
-	return result, nil
+	return m, nil
 }
 
-func getAPICall(apiCalls map[string]*apiCall, resource, subresource, verb, scope string) *apiCall {
-	key := getMetricKey(resource, subresource, verb, scope)
-	call, exists := apiCalls[key]
+func (m *apiCallMetrics) getAPICall(resource, subresource, verb, scope string) *apiCallMetric {
+	key := m.buildKey(resource, subresource, verb, scope)
+	call, exists := m.metrics[key]
 	if !exists {
-		call = &apiCall{
+		call = &apiCallMetric{
 			Resource:    resource,
 			Subresource: subresource,
 			Verb:        verb,
 			Scope:       scope,
 		}
-		apiCalls[key] = call
+		m.metrics[key] = call
 	}
 	return call
 }
 
-func addLatency(apiCalls map[string]*apiCall, resource, subresource, verb, scope string, quantile float64, latency time.Duration) {
-	call := getAPICall(apiCalls, resource, subresource, verb, scope)
+func (m *apiCallMetrics) SetLatency(resource, subresource, verb, scope string, quantile float64, latency time.Duration) {
+	call := m.getAPICall(resource, subresource, verb, scope)
 	call.Latency.SetQuantile(quantile, latency)
 }
 
-func addCount(apiCalls map[string]*apiCall, resource, subresource, verb, scope string, count int) {
+func (m *apiCallMetrics) SetCount(resource, subresource, verb, scope string, count int) {
 	if count == 0 {
 		return
 	}
-	call := getAPICall(apiCalls, resource, subresource, verb, scope)
+	call := m.getAPICall(resource, subresource, verb, scope)
 	call.Count = count
 }
 
-func getMetricKey(resource, subresource, verb, scope string) string {
-	return fmt.Sprintf("%s|%s|%s|%s", resource, subresource, verb, scope)
-}
-
-func getSLOThreshold(verb, scope string) time.Duration {
-	if verb != "LIST" {
-		return resourceThreshold
-	}
-	if scope == "cluster" {
-		return clusterThreshold
-	}
-	return namespaceThreshold
-}
-
-func validateAPICalls(identifier string, metrics *apiResponsiveness) []string {
-	badMetrics := make([]string, 0)
-	top := topToPrint
-
-	sort.Sort(sort.Reverse(metrics))
-	for _, apiCall := range metrics.APICalls {
-		isBad := false
-		sloThreshold := getSLOThreshold(apiCall.Verb, apiCall.Scope)
-		if err := apiCall.Latency.VerifyThreshold(sloThreshold); err != nil {
-			isBad = true
-			badMetrics = append(badMetrics, fmt.Sprintf("got: %+v; expected perc99 <= %v", apiCall, sloThreshold))
-		}
-		if top > 0 || isBad {
-			top--
-			prefix := ""
-			if isBad {
-				prefix = "WARNING "
-			}
-			klog.Infof("%s: %vTop latency metric: %+v; threshold: %v", identifier, prefix, apiCall, sloThreshold)
-		}
-	}
-	return badMetrics
-}
-
-// apiCallToPerfData transforms apiResponsiveness to PerfData.
-func apiCallToPerfData(apicalls *apiResponsiveness) *measurementutil.PerfData {
+func (m *apiCallMetrics) ToPerfData() *measurementutil.PerfData {
 	perfData := &measurementutil.PerfData{Version: currentAPICallMetricsVersion}
-	for _, apicall := range apicalls.APICalls {
+	for _, apicall := range m.sorted() {
 		item := measurementutil.DataItem{
 			Data: map[string]float64{
 				"Perc50": float64(apicall.Latency.Perc50) / 1000000, // us -> ms
@@ -307,4 +268,41 @@ func apiCallToPerfData(apicalls *apiResponsiveness) *measurementutil.PerfData {
 		perfData.DataItems = append(perfData.DataItems, item)
 	}
 	return perfData
+}
+
+func (m *apiCallMetrics) sorted() []*apiCallMetric {
+	all := make([]*apiCallMetric, 0)
+	for _, v := range m.metrics {
+		all = append(all, v)
+	}
+	sort.Slice(all, func(i, j int) bool {
+		return all[i].Latency.Perc99 < all[j].Latency.Perc99
+	})
+	return all
+}
+
+func (m *apiCallMetrics) buildKey(resource, subresource, verb, scope string) string {
+	return fmt.Sprintf("%s|%s|%s|%s", resource, subresource, verb, scope)
+}
+
+func (ap *apiCallMetric) Validate() error {
+	threshold := ap.getSLOThreshold()
+	if err := ap.Latency.VerifyThreshold(threshold); err != nil {
+		return fmt.Errorf("got: %+v; expected perc99 <= %v", ap, threshold)
+	}
+	return nil
+}
+
+func (ap *apiCallMetric) getSLOThreshold() time.Duration {
+	if ap.Verb != "LIST" {
+		return resourceThreshold
+	}
+	if ap.Scope == "cluster" {
+		return clusterThreshold
+	}
+	return namespaceThreshold
+}
+
+func (ap *apiCallMetric) String() string {
+	return fmt.Sprintf("%+v; threshold: %v", *ap, ap.getSLOThreshold())
 }

--- a/clusterloader2/pkg/measurement/common/slos/api_responsiveness_prometheus.go
+++ b/clusterloader2/pkg/measurement/common/slos/api_responsiveness_prometheus.go
@@ -59,6 +59,15 @@ const (
 	// countQuery %v should be replaced with (1) filters and (2) query window size.
 	countQuery = "sum(increase(apiserver_request_duration_seconds_count{%v}[%v])) by (resource, subresource, scope, verb)"
 
+	countSlowQuery = "sum(rate(apiserver_request_duration_seconds_bucket{%v}[%v])) by (resource, subresource, scope, verb)"
+
+	// exclude all buckets of 1s and shorter
+	filterGetAndMutating = `verb!~"WATCH|WATCHLIST|PROXY|CONNECT", le!~"0.\\d+|1"`
+	// exclude all buckets below or equal 5s
+	filterNamespaceList = `scope!="cluster", verb="LIST", le!~"[01234](.\\d+)?|5"`
+	// exclude all buckets below or equal 30s
+	filterClusterList = `scope="cluster", verb="LIST", le!~"[12]?[0-9](.\\d+)?|30"`
+
 	latencyWindowSize = 5 * time.Minute
 
 	// Number of metrics with highest latency to print. If the latency exceeeds SLO threshold, a metric is printed regardless.
@@ -79,7 +88,7 @@ type apiCallMetric struct {
 	Scope       string                        `json:"scope"`
 	Latency     measurementutil.LatencyMetric `json:"latency"`
 	Count       int                           `json:"count"`
-	FailedCount int                           `json:"failedCount"`
+	SlowCount   int                           `json:"slowCount"`
 }
 
 type apiCallMetrics struct {
@@ -104,7 +113,12 @@ func (a *apiResponsivenessGatherer) Gather(executor QueryExecutor, startTime tim
 	}
 	summary := measurement.CreateSummary(summaryName, "json", content)
 
-	badMetrics := a.validateAPICalls(config.Identifier, apiCalls)
+	allowedSlowCalls, err := util.GetIntOrDefault(config.Params, "allowedSlowCalls", 0)
+	if err != nil {
+		return nil, err
+	}
+
+	badMetrics := a.validateAPICalls(config.Identifier, allowedSlowCalls, apiCalls)
 	if len(badMetrics) > 0 {
 		err = errors.NewMetricViolationError("top latency metric", fmt.Sprintf("there should be no high-latency requests, but: %v", badMetrics))
 	}
@@ -122,6 +136,7 @@ func (a *apiResponsivenessGatherer) IsEnabled(config *measurement.MeasurementCon
 func (a *apiResponsivenessGatherer) gatherAPICalls(executor QueryExecutor, startTime time.Time, config *measurement.MeasurementConfig) (*apiCallMetrics, error) {
 	measurementEnd := time.Now()
 	measurementDuration := measurementEnd.Sub(startTime)
+	promDuration := measurementutil.ToPrometheusTime(measurementDuration)
 
 	useSimple, err := util.GetBoolOrDefault(config.Params, "useSimpleLatencyQuery", false)
 	if err != nil {
@@ -130,7 +145,6 @@ func (a *apiResponsivenessGatherer) gatherAPICalls(executor QueryExecutor, start
 
 	var latencySamples []*model.Sample
 	if useSimple {
-		promDuration := measurementutil.ToPrometheusTime(measurementDuration)
 		quantiles := []float64{0.5, 0.9, 0.99}
 		for _, q := range quantiles {
 			query := fmt.Sprintf(simpleLatencyQuery, q, filters, promDuration)
@@ -151,30 +165,50 @@ func (a *apiResponsivenessGatherer) gatherAPICalls(executor QueryExecutor, start
 		if latencyMeasurementDuration < time.Minute {
 			latencyMeasurementDuration = time.Minute
 		}
-		promDuration := measurementutil.ToPrometheusTime(latencyMeasurementDuration)
+		duration := measurementutil.ToPrometheusTime(latencyMeasurementDuration)
 
-		query := fmt.Sprintf(latencyQuery, filters, promDuration)
+		query := fmt.Sprintf(latencyQuery, filters, duration)
 		latencySamples, err = executor.Query(query, measurementEnd)
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	timeBoundedCountQuery := fmt.Sprintf(countQuery, filters, measurementutil.ToPrometheusTime(measurementDuration))
-	countSamples, err := executor.Query(timeBoundedCountQuery, measurementEnd)
+	query := fmt.Sprintf(countQuery, filters, promDuration)
+	countSamples, err := executor.Query(query, measurementEnd)
 	if err != nil {
 		return nil, err
 	}
-	return newFromSamples(latencySamples, countSamples)
+
+	allowedSlowCalls, err := util.GetIntOrDefault(config.Params, "allowedSlowCalls", 0)
+	if err != nil {
+		return nil, err
+	}
+
+	countSlowSamples := make([]*model.Sample, 0)
+	// TODO(oxddr): remove this guard once it's stable
+	if allowedSlowCalls != 0 {
+		filters := []string{filterGetAndMutating, filterNamespaceList, filterClusterList}
+		for _, filter := range filters {
+			query := fmt.Sprintf(countSlowQuery, filter, promDuration)
+			samples, err := executor.Query(query, measurementEnd)
+			if err != nil {
+				return nil, err
+			}
+			countSlowSamples = append(countSlowSamples, samples...)
+		}
+	}
+
+	return newFromSamples(latencySamples, countSamples, countSlowSamples)
 }
 
-func (a *apiResponsivenessGatherer) validateAPICalls(identifier string, metrics *apiCallMetrics) []error {
+func (a *apiResponsivenessGatherer) validateAPICalls(identifier string, allowedSlowCalls int, metrics *apiCallMetrics) []error {
 	badMetrics := make([]error, 0)
 	top := topToPrint
 
 	for _, apiCall := range metrics.sorted() {
 		var err error
-		if err = apiCall.Validate(); err != nil {
+		if err = apiCall.Validate(allowedSlowCalls); err != nil {
 			badMetrics = append(badMetrics, err)
 		}
 		if top > 0 || err != nil {
@@ -189,14 +223,15 @@ func (a *apiResponsivenessGatherer) validateAPICalls(identifier string, metrics 
 	return badMetrics
 }
 
-func newFromSamples(latencySamples, countSamples []*model.Sample) (*apiCallMetrics, error) {
+func newFromSamples(latencySamples, countSamples, countSlowSamples []*model.Sample) (*apiCallMetrics, error) {
+	extractCommon := func(sample *model.Sample) (string, string, string, string) {
+		return string(sample.Metric["resource"]), string(sample.Metric["subresource"]), string(sample.Metric["verb"]), string(sample.Metric["scope"])
+	}
+
 	m := &apiCallMetrics{metrics: make(map[string]*apiCallMetric)}
 
 	for _, sample := range latencySamples {
-		resource := string(sample.Metric["resource"])
-		subresource := string(sample.Metric["subresource"])
-		verb := string(sample.Metric["verb"])
-		scope := string(sample.Metric["scope"])
+		resource, subresource, verb, scope := extractCommon(sample)
 		quantile, err := strconv.ParseFloat(string(sample.Metric["quantile"]), 64)
 		if err != nil {
 			return nil, err
@@ -207,13 +242,15 @@ func newFromSamples(latencySamples, countSamples []*model.Sample) (*apiCallMetri
 	}
 
 	for _, sample := range countSamples {
-		resource := string(sample.Metric["resource"])
-		subresource := string(sample.Metric["subresource"])
-		verb := string(sample.Metric["verb"])
-		scope := string(sample.Metric["scope"])
-
+		resource, subresource, verb, scope := extractCommon(sample)
 		count := int(math.Round(float64(sample.Value)))
 		m.SetCount(resource, subresource, verb, scope, count)
+	}
+
+	for _, sample := range countSlowSamples {
+		resource, subresource, verb, scope := extractCommon(sample)
+		failedCount := int(math.Round(float64(sample.Value)))
+		m.SetSlowCount(resource, subresource, verb, scope, failedCount)
 	}
 
 	return m, nil
@@ -247,6 +284,14 @@ func (m *apiCallMetrics) SetCount(resource, subresource, verb, scope string, cou
 	call.Count = count
 }
 
+func (m *apiCallMetrics) SetSlowCount(resource, subresource, verb, scope string, count int) {
+	if count == 0 {
+		return
+	}
+	call := m.getAPICall(resource, subresource, verb, scope)
+	call.SlowCount = count
+}
+
 func (m *apiCallMetrics) ToPerfData() *measurementutil.PerfData {
 	perfData := &measurementutil.PerfData{Version: currentAPICallMetricsVersion}
 	for _, apicall := range m.sorted() {
@@ -263,6 +308,7 @@ func (m *apiCallMetrics) ToPerfData() *measurementutil.PerfData {
 				"Subresource": apicall.Subresource,
 				"Scope":       apicall.Scope,
 				"Count":       fmt.Sprintf("%v", apicall.Count),
+				"SlowCount":   fmt.Sprintf("%v", apicall.SlowCount),
 			},
 		}
 		perfData.DataItems = append(perfData.DataItems, item)
@@ -285,9 +331,13 @@ func (m *apiCallMetrics) buildKey(resource, subresource, verb, scope string) str
 	return fmt.Sprintf("%s|%s|%s|%s", resource, subresource, verb, scope)
 }
 
-func (ap *apiCallMetric) Validate() error {
+func (ap *apiCallMetric) Validate(allowedSlowCalls int) error {
 	threshold := ap.getSLOThreshold()
 	if err := ap.Latency.VerifyThreshold(threshold); err != nil {
+		// TODO(oxddr): remove allowedSlowCalls guard once it's stable
+		if allowedSlowCalls > 0 && ap.SlowCount <= allowedSlowCalls {
+			return nil
+		}
 		return fmt.Errorf("got: %+v; expected perc99 <= %v", ap, threshold)
 	}
 	return nil

--- a/clusterloader2/pkg/measurement/common/slos/api_responsiveness_prometheus_test.go
+++ b/clusterloader2/pkg/measurement/common/slos/api_responsiveness_prometheus_test.go
@@ -1,0 +1,329 @@
+package slos
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/perf-tests/clusterloader2/pkg/measurement"
+	measurementutil "k8s.io/perf-tests/clusterloader2/pkg/measurement/util"
+)
+
+type sample struct {
+	resource    string
+	subresource string
+	verb        string
+	scope       string
+	latency     float64
+	count       int
+}
+type summaryEntry struct {
+	resource    string
+	subresource string
+	verb        string
+	scope       string
+	p50         float64
+	p90         float64
+	p99         float64
+	count       string
+}
+
+type fakeQueryExecutor struct {
+	samples []*sample
+}
+
+func (ex *fakeQueryExecutor) Query(query string, queryTime time.Time) ([]*model.Sample, error) {
+	samples := make([]*model.Sample, 0)
+	for _, s := range ex.samples {
+		sample := &model.Sample{
+			Metric: model.Metric{
+				"resource":    model.LabelValue(s.resource),
+				"subresoruce": model.LabelValue(s.subresource),
+				"verb":        model.LabelValue(s.verb),
+				"scope":       model.LabelValue(s.scope),
+			},
+		}
+
+		if strings.HasPrefix(query, "sum") {
+			// countQuery
+			sample.Value = model.SampleValue(s.count)
+		} else if strings.HasPrefix(query, "histogram_quantile") {
+			// simpleLatencyQuery
+			sample.Value = model.SampleValue(s.latency)
+		} else if strings.HasPrefix(query, "quantile_over_time") {
+			// latencyQuery
+			sample.Metric["quantile"] = ".99"
+			sample.Value = model.SampleValue(s.latency)
+		}
+		samples = append(samples, sample)
+	}
+	return samples, nil
+}
+
+func TestAPIResponsivenessSLOFailures(t *testing.T) {
+	cases := []struct {
+		name      string
+		samples   []*sample
+		useSimple bool
+		hasError  bool
+	}{
+		{
+			name:     "slo_pass",
+			hasError: false,
+			samples: []*sample{
+				{
+					resource: "pod",
+					verb:     "POST",
+					scope:    "namespace",
+					latency:  0.2,
+				},
+				{
+					resource: "pod",
+					verb:     "GET",
+					scope:    "namespace",
+					latency:  0.2,
+				},
+				{
+					resource: "pod",
+					verb:     "LIST",
+					scope:    "namespace",
+					latency:  1.2,
+				},
+				{
+					resource: "pod",
+					verb:     "LIST",
+					scope:    "cluster",
+					latency:  5.2,
+				},
+			},
+		},
+		{
+			name:     "mutating_slo_failure",
+			hasError: true,
+			samples: []*sample{
+				{
+					resource: "pod",
+					verb:     "POST",
+					scope:    "namespace",
+					latency:  1.2,
+				},
+			},
+		},
+		{
+			name:     "get_slo_failure",
+			hasError: true,
+			samples: []*sample{
+				{
+					resource: "pod",
+					verb:     "GET",
+					scope:    "namespace",
+					latency:  1.2,
+				},
+			},
+		},
+		{
+			name:     "namespace_list_slo_failure",
+			hasError: true,
+			samples: []*sample{
+				{
+					resource: "pod",
+					verb:     "LIST",
+					scope:    "namespace",
+					latency:  5.2,
+				},
+			},
+		},
+		{
+			name:     "cluster_list_slo_failure",
+			hasError: true,
+			samples: []*sample{
+				{
+					resource: "pod",
+					verb:     "LIST",
+					scope:    "cluster",
+					latency:  30.2,
+				},
+			},
+		},
+		{
+			name:      "slo_pass_simple",
+			useSimple: true,
+			hasError:  false,
+			samples: []*sample{
+				{
+					resource: "pod",
+					verb:     "POST",
+					scope:    "namespace",
+					latency:  0.2,
+				},
+				{
+					resource: "pod",
+					verb:     "GET",
+					scope:    "namespace",
+					latency:  0.2,
+				},
+				{
+					resource: "pod",
+					verb:     "LIST",
+					scope:    "namespace",
+					latency:  1.2,
+				},
+				{
+					resource: "pod",
+					verb:     "LIST",
+					scope:    "cluster",
+					latency:  5.2,
+				},
+			},
+		},
+		{
+			name:      "mutating_slo_failure_simple",
+			useSimple: true,
+			hasError:  true,
+			samples: []*sample{
+				{
+					resource: "pod",
+					verb:     "POST",
+					scope:    "namespace",
+					latency:  1.2,
+				},
+			},
+		},
+		{
+			name:      "get_slo_failure_simple",
+			useSimple: true,
+			hasError:  true,
+			samples: []*sample{
+				{
+					resource: "pod",
+					verb:     "GET",
+					scope:    "namespace",
+					latency:  1.2,
+				},
+			},
+		},
+		{
+			name:      "namespace_list_slo_failure_simple",
+			useSimple: true,
+			hasError:  true,
+			samples: []*sample{
+				{
+					resource: "pod",
+					verb:     "LIST",
+					scope:    "namespace",
+					latency:  5.2,
+				},
+			},
+		},
+		{
+			name:      "cluster_list_slo_failure_simple",
+			useSimple: true,
+			hasError:  true,
+			samples: []*sample{
+				{
+					resource: "pod",
+					verb:     "LIST",
+					scope:    "cluster",
+					latency:  30.2,
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		executor := &fakeQueryExecutor{samples: tc.samples}
+		gatherer := &apiResponsivenessGatherer{}
+		config := &measurement.MeasurementConfig{
+			Params: map[string]interface{}{
+				"useSimpleLatencyQuery": tc.useSimple,
+			},
+		}
+
+		_, err := gatherer.Gather(executor, time.Now(), config)
+		if tc.hasError {
+			assert.NotNil(t, err, "%s: wanted error, but got none", tc.name)
+		} else {
+			assert.Nil(t, err, "%s: wanted no error, but got %v", tc.name, err)
+		}
+
+	}
+}
+
+func TestAPIResponsivenessSummary(t *testing.T) {
+	cases := []struct {
+		name    string
+		samples []*sample
+		summary []*summaryEntry
+	}{
+		{
+			name: "single_entry",
+			samples: []*sample{
+				{
+					resource: "pod",
+					verb:     "POST",
+					scope:    "namespace",
+					latency:  1.2,
+					count:    123,
+				},
+			},
+			summary: []*summaryEntry{
+				{
+					resource: "pod",
+					verb:     "POST",
+					scope:    "namespace",
+					p99:      1200.,
+					count:    "123",
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		executor := &fakeQueryExecutor{samples: tc.samples}
+		gatherer := &apiResponsivenessGatherer{}
+		config := &measurement.MeasurementConfig{}
+
+		summary, _ := gatherer.Gather(executor, time.Now(), config)
+		checkSummary(t, tc.name, summary, tc.summary)
+	}
+}
+
+func checkSummary(t *testing.T, tc string, got measurement.Summary, wanted []*summaryEntry) {
+	var perfData measurementutil.PerfData
+	if err := json.Unmarshal([]byte(got.SummaryContent()), &perfData); err != nil {
+		t.Errorf("unable to unmarshal summary: %v", err)
+		return
+	}
+	assert.Equal(t, currentAPICallMetricsVersion, perfData.Version)
+	assert.Len(t, perfData.DataItems, len(wanted))
+
+	toKey := func(resource, subresource, verb, scope string) string {
+		return fmt.Sprintf("%s-%s-%s-%s", resource, subresource, verb, scope)
+	}
+
+	items := make(map[string]*measurementutil.DataItem)
+	for _, item := range perfData.DataItems {
+		items[toKey(
+			item.Labels["Resource"],
+			item.Labels["Subresource"],
+			item.Labels["Verb"],
+			item.Labels["Scope"])] = &item
+	}
+
+	for _, entry := range wanted {
+		item, ok := items[toKey(entry.resource, entry.subresource, entry.verb, entry.scope)]
+		if !ok {
+			t.Errorf("%s, %s in %s: %s %s wanted, but not found", tc, entry.verb, entry.scope, entry.resource, entry.subresource)
+			continue
+		}
+		assert.Equal(t, "ms", item.Unit)
+		assert.Equal(t, entry.p50, item.Data["Perc50"])
+		assert.Equal(t, entry.p90, item.Data["Perc90"])
+		assert.Equal(t, entry.p99, item.Data["Perc99"])
+		assert.Equal(t, entry.count, item.Labels["Count"])
+	}
+}

--- a/clusterloader2/pkg/measurement/common/slos/api_responsiveness_prometheus_test.go
+++ b/clusterloader2/pkg/measurement/common/slos/api_responsiveness_prometheus_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package slos
 
 import (
@@ -249,7 +265,6 @@ func TestAPIResponsivenessSLOFailures(t *testing.T) {
 		} else {
 			assert.Nil(t, err, "%s: wanted no error, but got %v", tc.name, err)
 		}
-
 	}
 }
 

--- a/clusterloader2/pkg/measurement/common/slos/prometheus_measurement.go
+++ b/clusterloader2/pkg/measurement/common/slos/prometheus_measurement.go
@@ -88,6 +88,7 @@ func (m *prometheusMeasurement) Execute(config *measurement.MeasurementConfig) (
 		summary, err := m.gatherer.Gather(executor, m.startTime, config)
 		if err != nil {
 			if !errors.IsMetricViolationError(err) {
+				klog.Errorf("%s gathering error: %v", config.Identifier, err)
 				return nil, err
 			}
 			if !enableViolations {

--- a/clusterloader2/testing/density/config.yaml
+++ b/clusterloader2/testing/density/config.yaml
@@ -58,12 +58,10 @@ steps:
     Method: APIResponsivenessPrometheus
     Params:
       action: start
-      allowedSlowCalls: {{$ALLOWED_SLOW_API_CALLS}}
   - Identifier: APIResponsivenessPrometheusSimple
     Method: APIResponsivenessPrometheus
     Params:
       action: start
-      allowedSlowCalls: {{$ALLOWED_SLOW_API_CALLS}}
   # TODO(oxddr): figure out how many probers to run in function of cluster
   - Identifier: InClusterNetworkLatency
     Method: InClusterNetworkLatency
@@ -234,11 +232,13 @@ steps:
       enableViolations: true
       useSimpleLatencyQuery: true
       summaryName: APIResponsivenessPrometheus_simple
+      allowedSlowCalls: {{$ALLOWED_SLOW_API_CALLS}}
   {{if not $USE_SIMPLE_LATENCY_QUERY}}
   - Identifier: APIResponsivenessPrometheus
     Method: APIResponsivenessPrometheus
     Params:
       action: gather
+      allowedSlowCalls: {{$ALLOWED_SLOW_API_CALLS}}
   {{end}}
   - Identifier: InClusterNetworkLatency
     Method: InClusterNetworkLatency

--- a/clusterloader2/testing/density/config.yaml
+++ b/clusterloader2/testing/density/config.yaml
@@ -25,6 +25,7 @@
 {{$USE_SIMPLE_LATENCY_QUERY := DefaultParam .USE_SIMPLE_LATENCY_QUERY false}}
 {{$ENABLE_RESTART_COUNT_CHECK := DefaultParam .ENABLE_RESTART_COUNT_CHECK false}}
 {{$RESTART_COUNT_THRESHOLD_OVERRIDES:= DefaultParam .RESTART_COUNT_THRESHOLD_OVERRIDES ""}}
+{{$ALLOWED_SLOW_API_CALLS := DefaultParam .CL2_ALLOWED_SLOW_API_CALLS 0}}
 #Variables
 {{$namespaces := DivideInt .Nodes $NODES_PER_NAMESPACE}}
 {{$podsPerNamespace := MultiplyInt $PODS_PER_NODE $NODES_PER_NAMESPACE}}
@@ -57,10 +58,12 @@ steps:
     Method: APIResponsivenessPrometheus
     Params:
       action: start
+      allowedSlowCalls: {{$ALLOWED_SLOW_API_CALLS}}
   - Identifier: APIResponsivenessPrometheusSimple
     Method: APIResponsivenessPrometheus
     Params:
       action: start
+      allowedSlowCalls: {{$ALLOWED_SLOW_API_CALLS}}
   # TODO(oxddr): figure out how many probers to run in function of cluster
   - Identifier: InClusterNetworkLatency
     Method: InClusterNetworkLatency

--- a/clusterloader2/testing/load/config.yaml
+++ b/clusterloader2/testing/load/config.yaml
@@ -84,12 +84,10 @@ steps:
     Method: APIResponsivenessPrometheus
     Params:
       action: start
-      allowedSlowCalls: {{$ALLOWED_SLOW_API_CALLS}}
   - Identifier: APIResponsivenessPrometheusSimple
     Method: APIResponsivenessPrometheus
     Params:
       action: start
-      allowedSlowCalls: {{$ALLOWED_SLOW_API_CALLS}}
   - Identifier: PodStartupLatency
     Method: PodStartupLatency
     Params:
@@ -754,11 +752,13 @@ steps:
       enableViolations: true
       useSimpleLatencyQuery: true
       summaryName: APIResponsivenessPrometheus_simple
+      allowedSlowCalls: {{$ALLOWED_SLOW_API_CALLS}}
   {{if not $USE_SIMPLE_LATENCY_QUERY}}
   - Identifier: APIResponsivenessPrometheus
     Method: APIResponsivenessPrometheus
     Params:
       action: gather
+      allowedSlowCalls: {{$ALLOWED_SLOW_API_CALLS}}
   {{end}}
   - Identifier: PodStartupLatency
     Method: PodStartupLatency

--- a/clusterloader2/testing/load/config.yaml
+++ b/clusterloader2/testing/load/config.yaml
@@ -30,6 +30,7 @@
 {{$USE_SIMPLE_LATENCY_QUERY := DefaultParam .USE_SIMPLE_LATENCY_QUERY false}}
 {{$ENABLE_RESTART_COUNT_CHECK := DefaultParam .ENABLE_RESTART_COUNT_CHECK false}}
 {{$RESTART_COUNT_THRESHOLD_OVERRIDES:= DefaultParam .RESTART_COUNT_THRESHOLD_OVERRIDES ""}}
+{{$ALLOWED_SLOW_API_CALLS := DefaultParam .CL2_ALLOWED_SLOW_API_CALLS 0}}
 #Variables
 {{$namespaces := DivideInt .Nodes $NODES_PER_NAMESPACE}}
 {{$totalPods := MultiplyInt $namespaces $NODES_PER_NAMESPACE $PODS_PER_NODE}}
@@ -83,10 +84,12 @@ steps:
     Method: APIResponsivenessPrometheus
     Params:
       action: start
+      allowedSlowCalls: {{$ALLOWED_SLOW_API_CALLS}}
   - Identifier: APIResponsivenessPrometheusSimple
     Method: APIResponsivenessPrometheus
     Params:
       action: start
+      allowedSlowCalls: {{$ALLOWED_SLOW_API_CALLS}}
   - Identifier: PodStartupLatency
     Method: PodStartupLatency
     Params:


### PR DESCRIPTION
Backport #1262, #1258, #1213, #1229 and #1209 to get rid of API call measurement flakes due to single slow API calls breaking the latency SLOs.

/sig scalability
/cc jkaniuk
/cc mm4tt
/cc wojtek-t