### PR TITLE
Update etcd_disk_backend_commit_duration_seconds histogram to etcd_disk_backend_commit_duration_seconds_bucket

### DIFF
--- a/clusterloader2/pkg/prometheus/manifests/dashboards/master-dashboard.dashboard.py
+++ b/clusterloader2/pkg/prometheus/manifests/dashboards/master-dashboard.dashboard.py
@@ -194,7 +194,7 @@ histogram_quantile(
     ),
     d.simple_graph(
         "etcd_disk_backend_commit_duration_seconds",
-        "histogram_quantile(0.99, sum(rate(etcd_disk_backend_commit_duration_seconds[1m])) by (le, instance))",
+        "histogram_quantile(0.99, sum(rate(etcd_disk_backend_commit_duration_seconds_bucket[1m])) by (le, instance))",
         yAxes=g.single_y_axis(format=g.SECONDS_FORMAT),
     ),
     d.simple_graph(


### PR DESCRIPTION
Fix https://github.com/kubernetes/perf-tests/issues/1371

update etcd_disk_backend_commit_duration_seconds to etcd_disk_backend_commit_duration_seconds_bucket in master dashboard.

I have a problem that run `make all` always show `make: Nothing to be done for 'all'.`, i don't know why, if someone knows, please tell me. Thanks.
