### PR TITLE
* Added support for GitHub bearer token

### DIFF
--- a/perfdash/github-configs-fetcher.go
+++ b/perfdash/github-configs-fetcher.go
@@ -21,6 +21,7 @@ import (
 	"io/ioutil"
 	"k8s.io/klog"
 	"net/http"
+	"os"
 	"strings"
 
 	"gopkg.in/yaml.v2"
@@ -59,7 +60,15 @@ func GetConfigsFromGithub(url string) ([]string, error) {
 
 func getGithubDirContents(url string) ([]githubDirContent, error) {
 	klog.Infof("Downloading github spec from %v", url)
-	resp, err := http.Get(url)
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	if token := os.Getenv("GITHUB_TOKEN"); len(token) != 0 {
+		req.Header.Add("Authorization", fmt.Sprintf("Bearer: %s", token))
+	}
+	client := &http.Client{}
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("error calling github API %s: %v", url, err)
 	}


### PR DESCRIPTION
GitHub's API will rate limit unauthenticated requests from IPs with high request
rates, but will allow requests that include authentication. This adds
support for reading in a `GITHUB_TOKEN` environment variable and adding
it as a bearer token to requests against the GitHub API

I got the message when trying to test this tool on my corporate network.
```json
{
  "message": "API rate limit exceeded for xxx.xxx.xxx.xxx. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)",
  "documentation_url": "https://developer.github.com/v3/#rate-limiting"
}
```