### PR TITLE
Refactor perfdash codebase for future S3 support

### DIFF
--- a/perfdash/Makefile
+++ b/perfdash/Makefile
@@ -5,7 +5,7 @@ TAG = 2.25
 
 REPO = gcr.io/k8s-testimages
 
-test: perfdash.go parser.go config.go downloader.go google-gcs-downloader.go
+test: perfdash.go parser.go config.go metrics-downloader-helper.go metrics-downloader.go
 	go test
 
 perfdash: test
@@ -28,3 +28,4 @@ push: container
 
 clean:
 	rm -f perfdash
+

--- a/perfdash/metrics-downloader-helper.go
+++ b/perfdash/metrics-downloader-helper.go
@@ -26,11 +26,6 @@ import (
 	"k8s.io/kubernetes/test/e2e/perftype"
 )
 
-// Downloader is the interface that gets a data from a predefined source.
-type Downloader interface {
-	getData() (MetricToBuildData, error)
-}
-
 // BuildData contains job name and a map from build number to perf data.
 type BuildData struct {
 	Builds  map[string][]perftype.DataItem `json:"builds"`


### PR DESCRIPTION
This PR refactors the perfdash codebase for future S3 support. My changes consist of:  
* renaming many of the variables, functions, and files to be more generic/readable
* converting bucketUtil to an interface called MetricsBucket
* moving GCS specific flags to a GCSDownloaderOptions struct