### PR TITLE
Use gofmt to fix lint issues and update perfdash README

### DIFF
--- a/perfdash/README.md
+++ b/perfdash/README.md
@@ -41,8 +41,6 @@ Images are stored in *gcr.io/k8s-testimages* project container registry.
 
 ## Local development
 
-First, ensure godep is installed using `go install github.com/tools/godep`.
-
 To test your changes locally, execute `make run`. It will build the binary and
 start perfdash website at <http://localhost:8080>. Note that it might take a
 short while for perfdash to start since it needs to fetch the job artifacts first.

--- a/perfdash/metrics-downloader.go
+++ b/perfdash/metrics-downloader.go
@@ -20,13 +20,14 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
-	"k8s.io/klog"
 	"path"
 	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
 	"sync"
+
+	"k8s.io/klog"
 
 	"cloud.google.com/go/storage"
 	"google.golang.org/api/iterator"
@@ -46,8 +47,8 @@ type DownloaderOptions struct {
 
 // Downloader that gets data about results from a storage service (GCS) repository.
 type Downloader struct {
-	MetricsBkt     MetricsBucket
-	Options        *DownloaderOptions
+	MetricsBkt MetricsBucket
+	Options    *DownloaderOptions
 }
 
 // NewDownloader creates a new Downloader.

--- a/perfdash/perfdash.go
+++ b/perfdash/perfdash.go
@@ -19,10 +19,11 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"k8s.io/klog"
 	"net/http"
 	"os"
 	"time"
+
+	"k8s.io/klog"
 
 	"github.com/spf13/pflag"
 )
@@ -46,7 +47,7 @@ var (
 
 	// Storage Service Bucket and Path flags
 	logsBucket = pflag.String("logsBucket", "kubernetes-jenkins", "Name of the data bucket")
-	logsPath = pflag.String("logsPath", "logs", "Path to the logs inside the logs bucket")
+	logsPath   = pflag.String("logsPath", "logs", "Path to the logs inside the logs bucket")
 
 	// Google GCS Specific flags
 	credentialPath = pflag.String("credentialPath", "", "Path to the gcs credential json")


### PR DESCRIPTION
In this PR: 
- I fix the lint issues from PR #1382. My gofmt/golint was not working properly. The PR was merged, but it failed the verify-lint test
- I updated the readme to reflect that perfdash is no longer using godeps since we moved to go modules