### PR TITLE
Cl2 env template params - backport #1263, #1145, #998 & #921 (release-1.17)

### DIFF
--- a/clusterloader2/README.md
+++ b/clusterloader2/README.md
@@ -62,6 +62,25 @@ each reference has to be opaqued with ```DefaultParam``` function that will
 handle case if given variable doesn't exist. \
 Example of overrides can be found here: [overrides]
 
+#### Passing environment variables
+
+Instead of using overrides in file, it is possible to depend on environment
+variables. Only variables that start with `CL2_` prefix will be parsed and
+available in script.
+
+Environment variables can be used with `DefaultParam` function to provide sane
+default values.
+
+##### Setting variables in shell
+```shell
+export CL2_ACCESS_TOKENS_QPS=5
+```
+
+##### Usage from test definition
+```yaml
+{{$qpsPerToken := DefaultParam .CL2_ACCESS_TOKENS_QPS 0.1}}
+```
+
 ## Measurement
 
 Currently available measurements are:

--- a/clusterloader2/pkg/config/template_provider.go
+++ b/clusterloader2/pkg/config/template_provider.go
@@ -246,13 +246,13 @@ func LoadCL2Envs() (map[string]interface{}, error) {
 }
 
 func unpackStringValue(str string) interface{} {
-	if v, err := strconv.ParseBool(str); err == nil {
-		return v
-	}
 	if v, err := strconv.ParseInt(str, 10, 64); err == nil {
 		return v
 	}
 	if v, err := strconv.ParseFloat(str, 64); err == nil {
+		return v
+	}
+	if v, err := strconv.ParseBool(str); err == nil {
 		return v
 	}
 	return str

--- a/clusterloader2/pkg/config/template_provider.go
+++ b/clusterloader2/pkg/config/template_provider.go
@@ -25,6 +25,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"text/template"
@@ -239,9 +240,22 @@ func LoadCL2Envs() (map[string]interface{}, error) {
 			return nil, fmt.Errorf("unparsable string in os.Eviron(): %v", keyValue)
 		}
 		key, value := split[0], split[1]
-		mapping[key] = value
+		mapping[key] = unpackStringValue(value)
 	}
 	return mapping, nil
+}
+
+func unpackStringValue(str string) interface{} {
+	if v, err := strconv.ParseBool(str); err == nil {
+		return v
+	}
+	if v, err := strconv.ParseInt(str, 10, 64); err == nil {
+		return v
+	}
+	if v, err := strconv.ParseFloat(str, 64); err == nil {
+		return v
+	}
+	return str
 }
 
 // MergeMappings modifies map b to contain all new key=value pairs from b.

--- a/clusterloader2/pkg/config/template_provider.go
+++ b/clusterloader2/pkg/config/template_provider.go
@@ -21,7 +21,9 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"path/filepath"
+	"reflect"
 	"regexp"
 	"strings"
 	"sync"
@@ -217,5 +219,43 @@ func GetMapping(clusterLoaderConfig *ClusterLoaderConfig) (map[string]interface{
 		return nil, errors.NewErrorList(fmt.Errorf("mapping creation error: %v", err))
 	}
 	mapping["Nodes"] = clusterLoaderConfig.ClusterConfig.Nodes
+	envMapping, err := LoadCL2Envs()
+	if err != nil {
+		return nil, errors.NewErrorList(fmt.Errorf("mapping creation error: %v", err))
+	}
+	MergeMappings(mapping, envMapping)
 	return mapping, nil
+}
+
+// LoadCL2Envs returns mapping from the envs starting with CL2_ prefix.
+func LoadCL2Envs() (map[string]interface{}, error) {
+	mapping := make(map[string]interface{})
+	for _, keyValue := range os.Environ() {
+		if !strings.HasPrefix(keyValue, "CL2_") {
+			continue
+		}
+		split := strings.Split(keyValue, "=")
+		if len(split) != 2 {
+			return nil, fmt.Errorf("unparsable string in os.Eviron(): %v", keyValue)
+		}
+		key, value := split[0], split[1]
+		mapping[key] = value
+	}
+	return mapping, nil
+}
+
+// MergeMappings modifies map b to contain all new key=value pairs from b.
+// It will return error in case of conflict, i.e. if exists key k for which a[k] != b[k]
+func MergeMappings(a, b map[string]interface{}) error {
+	for k, bv := range b {
+		av, ok := a[k]
+		if !ok {
+			a[k] = bv
+			continue
+		}
+		if !reflect.DeepEqual(av, bv) {
+			return fmt.Errorf("merge conflict for key '%v': old value=%v, new value=%v", k, av, bv)
+		}
+	}
+	return nil
 }

--- a/clusterloader2/pkg/config/template_provider_test.go
+++ b/clusterloader2/pkg/config/template_provider_test.go
@@ -80,18 +80,22 @@ func TestLoadCL2Envs(t *testing.T) {
 				"NODE_SIZE":    "n1-standard-1",
 			},
 			wantedMapping: map[string]interface{}{
-				"CL2_MY_PARAM": "100",
+				"CL2_MY_PARAM": int64(100),
 			},
 		},
 		{
 			name: "Multiple CL2 envs",
 			env: map[string]string{
 				"CL2_MY_PARAM1": "100",
-				"CL2_MY_PARAM2": "XXX",
+				"CL2_MY_PARAM2": "true",
+				"CL2_MY_PARAM3": "99.99",
+				"CL2_MY_PARAM4": "XXX",
 			},
 			wantedMapping: map[string]interface{}{
-				"CL2_MY_PARAM1": "100",
-				"CL2_MY_PARAM2": "XXX",
+				"CL2_MY_PARAM1": int64(100),
+				"CL2_MY_PARAM2": true,
+				"CL2_MY_PARAM3": 99.99,
+				"CL2_MY_PARAM4": "XXX",
 			},
 		},
 		{

--- a/clusterloader2/pkg/config/template_provider_test.go
+++ b/clusterloader2/pkg/config/template_provider_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package config
 
 import (
+	"os"
+	"reflect"
 	"testing"
 
 	"k8s.io/perf-tests/clusterloader2/api"
@@ -60,6 +62,115 @@ func TestValidateTestSuite(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if err := validateTestSuite(tt.suite); (err != nil) != tt.wantErr {
 				t.Errorf("validateTestSuite() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestLoadCL2Envs(t *testing.T) {
+	tests := []struct {
+		name          string
+		env           map[string]string
+		wantedMapping map[string]interface{}
+	}{
+		{
+			name: "One CL2 env, one non-CL2 env",
+			env: map[string]string{
+				"CL2_MY_PARAM": "100",
+				"NODE_SIZE":    "n1-standard-1",
+			},
+			wantedMapping: map[string]interface{}{
+				"CL2_MY_PARAM": "100",
+			},
+		},
+		{
+			name: "Multiple CL2 envs",
+			env: map[string]string{
+				"CL2_MY_PARAM1": "100",
+				"CL2_MY_PARAM2": "XXX",
+			},
+			wantedMapping: map[string]interface{}{
+				"CL2_MY_PARAM1": "100",
+				"CL2_MY_PARAM2": "XXX",
+			},
+		},
+		{
+			name: "No CL2 envs",
+			env: map[string]string{
+				"NODE_SIZE": "n1-standard-1",
+				"CLUSTER":   "my-cluster",
+			},
+			wantedMapping: map[string]interface{}{},
+		},
+		{
+			name: "Env prefix is case sensitive",
+			env: map[string]string{
+				"cl2_my_param": "123",
+			},
+			wantedMapping: map[string]interface{}{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			os.Clearenv()
+			for k, v := range tt.env {
+				os.Setenv(k, v)
+			}
+			mapping, err := LoadCL2Envs()
+			if err != nil {
+				t.Error(err)
+			}
+			if !reflect.DeepEqual(mapping, tt.wantedMapping) {
+				t.Errorf("wanted: %v, got: %v", tt.wantedMapping, mapping)
+			}
+		})
+	}
+}
+
+func TestMergeMappings(t *testing.T) {
+	tests := []struct {
+		name    string
+		a       map[string]interface{}
+		b       map[string]interface{}
+		wantedA map[string]interface{}
+		wantErr bool
+	}{
+		{
+			name: "Different keys",
+			a:    map[string]interface{}{"ENABLE_XXX": true},
+			b:    map[string]interface{}{"CL2_PARAM1": 123},
+			wantedA: map[string]interface{}{
+				"ENABLE_XXX": true,
+				"CL2_PARAM1": 123,
+			},
+		},
+		{
+			name: "Same keys, no conflict",
+			a:    map[string]interface{}{"CL2_PARAM1": 100},
+			b:    map[string]interface{}{"CL2_PARAM1": 100},
+			wantedA: map[string]interface{}{
+				"CL2_PARAM1": 100,
+			},
+		},
+		{
+			name:    "Same keys, conflict",
+			a:       map[string]interface{}{"CL2_PARAM1": 100},
+			b:       map[string]interface{}{"CL2_PARAM1": 105},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := MergeMappings(tt.a, tt.b); err != nil {
+				if !tt.wantErr {
+					t.Errorf("unexpceted MergeMappings() error: %v", err)
+				}
+				return
+			}
+			if !reflect.DeepEqual(tt.a, tt.wantedA) {
+				t.Errorf("wanted: %v, got: %v", tt.wantedA, tt.a)
 			}
 		})
 	}

--- a/clusterloader2/pkg/config/template_provider_test.go
+++ b/clusterloader2/pkg/config/template_provider_test.go
@@ -90,12 +90,14 @@ func TestLoadCL2Envs(t *testing.T) {
 				"CL2_MY_PARAM2": "true",
 				"CL2_MY_PARAM3": "99.99",
 				"CL2_MY_PARAM4": "XXX",
+				"CL2_MY_PARAM5": "1",
 			},
 			wantedMapping: map[string]interface{}{
 				"CL2_MY_PARAM1": int64(100),
 				"CL2_MY_PARAM2": true,
 				"CL2_MY_PARAM3": 99.99,
 				"CL2_MY_PARAM4": "XXX",
+				"CL2_MY_PARAM5": int64(1),
 			},
 		},
 		{


### PR DESCRIPTION
Backports #1263, #1145, #998 & #921.

This will facilitate leveraging some of the backported features in perf-tests (like in #1379 where we'd need to add an override file and enable it in each 1.17 test job).

/sig scalability
/cc mm4tt