### PR TITLE
Cherry-pick CL2_* env template params fixes to release-1.18

### DIFF
--- a/clusterloader2/pkg/config/template_provider.go
+++ b/clusterloader2/pkg/config/template_provider.go
@@ -25,6 +25,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"text/template"
@@ -240,9 +241,22 @@ func LoadCL2Envs() (map[string]interface{}, error) {
 			return nil, goerrors.Errorf("unparsable string in os.Eviron(): %v", keyValue)
 		}
 		key, value := split[0], split[1]
-		mapping[key] = value
+		mapping[key] = unpackStringValue(value)
 	}
 	return mapping, nil
+}
+
+func unpackStringValue(str string) interface{} {
+	if v, err := strconv.ParseBool(str); err == nil {
+		return v
+	}
+	if v, err := strconv.ParseInt(str, 10, 64); err == nil {
+		return v
+	}
+	if v, err := strconv.ParseFloat(str, 64); err == nil {
+		return v
+	}
+	return str
 }
 
 // MergeMappings modifies map b to contain all new key=value pairs from b.

--- a/clusterloader2/pkg/config/template_provider.go
+++ b/clusterloader2/pkg/config/template_provider.go
@@ -247,13 +247,13 @@ func LoadCL2Envs() (map[string]interface{}, error) {
 }
 
 func unpackStringValue(str string) interface{} {
-	if v, err := strconv.ParseBool(str); err == nil {
-		return v
-	}
 	if v, err := strconv.ParseInt(str, 10, 64); err == nil {
 		return v
 	}
 	if v, err := strconv.ParseFloat(str, 64); err == nil {
+		return v
+	}
+	if v, err := strconv.ParseBool(str); err == nil {
 		return v
 	}
 	return str

--- a/clusterloader2/pkg/config/template_provider_test.go
+++ b/clusterloader2/pkg/config/template_provider_test.go
@@ -80,18 +80,22 @@ func TestLoadCL2Envs(t *testing.T) {
 				"NODE_SIZE":    "n1-standard-1",
 			},
 			wantedMapping: map[string]interface{}{
-				"CL2_MY_PARAM": "100",
+				"CL2_MY_PARAM": int64(100),
 			},
 		},
 		{
 			name: "Multiple CL2 envs",
 			env: map[string]string{
 				"CL2_MY_PARAM1": "100",
-				"CL2_MY_PARAM2": "XXX",
+				"CL2_MY_PARAM2": "true",
+				"CL2_MY_PARAM3": "99.99",
+				"CL2_MY_PARAM4": "XXX",
 			},
 			wantedMapping: map[string]interface{}{
-				"CL2_MY_PARAM1": "100",
-				"CL2_MY_PARAM2": "XXX",
+				"CL2_MY_PARAM1": int64(100),
+				"CL2_MY_PARAM2": true,
+				"CL2_MY_PARAM3": 99.99,
+				"CL2_MY_PARAM4": "XXX",
 			},
 		},
 		{

--- a/clusterloader2/pkg/config/template_provider_test.go
+++ b/clusterloader2/pkg/config/template_provider_test.go
@@ -90,12 +90,14 @@ func TestLoadCL2Envs(t *testing.T) {
 				"CL2_MY_PARAM2": "true",
 				"CL2_MY_PARAM3": "99.99",
 				"CL2_MY_PARAM4": "XXX",
+				"CL2_MY_PARAM5": "1",
 			},
 			wantedMapping: map[string]interface{}{
 				"CL2_MY_PARAM1": int64(100),
 				"CL2_MY_PARAM2": true,
 				"CL2_MY_PARAM3": 99.99,
 				"CL2_MY_PARAM4": "XXX",
+				"CL2_MY_PARAM5": int64(1),
 			},
 		},
 		{


### PR DESCRIPTION
Handling `CL2_*` environment variables by cl2 is present in `release-1.18` branch but it's lacking #1263 and #1145 that fix the behavior of parsing those variables when a boolean or a number is expected.

/sig scalability
/cc mm4tt