### PR TITLE
Add AWS S3 functionality for perfdash

### DIFF
--- a/perfdash/Makefile
+++ b/perfdash/Makefile
@@ -5,7 +5,7 @@ TAG = 2.25
 
 REPO = gcr.io/k8s-testimages
 
-test: perfdash.go parser.go config.go metrics-downloader-helper.go metrics-downloader.go
+test: perfdash.go parser.go config.go metrics-downloader-helper.go metrics-downloader.go gcs_metrics_bucket.go s3_metrics_bucket.go
 	go test
 
 perfdash: test

--- a/perfdash/gcs_metrics_bucket.go
+++ b/perfdash/gcs_metrics_bucket.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"strconv"
+	"strings"
+
+	"cloud.google.com/go/storage"
+	"google.golang.org/api/iterator"
+	"google.golang.org/api/option"
+	"k8s.io/klog"
+)
+
+// GCSMetricsBucket that creates a Google Cloud Storage client to fetch data.
+type GCSMetricsBucket struct {
+	client  *storage.Client
+	bucket  *storage.BucketHandle
+	logPath string
+}
+
+// NewGCSMetricsBucket creates a new GCSMetricsBucket.
+func NewGCSMetricsBucket(bucket, path, credentialPath string) (MetricsBucket, error) {
+	ctx := context.Background()
+	authOpt := option.WithoutAuthentication()
+	if credentialPath != "" {
+		authOpt = option.WithCredentialsFile(credentialPath)
+	}
+	c, err := storage.NewClient(ctx, authOpt)
+	if err != nil {
+		return nil, err
+	}
+	b := c.Bucket(bucket)
+	return &GCSMetricsBucket{
+		client:  c,
+		bucket:  b,
+		logPath: path,
+	}, nil
+}
+
+// GetBuildNumbers fetches the build numbers from a GCS Bucket.
+func (b *GCSMetricsBucket) GetBuildNumbers(job string) ([]int, error) {
+	var builds []int
+	ctx := context.Background()
+	jobPrefix := joinStringsAndInts(b.logPath, job) + "/"
+	klog.Infof("%s", jobPrefix)
+	it := b.bucket.Objects(ctx, &storage.Query{
+		Prefix:    jobPrefix,
+		Delimiter: "/",
+	})
+	for {
+		attrs, err := it.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		if attrs.Prefix == "" {
+			continue
+		}
+		build := strings.TrimPrefix(attrs.Prefix, jobPrefix)
+		build = strings.TrimSuffix(build, "/")
+		buildNo, err := strconv.Atoi(build)
+		if err != nil {
+			return nil, fmt.Errorf("unknown build name convention: %s", build)
+		}
+		builds = append(builds, buildNo)
+	}
+	return builds, nil
+}
+
+// ListFilesInBuild fetches the files in the build from GCS.
+func (b *GCSMetricsBucket) ListFilesInBuild(job string, buildNumber int, prefix string) ([]string, error) {
+	var files []string
+	ctx := context.Background()
+	jobPrefix := joinStringsAndInts(b.logPath, job, buildNumber, prefix)
+	it := b.bucket.Objects(ctx, &storage.Query{
+		Prefix: jobPrefix,
+	})
+	for {
+		attrs, err := it.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+
+		files = append(files, attrs.Name)
+	}
+	return files, nil
+}
+
+// ReadFile reads the file contents from the GCS bucket.
+func (b *GCSMetricsBucket) ReadFile(job string, buildNumber int, path string) ([]byte, error) {
+	ctx := context.Background()
+	filePath := joinStringsAndInts(b.logPath, job, buildNumber, path)
+	rc, err := b.bucket.Object(filePath).NewReader(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer rc.Close()
+
+	data, err := ioutil.ReadAll(rc)
+	if err != nil {
+		return nil, err
+	}
+	return data, nil
+}

--- a/perfdash/go.mod
+++ b/perfdash/go.mod
@@ -4,6 +4,7 @@ go 1.13
 
 require (
 	cloud.google.com/go v0.34.0
+	github.com/aws/aws-sdk-go v1.16.26
 	github.com/ghodss/yaml v0.0.0-20180820084758-c7ce16629ff4
 	github.com/google/martian v2.1.0+incompatible // indirect
 	github.com/googleapis/gax-go v1.0.3 // indirect

--- a/perfdash/go.sum
+++ b/perfdash/go.sum
@@ -23,6 +23,7 @@ github.com/Rican7/retry v0.1.0/go.mod h1:FgOROf8P5bebcC1DS0PdOQiqGUridaZvikzUmkF
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/auth0/go-jwt-middleware v0.0.0-20170425171159-5493cabe49f7/go.mod h1:LWMyo4iOLWXHGdBki7NIht1kHru/0wM179h+d3g8ATM=
+github.com/aws/aws-sdk-go v1.16.26 h1:GWkl3rkRO/JGRTWoLLIqwf7AWC4/W/1hMOUZqmX0js4=
 github.com/aws/aws-sdk-go v1.16.26/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/bazelbuild/bazel-gazelle v0.0.0-20181012220611-c728ce9f663e/go.mod h1:uHBSeeATKpVazAACZBDPL/Nk/UhQDDsJWDlqYJo8/Us=
 github.com/bazelbuild/buildtools v0.0.0-20180226164855-80c7f0d45d7e/go.mod h1:5JP0TXzWDHXv8qvxRC4InIazwdyDseBDbzESUMKk1yU=
@@ -158,6 +159,7 @@ github.com/heketi/utils v0.0.0-20170317161834-435bc5bdfa64/go.mod h1:RYlF4ghFZPP
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
+github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5imkbgOkpRUYLnmbU7UEFbjtDA2hxJ1ichM=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jonboulle/clockwork v0.0.0-20141017032234-72f9bd7c4e0c/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/json-iterator/go v0.0.0-20180612202835-f2b4162afba3/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=

--- a/perfdash/s3_metrics_bucket.go
+++ b/perfdash/s3_metrics_bucket.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"strconv"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"k8s.io/klog"
+)
+
+// S3MetricsBucket that creates a AWS S3 client to fetch data.
+type S3MetricsBucket struct {
+	client  *s3.S3
+	bucket  *string
+	logPath string
+}
+
+// NewS3MetricsBucket creates a new S3MetricsBucket.
+func NewS3MetricsBucket(bucket, pathPrefix, region string) (MetricsBucket, error) {
+	return &S3MetricsBucket{
+		client: s3.New(session.Must(session.NewSession(&aws.Config{
+			Region:                        aws.String(region),
+			CredentialsChainVerboseErrors: aws.Bool(true),
+		}))),
+		bucket:  aws.String(bucket),
+		logPath: pathPrefix,
+	}, nil
+}
+
+// GetBuildNumbers fetches the build numbers from an S3 Bucket.
+func (s *S3MetricsBucket) GetBuildNumbers(job string) ([]int, error) {
+	var builds []int
+	jobPrefix := joinStringsAndInts(s.logPath, job) + "/"
+	klog.Infof("%s", jobPrefix)
+
+	objects, err := s.client.ListObjectsV2(&s3.ListObjectsV2Input{
+		Bucket:    s.bucket,
+		Prefix:    aws.String(jobPrefix),
+		Delimiter: aws.String("/"),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	for _, key := range objects.CommonPrefixes {
+		build := *key.Prefix
+		build = strings.TrimPrefix(build, jobPrefix)
+		build = strings.TrimSuffix(build, "/")
+
+		buildNo, err := strconv.Atoi(build)
+		if err != nil {
+			return nil, fmt.Errorf("unknown build name convention: %s", build)
+		}
+		builds = append(builds, buildNo)
+	}
+
+	return builds, nil
+}
+
+// ListFilesInBuild fetches the files in the build from S3.
+func (s *S3MetricsBucket) ListFilesInBuild(job string, buildNumber int, prefix string) ([]string, error) {
+	var files []string
+	jobPrefix := joinStringsAndInts(s.logPath, job, buildNumber, prefix)
+
+	if err := s.client.ListObjectsV2Pages(&s3.ListObjectsV2Input{Bucket: s.bucket, Prefix: aws.String(jobPrefix)},
+		func(objects *s3.ListObjectsV2Output, lastPage bool) bool {
+			for _, key := range objects.Contents {
+				files = append(files, *key.Key)
+			}
+			return true
+		}); err != nil {
+		return nil, fmt.Errorf("while listing objects %v", err.Error())
+	}
+
+	return files, nil
+}
+
+// ReadFile reads the file contents from the S3 bucket.
+func (s *S3MetricsBucket) ReadFile(job string, buildNumber int, path string) ([]byte, error) {
+	filePath := joinStringsAndInts(s.logPath, job, buildNumber, path)
+
+	resp, err := s.client.GetObject(&s3.GetObjectInput{
+		Bucket: s.bucket,
+		Key:    aws.String(filePath),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+	return ioutil.ReadAll(resp.Body)
+}


### PR DESCRIPTION
In this PR, I added functionality to get data from AWS S3 by:
- adding s3 specific functions to pull build numbers and files from the specified s3 bucket
- adding s3 specific flags (flag to specify region)
- adding mode flag to specify whether to get data from s3 or gcs (the default is gcs)

I also moved s3 and gcs functions to their own files (s3_metrics_bucket.go and gcs_metrics_bucket.go). I tested the changes on local and on an EKS cluster; metrics were successfully pulled from S3 and displayed on perfdash. 😄 