### PR TITLE
Set the verbosity level in the info logs

### DIFF
--- a/clusterloader2/cmd/clusterloader.go
+++ b/clusterloader2/cmd/clusterloader.go
@@ -140,13 +140,13 @@ func completeConfig(m *framework.MultiClientSet) error {
 			return fmt.Errorf("getting number of nodes error: %v", err)
 		}
 		clusterLoaderConfig.ClusterConfig.Nodes = nodes
-		klog.Infof("ClusterConfig.Nodes set to %v", nodes)
+		klog.V(0).Infof("ClusterConfig.Nodes set to %v", nodes)
 	}
 	if clusterLoaderConfig.ClusterConfig.MasterName == "" {
 		masterName, err := util.GetMasterName(m.GetClient())
 		if err == nil {
 			clusterLoaderConfig.ClusterConfig.MasterName = masterName
-			klog.Infof("ClusterConfig.MasterName set to %v", masterName)
+			klog.V(0).Infof("ClusterConfig.MasterName set to %v", masterName)
 		} else {
 			klog.Errorf("Getting master name error: %v", err)
 		}
@@ -155,7 +155,7 @@ func completeConfig(m *framework.MultiClientSet) error {
 		masterIPs, err := util.GetMasterIPs(m.GetClient(), corev1.NodeExternalIP)
 		if err == nil {
 			clusterLoaderConfig.ClusterConfig.MasterIPs = masterIPs
-			klog.Infof("ClusterConfig.MasterIP set to %v", masterIPs)
+			klog.V(0).Infof("ClusterConfig.MasterIP set to %v", masterIPs)
 		} else {
 			klog.Errorf("Getting master external ip error: %v", err)
 		}
@@ -164,7 +164,7 @@ func completeConfig(m *framework.MultiClientSet) error {
 		masterIPs, err := util.GetMasterIPs(m.GetClient(), corev1.NodeInternalIP)
 		if err == nil {
 			clusterLoaderConfig.ClusterConfig.MasterInternalIPs = masterIPs
-			klog.Infof("ClusterConfig.MasterInternalIP set to %v", masterIPs)
+			klog.V(0).Infof("ClusterConfig.MasterInternalIP set to %v", masterIPs)
 		} else {
 			klog.Errorf("Getting master internal ip error: %v", err)
 		}
@@ -207,13 +207,13 @@ func createReportDir() error {
 }
 
 func printTestStart(name string) {
-	klog.Infof(dashLine)
-	klog.Infof("Running %v", name)
-	klog.Infof(dashLine)
+	klog.V(0).Infof(dashLine)
+	klog.V(0).Infof("Running %v", name)
+	klog.V(0).Infof(dashLine)
 }
 
 func printTestResult(name, status, errors string) {
-	logf := klog.Infof
+	logf := klog.V(0).Infof
 	if errors != "" {
 		logf = klog.Errorf
 	}
@@ -253,7 +253,7 @@ func main() {
 		klog.Exitf("Config completing error: %v", err)
 	}
 
-	klog.Infof("Using config: %+v", clusterLoaderConfig)
+	klog.V(0).Infof("Using config: %+v", clusterLoaderConfig)
 
 	if err = createReportDir(); err != nil {
 		klog.Exitf("Cannot create report directory: %v", err)

--- a/clusterloader2/pkg/execservice/exec_service.go
+++ b/clusterloader2/pkg/execservice/exec_service.go
@@ -57,9 +57,9 @@ func SetUpExecService(f *framework.Framework) error {
 	lock.Lock()
 	defer lock.Unlock()
 	if podStore != nil {
-		klog.Infof("%s: service already running!", execServiceName)
+		klog.V(3).Infof("%s: service already running!", execServiceName)
 	}
-	klog.Infof("%v: setting up service!", execServiceName)
+	klog.V(2).Infof("%v: setting up service!", execServiceName)
 	mapping := make(map[string]interface{})
 	mapping["Name"] = execDeploymentName
 	mapping["Namespace"] = execDeploymentNamespace
@@ -96,7 +96,7 @@ func SetUpExecService(f *framework.Framework) error {
 	if err != nil {
 		return fmt.Errorf("pod store creation error: %v", err)
 	}
-	klog.Infof("%v: service set up successfully!", execServiceName)
+	klog.V(2).Infof("%v: service set up successfully!", execServiceName)
 	return nil
 }
 
@@ -104,7 +104,7 @@ func SetUpExecService(f *framework.Framework) error {
 func TearDownExecService(f *framework.Framework) error {
 	lock.Lock()
 	defer lock.Unlock()
-	klog.Infof("%v: tearing down service", execServiceName)
+	klog.V(2).Infof("%v: tearing down service", execServiceName)
 	if podStore != nil {
 		podStore.Stop()
 		podStore = nil

--- a/clusterloader2/pkg/framework/framework.go
+++ b/clusterloader2/pkg/framework/framework.go
@@ -236,7 +236,7 @@ func (f *Framework) ApplyTemplatedManifests(manifestGlob string, templateMapping
 		klog.Warningf("There is no matching file for pattern %v.\n", manifestGlob)
 	}
 	for _, manifest := range manifests {
-		klog.Infof("Applying %s\n", manifest)
+		klog.V(1).Infof("Applying %s\n", manifest)
 		obj, err := templateProvider.TemplateToObject(filepath.Base(manifest), templateMapping)
 		if err != nil {
 			if err == config.ErrorEmptyFile {

--- a/clusterloader2/pkg/measurement/common/etcd_metrics.go
+++ b/clusterloader2/pkg/measurement/common/etcd_metrics.go
@@ -64,7 +64,7 @@ func (e *etcdMetricsMeasurement) Execute(config *measurement.Config) ([]measurem
 	provider := config.ClusterFramework.GetClusterConfig().Provider
 	// Etcd is only exposed on localhost level. We are using ssh method
 	if !provider.Features().SupportSSHToMaster {
-		klog.Infof("not grabbing etcd metrics through master SSH: unsupported for provider, %s", config.ClusterFramework.GetClusterConfig().Provider.Name())
+		klog.Warningf("not grabbing etcd metrics through master SSH: unsupported for provider, %s", config.ClusterFramework.GetClusterConfig().Provider.Name())
 		return nil, nil
 	}
 
@@ -82,7 +82,7 @@ func (e *etcdMetricsMeasurement) Execute(config *measurement.Config) ([]measurem
 	etcdInsecurePort := config.ClusterFramework.GetClusterConfig().EtcdInsecurePort
 	switch action {
 	case "start":
-		klog.Infof("%s: starting etcd metrics collecting...", e)
+		klog.V(2).Infof("%s: starting etcd metrics collecting...", e)
 		waitTime, err := util.GetDurationOrDefault(config.Params, "waitTime", time.Minute)
 		if err != nil {
 			return nil, err

--- a/clusterloader2/pkg/measurement/common/exec.go
+++ b/clusterloader2/pkg/measurement/common/exec.go
@@ -68,12 +68,12 @@ func (e *execMeasurement) Execute(config *measurement.Config) ([]measurement.Sum
 	for i := range command {
 		command[i] = os.ExpandEnv(command[i])
 	}
-	klog.Infof("Running %v with timeout %v", command, timeout)
+	klog.V(2).Infof("Running %v with timeout %v", command, timeout)
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, command[0], command[1:]...)
 	out, err := cmd.CombinedOutput()
-	klog.Infof("output: %v", string(out))
+	klog.V(3).Infof("output: %v", string(out))
 	if err != nil {
 		return nil, fmt.Errorf("command %v failed: %v", command, err)
 	}

--- a/clusterloader2/pkg/measurement/common/ooms_tracker.go
+++ b/clusterloader2/pkg/measurement/common/ooms_tracker.go
@@ -83,7 +83,7 @@ func (m *clusterOOMsTrackerMeasurement) Execute(config *measurement.Config) ([]m
 		return nil, fmt.Errorf("problem with getting %s param: %w", clusterOOMsTrackerEnabledParamName, err)
 	}
 	if !clusterOOMsTrackerEnabled {
-		klog.Info("skipping tracking of OOMs in the cluster")
+		klog.V(1).Info("skipping tracking of OOMs in the cluster")
 		return nil, nil
 	}
 
@@ -117,10 +117,10 @@ func (m *clusterOOMsTrackerMeasurement) String() string {
 
 func (m *clusterOOMsTrackerMeasurement) start(config *measurement.Config) error {
 	if m.isRunning {
-		klog.Infof("%s: cluster OOMs tracking measurement already running", m)
+		klog.V(2).Infof("%s: cluster OOMs tracking measurement already running", m)
 		return nil
 	}
-	klog.Infof("%s: starting cluster OOMs tracking measurement...", m)
+	klog.V(2).Infof("%s: starting cluster OOMs tracking measurement...", m)
 	if err := m.initFields(config); err != nil {
 		return fmt.Errorf("problem with OOMs tracking measurement fields initialization: %w", err)
 	}
@@ -170,7 +170,7 @@ func (m *clusterOOMsTrackerMeasurement) stop() {
 }
 
 func (m *clusterOOMsTrackerMeasurement) gather() ([]measurement.Summary, error) {
-	klog.Infof("%s: gathering cluster OOMs tracking measurement", clusterOOMsTrackerName)
+	klog.V(2).Infof("%s: gathering cluster OOMs tracking measurement", clusterOOMsTrackerName)
 	if !m.isRunning {
 		return nil, fmt.Errorf("measurement %s has not been started", clusterOOMsTrackerName)
 	}

--- a/clusterloader2/pkg/measurement/common/probes/probes.go
+++ b/clusterloader2/pkg/measurement/common/probes/probes.go
@@ -99,7 +99,7 @@ type probesMeasurement struct {
 // - gather - Gathers and prints metrics.
 func (p *probesMeasurement) Execute(config *measurement.Config) ([]measurement.Summary, error) {
 	if !config.CloudProvider.Features().SupportProbe {
-		klog.Infof("%s: Probes cannot work in %s, skipping the measurement!", p, config.CloudProvider.Name())
+		klog.V(1).Infof("%s: Probes cannot work in %s, skipping the measurement!", p, config.CloudProvider.Name())
 		return nil, nil
 	}
 	if config.PrometheusFramework == nil {
@@ -128,10 +128,10 @@ func (p *probesMeasurement) Execute(config *measurement.Config) ([]measurement.S
 // Dispose cleans up after the measurement.
 func (p *probesMeasurement) Dispose() {
 	if p.framework == nil {
-		klog.Infof("Probe %s wasn't started, skipping the Dispose() step", p)
+		klog.V(1).Infof("Probe %s wasn't started, skipping the Dispose() step", p)
 		return
 	}
-	klog.Infof("Stopping %s probe...", p)
+	klog.V(2).Infof("Stopping %s probe...", p)
 	k8sClient := p.framework.GetClientSets().GetClient()
 	if err := client.DeleteNamespace(k8sClient, probesNamespace); err != nil {
 		klog.Errorf("error while deleting %s namespace: %v", probesNamespace, err)
@@ -158,7 +158,7 @@ func (p *probesMeasurement) initialize(config *measurement.Config) error {
 }
 
 func (p *probesMeasurement) start(config *measurement.Config) error {
-	klog.Infof("Starting %s probe...", p)
+	klog.V(2).Infof("Starting %s probe...", p)
 	if !p.startTime.IsZero() {
 		return fmt.Errorf("measurement %s cannot be started twice", p)
 	}
@@ -180,7 +180,7 @@ func (p *probesMeasurement) start(config *measurement.Config) error {
 }
 
 func (p *probesMeasurement) gather(params map[string]interface{}) (measurement.Summary, error) {
-	klog.Info("Gathering metrics from probes...")
+	klog.V(2).Info("Gathering metrics from probes...")
 	if p.startTime.IsZero() {
 		return nil, fmt.Errorf("measurement %s has not been started", p)
 	}
@@ -211,7 +211,7 @@ func (p *probesMeasurement) gather(params map[string]interface{}) (measurement.S
 			prefix = " WARNING"
 		}
 	}
-	klog.Infof("%s:%s got %v%s", p, prefix, latency, suffix)
+	klog.V(2).Infof("%s:%s got %v%s", p, prefix, latency, suffix)
 
 	summary, err := p.createSummary(*latency)
 	if err != nil {
@@ -225,7 +225,7 @@ func (p *probesMeasurement) createProbesObjects() error {
 }
 
 func (p *probesMeasurement) waitForProbesReady(config *measurement.Config) error {
-	klog.Infof("Waiting for Probe %s to become ready...", p)
+	klog.V(2).Infof("Waiting for Probe %s to become ready...", p)
 	checkProbesReadyTimeout, err := util.GetDurationOrDefault(config.Params, "checkProbesReadyTimeout", defaultCheckProbesReadyTimeout)
 	if err != nil {
 		return err

--- a/clusterloader2/pkg/measurement/common/profile.go
+++ b/clusterloader2/pkg/measurement/common/profile.go
@@ -161,7 +161,7 @@ func (p *profileMeasurement) Execute(config *measurement.Config) ([]measurement.
 	switch action {
 	case "start":
 		if p.isRunning {
-			klog.Infof("%s: measurement already running", p)
+			klog.V(2).Infof("%s: measurement already running", p)
 			return nil, nil
 		}
 		return nil, p.start(config, SSHToMasterSupported)
@@ -244,7 +244,7 @@ func (p *profileMeasurement) getProfileCommand(config *measurement.Config) (stri
 }
 
 func exposeAPIServerDebugEndpoint(c clientset.Interface) error {
-	klog.Info("Exposing kube-apiserver debug endpoint for anonymous access")
+	klog.V(2).Info("Exposing kube-apiserver debug endpoint for anonymous access")
 	createClusterRole := func() error {
 		_, err := c.RbacV1().ClusterRoles().Create(context.TODO(), &rbacv1.ClusterRole{
 			ObjectMeta: metav1.ObjectMeta{Name: "apiserver-debug-viewer"},

--- a/clusterloader2/pkg/measurement/common/resource_usage.go
+++ b/clusterloader2/pkg/measurement/common/resource_usage.go
@@ -106,7 +106,7 @@ func (e *resourceUsageMetricMeasurement) Execute(config *measurement.Config) ([]
 			nodesSet = gatherers.AllNodes
 		}
 
-		klog.Infof("%s: starting resource usage collecting...", e)
+		klog.V(2).Infof("%s: starting resource usage collecting...", e)
 		e.gatherer, err = gatherers.NewResourceUsageGatherer(config.ClusterFramework.GetClientSets().GetClient(), host, config.ClusterFramework.GetClusterConfig().KubeletPort,
 			provider, gatherers.ResourceGathererOptions{
 				InKubemark:                        provider.Name() == "kubemark",
@@ -124,7 +124,7 @@ func (e *resourceUsageMetricMeasurement) Execute(config *measurement.Config) ([]
 			klog.Errorf("%s: gatherer not initialized", e)
 			return nil, nil
 		}
-		klog.Infof("%s: gathering resource usage...", e)
+		klog.V(2).Infof("%s: gathering resource usage...", e)
 		summary, err := e.gatherer.StopAndSummarize([]int{50, 90, 99, 100})
 		if err != nil {
 			return nil, err

--- a/clusterloader2/pkg/measurement/common/scheduler_latency.go
+++ b/clusterloader2/pkg/measurement/common/scheduler_latency.go
@@ -103,7 +103,7 @@ func (s *schedulerLatencyMeasurement) Execute(config *measurement.Config) ([]mea
 	}
 
 	if !SSHToMasterSupported && !masterRegistered {
-		klog.Infof("unable to fetch scheduler metrics for provider: %s", provider.Name())
+		klog.Warningf("unable to fetch scheduler metrics for provider: %s", provider.Name())
 		return nil, nil
 	}
 
@@ -122,13 +122,13 @@ func (s *schedulerLatencyMeasurement) Execute(config *measurement.Config) ([]mea
 
 	switch action {
 	case "reset":
-		klog.Infof("%s: start collecting latency initial metrics in scheduler...", s)
+		klog.V(2).Infof("%s: start collecting latency initial metrics in scheduler...", s)
 		return nil, s.getSchedulingInitialLatency(config.ClusterFramework.GetClientSets().GetClient(), masterIP, provider, masterName, masterRegistered)
 	case "start":
-		klog.Infof("%s: start collecting latency metrics in scheduler...", s)
+		klog.V(2).Infof("%s: start collecting latency metrics in scheduler...", s)
 		return nil, s.getSchedulingInitialLatency(config.ClusterFramework.GetClientSets().GetClient(), masterIP, provider, masterName, masterRegistered)
 	case "gather":
-		klog.Infof("%s: gathering latency metrics in scheduler...", s)
+		klog.V(2).Infof("%s: gathering latency metrics in scheduler...", s)
 		return s.getSchedulingLatency(config.ClusterFramework.GetClientSets().GetClient(), masterIP, provider, masterName, masterRegistered)
 	default:
 		return nil, fmt.Errorf("unknown action %v", action)

--- a/clusterloader2/pkg/measurement/common/scheduling_throughput.go
+++ b/clusterloader2/pkg/measurement/common/scheduling_throughput.go
@@ -64,7 +64,7 @@ func (s *schedulingThroughputMeasurement) Execute(config *measurement.Config) ([
 	switch action {
 	case "start":
 		if s.isRunning {
-			klog.Infof("%s: measurement already running", s)
+			klog.V(3).Infof("%s: measurement already running", s)
 			return nil, nil
 		}
 		selector := measurementutil.NewObjectSelector()
@@ -104,7 +104,7 @@ func (s *schedulingThroughputMeasurement) start(clientSet clientset.Interface, s
 		return fmt.Errorf("pod store creation error: %v", err)
 	}
 	s.isRunning = true
-	klog.Infof("%s: starting collecting throughput data", s)
+	klog.V(2).Infof("%s: starting collecting throughput data", s)
 
 	go func() {
 		defer ps.Stop()
@@ -119,7 +119,7 @@ func (s *schedulingThroughputMeasurement) start(clientSet clientset.Interface, s
 				throughput := float64(podsStatus.Scheduled-lastScheduledCount) / float64(measurmentInterval/time.Second)
 				s.schedulingThroughputs = append(s.schedulingThroughputs, throughput)
 				lastScheduledCount = podsStatus.Scheduled
-				klog.Infof("%v: %s: %d pods scheduled", s, selector.String(), lastScheduledCount)
+				klog.V(3).Infof("%v: %s: %d pods scheduled", s, selector.String(), lastScheduledCount)
 			}
 		}
 	}()
@@ -132,7 +132,7 @@ func (s *schedulingThroughputMeasurement) gather(threshold float64) ([]measureme
 		return nil, fmt.Errorf("measurement is not running")
 	}
 	s.stop()
-	klog.Infof("%s: gathering data", s)
+	klog.V(2).Infof("%s: gathering data", s)
 
 	throughputSummary := &schedulingThroughput{}
 	if length := len(s.schedulingThroughputs); length > 0 {

--- a/clusterloader2/pkg/measurement/common/service_creation_latency.go
+++ b/clusterloader2/pkg/measurement/common/service_creation_latency.go
@@ -126,10 +126,10 @@ func (s *serviceCreationLatencyMeasurement) String() string {
 
 func (s *serviceCreationLatencyMeasurement) start() error {
 	if s.isRunning {
-		klog.Infof("%s: service creation latency measurement already running", s)
+		klog.V(2).Infof("%s: service creation latency measurement already running", s)
 		return nil
 	}
-	klog.Infof("%s: starting service creation latency measurement...", s)
+	klog.V(2).Infof("%s: starting service creation latency measurement...", s)
 
 	s.isRunning = true
 	s.stopCh = make(chan struct{})
@@ -153,7 +153,7 @@ func (s *serviceCreationLatencyMeasurement) waitForReady() error {
 		for _, svcType := range []corev1.ServiceType{corev1.ServiceTypeClusterIP, corev1.ServiceTypeNodePort, corev1.ServiceTypeLoadBalancer} {
 			reachable := s.creationTimes.Count(phaseName(reachabilityPhase, svcType))
 			created := s.creationTimes.Count(phaseName(creatingPhase, svcType))
-			klog.Infof("%s type %s: %d created, %d reachable", s, svcType, created, reachable)
+			klog.V(2).Infof("%s type %s: %d created, %d reachable", s, svcType, created, reachable)
 			if created != reachable {
 				return false, nil
 			}
@@ -163,7 +163,7 @@ func (s *serviceCreationLatencyMeasurement) waitForReady() error {
 }
 
 func (s *serviceCreationLatencyMeasurement) gather(identifier string) ([]measurement.Summary, error) {
-	klog.Infof("%s: gathering service created latency measurement...", s)
+	klog.V(2).Infof("%s: gathering service created latency measurement...", s)
 	if !s.isRunning {
 		return nil, fmt.Errorf("metric %s has not been started", s)
 	}

--- a/clusterloader2/pkg/measurement/common/slos/api_responsiveness_prometheus.go
+++ b/clusterloader2/pkg/measurement/common/slos/api_responsiveness_prometheus.go
@@ -241,7 +241,7 @@ func getCustomThresholds(config *measurement.Config, metrics *apiCallMetrics) (c
 		}
 		key := entry.getKey()
 		if _, ok := metrics.metrics[key]; !ok {
-			klog.Infof("WARNING: unrecognized custom threshold API call key: %v", key)
+			klog.V(1).Infof("WARNING: unrecognized custom threshold API call key: %v", key)
 		} else {
 			customThresholds[key] = entry.Threshold
 		}
@@ -270,7 +270,7 @@ func (a *apiResponsivenessGatherer) validateAPICalls(identifier string, allowedS
 			if err != nil {
 				prefix = "WARNING "
 			}
-			klog.Infof("%s: %vTop latency metric: %+v; threshold: %v", identifier, prefix, *apiCall, threshold)
+			klog.V(2).Infof("%s: %vTop latency metric: %+v; threshold: %v", identifier, prefix, *apiCall, threshold)
 		}
 	}
 	return badMetrics

--- a/clusterloader2/pkg/measurement/common/slos/api_responsiveness_prometheus_test.go
+++ b/clusterloader2/pkg/measurement/common/slos/api_responsiveness_prometheus_test.go
@@ -47,6 +47,7 @@ func turnOffLoggingToStderrInKlog() {
 	if klogLogToStderr {
 		klog.InitFlags(nil)
 		flag.Set("logtostderr", "false")
+		flag.Set("v", "2")
 		flag.Parse()
 		klogLogToStderr = false
 	}

--- a/clusterloader2/pkg/measurement/common/slos/network_programming.go
+++ b/clusterloader2/pkg/measurement/common/slos/network_programming.go
@@ -62,7 +62,7 @@ func (n *netProgGatherer) Gather(executor QueryExecutor, startTime time.Time, co
 		return nil, err
 	}
 
-	klog.Infof("%s: got %v", netProg, latency)
+	klog.V(2).Infof("%s: got %v", netProg, latency)
 	summary, err := n.createSummary(latency)
 	return []measurement.Summary{summary}, err
 }

--- a/clusterloader2/pkg/measurement/common/slos/pod_startup_latency.go
+++ b/clusterloader2/pkg/measurement/common/slos/pod_startup_latency.go
@@ -104,10 +104,10 @@ func (p *podStartupLatencyMeasurement) String() string {
 
 func (p *podStartupLatencyMeasurement) start(c clientset.Interface) error {
 	if p.isRunning {
-		klog.Infof("%s: pod startup latancy measurement already running", p)
+		klog.V(2).Infof("%s: pod startup latancy measurement already running", p)
 		return nil
 	}
-	klog.Infof("%s: starting pod startup latency measurement...", p)
+	klog.V(2).Infof("%s: starting pod startup latency measurement...", p)
 	p.isRunning = true
 	p.stopCh = make(chan struct{})
 	i := informer.NewInformer(
@@ -127,7 +127,7 @@ func (p *podStartupLatencyMeasurement) stop() {
 }
 
 func (p *podStartupLatencyMeasurement) gather(c clientset.Interface, identifier string) ([]measurement.Summary, error) {
-	klog.Infof("%s: gathering pod startup latency measurement...", p)
+	klog.V(2).Infof("%s: gathering pod startup latency measurement...", p)
 	if !p.isRunning {
 		return nil, fmt.Errorf("metric %s has not been started", podStartupLatencyMeasurementName)
 	}

--- a/clusterloader2/pkg/measurement/common/slos/prometheus_measurement.go
+++ b/clusterloader2/pkg/measurement/common/slos/prometheus_measurement.go
@@ -72,11 +72,11 @@ func (m *prometheusMeasurement) Execute(config *measurement.Config) ([]measureme
 
 	switch action {
 	case "start":
-		klog.Infof("%s has started", config.Identifier)
+		klog.V(2).Infof("%s has started", config.Identifier)
 		m.startTime = time.Now()
 		return nil, nil
 	case "gather":
-		klog.Infof("%s gathering results", config.Identifier)
+		klog.V(2).Infof("%s gathering results", config.Identifier)
 		enableViolations, err := util.GetBoolOrDefault(config.Params, "enableViolations", false)
 		if err != nil {
 			return nil, err

--- a/clusterloader2/pkg/measurement/common/system_pod_metrics.go
+++ b/clusterloader2/pkg/measurement/common/system_pod_metrics.go
@@ -80,7 +80,7 @@ func (m *systemPodMetricsMeasurement) Execute(config *measurement.Config) ([]mea
 		return nil, err
 	}
 	if !systemPodMetricsEnabled {
-		klog.Info("skipping collection of system pod metrics")
+		klog.V(2).Info("skipping collection of system pod metrics")
 		return []measurement.Summary{}, nil
 	}
 
@@ -122,7 +122,7 @@ func (m *systemPodMetricsMeasurement) Execute(config *measurement.Config) ([]mea
 }
 
 func getPodMetrics(config *measurement.Config) (*systemPodsMetrics, error) {
-	klog.Info("collecting system pod metrics...")
+	klog.V(2).Info("collecting system pod metrics...")
 	lst, err := getPodList(config.ClusterFramework.GetClientSets().GetClient())
 	if err != nil {
 		return &systemPodsMetrics{}, err
@@ -226,7 +226,7 @@ func getThresholdOverrides(config *measurement.Config) (map[string]int, error) {
 	if err != nil {
 		return nil, err
 	}
-	klog.Infof("Loaded restart count threshold overrides: %v", parsed)
+	klog.V(2).Infof("Loaded restart count threshold overrides: %v", parsed)
 	return parsed, nil
 }
 

--- a/clusterloader2/pkg/measurement/common/timer.go
+++ b/clusterloader2/pkg/measurement/common/timer.go
@@ -79,7 +79,7 @@ func (t *timer) Execute(config *measurement.Config) ([]measurement.Summary, erro
 			return nil, fmt.Errorf("uninitialized timer %s", label)
 		}
 		duration := time.Since(startTime)
-		klog.Infof("%s: %s - %v", t, label, duration)
+		klog.V(0).Infof("%s: %s - %v", t, label, duration)
 		t.durations[label] = duration
 		delete(t.startTimes, label)
 	case "gather":

--- a/clusterloader2/pkg/measurement/common/wait_for_controlled_pods.go
+++ b/clusterloader2/pkg/measurement/common/wait_for_controlled_pods.go
@@ -157,10 +157,10 @@ func (*waitForControlledPodsRunningMeasurement) String() string {
 
 func (w *waitForControlledPodsRunningMeasurement) start() error {
 	if w.isRunning {
-		klog.Infof("%v: wait for controlled pods measurement already running", w)
+		klog.V(2).Infof("%v: wait for controlled pods measurement already running", w)
 		return nil
 	}
-	klog.Infof("%v: starting wait for controlled pods measurement...", w)
+	klog.V(2).Infof("%v: starting wait for controlled pods measurement...", w)
 	gv, err := schema.ParseGroupVersion(w.apiVersion)
 	if err != nil {
 		return err
@@ -185,7 +185,7 @@ func (w *waitForControlledPodsRunningMeasurement) start() error {
 }
 
 func (w *waitForControlledPodsRunningMeasurement) gather(syncTimeout time.Duration) error {
-	klog.Infof("%v: waiting for controlled pods measurement...", w)
+	klog.V(2).Infof("%v: waiting for controlled pods measurement...", w)
 	if !w.isRunning {
 		return fmt.Errorf("metric %s has not been started", w)
 	}
@@ -243,7 +243,7 @@ func (w *waitForControlledPodsRunningMeasurement) gather(syncTimeout time.Durati
 			}
 		}
 	}
-	klog.Infof("%s: running %d, deleted %d, timeout: %d, unknown: %d", w, numberRunning, numberDeleted, numberTimeout, numberUnknown)
+	klog.V(2).Infof("%s: running %d, deleted %d, timeout: %d, unknown: %d", w, numberRunning, numberDeleted, numberTimeout, numberUnknown)
 	if numberTimeout > 0 {
 		klog.Errorf("Timed out %ss: %s", w.kind, strings.Join(timedOutObjects, ", "))
 		return fmt.Errorf("%d objects timed out: %ss: %s", numberTimeout, w.kind, strings.Join(timedOutObjects, ", "))
@@ -257,7 +257,7 @@ func (w *waitForControlledPodsRunningMeasurement) gather(syncTimeout time.Durati
 		return fmt.Errorf("unknown objects statuses: %v", unknowStatusErrList.String())
 	}
 
-	klog.Infof("%s: %d/%d %ss are running with all pods", w, numberRunning, objectKeys.Len(), w.kind)
+	klog.V(2).Infof("%s: %d/%d %ss are running with all pods", w, numberRunning, objectKeys.Len(), w.kind)
 	return nil
 }
 

--- a/clusterloader2/pkg/measurement/util/gatherers/container_resource_gatherer.go
+++ b/clusterloader2/pkg/measurement/util/gatherers/container_resource_gatherer.go
@@ -189,7 +189,7 @@ func (g *ContainerResourceGatherer) StartGatheringData() {
 // generates resource summary for the passed-in percentiles, and returns the summary.
 func (g *ContainerResourceGatherer) StopAndSummarize(percentiles []int) (*ResourceUsageSummary, error) {
 	g.stop()
-	klog.Infof("Closed stop channel. Waiting for %v workers", len(g.workers))
+	klog.V(2).Infof("Closed stop channel. Waiting for %v workers", len(g.workers))
 	finished := make(chan struct{})
 	go func() {
 		g.workerWg.Wait()
@@ -197,7 +197,7 @@ func (g *ContainerResourceGatherer) StopAndSummarize(percentiles []int) (*Resour
 	}()
 	select {
 	case <-finished:
-		klog.Infof("Waitgroup finished.")
+		klog.V(2).Infof("Waitgroup finished.")
 	case <-time.After(2 * time.Minute):
 		unfinished := make([]string, 0)
 		for i := range g.workers {
@@ -205,11 +205,11 @@ func (g *ContainerResourceGatherer) StopAndSummarize(percentiles []int) (*Resour
 				unfinished = append(unfinished, g.workers[i].nodeName)
 			}
 		}
-		klog.Infof("Timed out while waiting for waitgroup, some workers failed to finish: %v", unfinished)
+		klog.V(1).Infof("Timed out while waiting for waitgroup, some workers failed to finish: %v", unfinished)
 	}
 
 	if len(percentiles) == 0 {
-		klog.Infof("Warning! Empty percentile list for stopAndPrintData.")
+		klog.Warningf("Empty percentile list for stopAndPrintData.")
 		return &ResourceUsageSummary{}, fmt.Errorf("failed to get any resource usage data")
 	}
 	data := make(map[int]util.ResourceUsagePerContainer)

--- a/clusterloader2/pkg/measurement/util/phase_latency.go
+++ b/clusterloader2/pkg/measurement/util/phase_latency.go
@@ -132,7 +132,7 @@ func (o *ObjectTransitionTimes) printLatencies(latencies []LatencyData, header s
 	if threshold != time.Duration(0) {
 		thresholdString = fmt.Sprintf("; threshold %v", threshold)
 	}
-	klog.Infof("%s: perc50: %v, perc90: %v, perc99: %v%s", o.name, metrics.Perc50, metrics.Perc90, metrics.Perc99, thresholdString)
+	klog.V(0).Infof("%s: perc50: %v, perc90: %v, perc99: %v%s", o.name, metrics.Perc50, metrics.Perc90, metrics.Perc99, thresholdString)
 }
 
 type latencyData struct {

--- a/clusterloader2/pkg/measurement/util/prometheus.go
+++ b/clusterloader2/pkg/measurement/util/prometheus.go
@@ -106,7 +106,7 @@ func (e *PrometheusQueryExecutor) Query(query string, queryTime time.Time) ([]*m
 		"query": query,
 		"time":  queryTime.Format(time.RFC3339),
 	}
-	klog.Infof("Executing %q at %v", query, queryTime.Format(time.RFC3339))
+	klog.V(2).Infof("Executing %q at %v", query, queryTime.Format(time.RFC3339))
 	if err := wait.PollImmediate(queryInterval, queryTimeout, func() (bool, error) {
 		body, queryErr = e.client.CoreV1().
 			Services("monitoring").

--- a/clusterloader2/pkg/measurement/util/wait_for_pods.go
+++ b/clusterloader2/pkg/measurement/util/wait_for_pods.go
@@ -71,7 +71,7 @@ func WaitForPods(clientSet clientset.Interface, stopCh <-chan struct{}, options 
 	for {
 		select {
 		case <-stopCh:
-			klog.Infof("%s: %s: pods status: %v", options.CallerName, options.Selector.String(), ComputePodsStatus(oldPods, options.DesiredPodCount))
+			klog.V(2).Infof("%s: %s: pods status: %v", options.CallerName, options.Selector.String(), ComputePodsStatus(oldPods, options.DesiredPodCount))
 			return fmt.Errorf("timeout while waiting for %d pods to be running in namespace '%v' with labels '%v' and fields '%v' - only %d found running",
 				options.DesiredPodCount, options.Selector.Namespace, options.Selector.LabelSelector, options.Selector.FieldSelector, podsStatus.Running)
 		case <-time.After(options.WaitForPodsInterval):

--- a/clusterloader2/pkg/modifier/modifier.go
+++ b/clusterloader2/pkg/modifier/modifier.go
@@ -64,7 +64,7 @@ func (m *simpleModifier) modifySkipSteps(c *api.Config) {
 		for _, i := range m.skipSteps {
 			if i == s.Name {
 				ignored = true
-				klog.Infof("Ignoring step %s", s.Name)
+				klog.V(3).Infof("Ignoring step %s", s.Name)
 				break
 			}
 		}
@@ -115,17 +115,17 @@ func (m *simpleModifier) overwriteValue(node reflect.Value, v, k string) error {
 		if err != nil {
 			return fmt.Errorf("test config overwrite error: Cannot parse '%s' for key '%s' to bool: %v", v, k, err)
 		}
-		klog.Infof("Setting bool value '%t' for key '%s'", boolV, k)
+		klog.V(2).Infof("Setting bool value '%t' for key '%s'", boolV, k)
 		node.SetBool(boolV)
 	case reflect.String:
-		klog.Infof("Setting string value '%s' for key '%s'", v, k)
+		klog.V(2).Infof("Setting string value '%s' for key '%s'", v, k)
 		node.SetString(v)
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 		intV, err := strconv.ParseInt(v, 10, node.Type().Bits())
 		if err != nil {
 			return fmt.Errorf("test config overwrite error: Cannot parse '%s' for key '%s' to int: %v", v, k, err)
 		}
-		klog.Infof("Setting int value '%d' for key '%s'", intV, k)
+		klog.V(2).Infof("Setting int value '%d' for key '%s'", intV, k)
 		node.SetInt(intV)
 	default:
 		return fmt.Errorf("unsupported kind: %v for key %s", node.Kind(), k)

--- a/clusterloader2/pkg/prometheus/gce_windows_util.go
+++ b/clusterloader2/pkg/prometheus/gce_windows_util.go
@@ -78,7 +78,7 @@ func installWmiExporter(k8sClient kubernetes.Interface, windowsNode *gceNode, ma
 	if windowsNode == nil {
 		return fmt.Errorf("no windows nodes available to install wmi exporter")
 	}
-	klog.Infof("Installing wmi exporter onto projectId: %s, zone: %s, nodeName: %s with cmd: %s", windowsNode.projectID, windowsNode.zone, windowsNode.nodeName, installWmiExporterCmd)
+	klog.V(2).Infof("Installing wmi exporter onto projectId: %s, zone: %s, nodeName: %s with cmd: %s", windowsNode.projectID, windowsNode.zone, windowsNode.nodeName, installWmiExporterCmd)
 	cmd := exec.Command("gcloud", "compute", "ssh", "--project", windowsNode.projectID, "--zone", windowsNode.zone, windowsNode.nodeName, "--command", powershellCmd)
 	err := cmd.Run()
 	if err != nil {

--- a/clusterloader2/pkg/prometheus/util.go
+++ b/clusterloader2/pkg/prometheus/util.go
@@ -82,7 +82,7 @@ func CheckTargetsReady(k8sClient kubernetes.Interface, selector func(Target) boo
 		exampleNotReadyTarget = t
 	}
 	if nTotal < minActiveTargets {
-		klog.Infof("Not enough active targets (%d), expected at least (%d), waiting for more to become active...",
+		klog.V(2).Infof("Not enough active targets (%d), expected at least (%d), waiting for more to become active...",
 			nTotal, minActiveTargets)
 		return false, nil
 	}
@@ -90,10 +90,10 @@ func CheckTargetsReady(k8sClient kubernetes.Interface, selector func(Target) boo
 		minReadyTargets = nTotal
 	}
 	if nReady < minReadyTargets {
-		klog.Infof("%d/%d targets are ready, example not ready target: %v", nReady, minReadyTargets, exampleNotReadyTarget)
+		klog.V(2).Infof("%d/%d targets are ready, example not ready target: %v", nReady, minReadyTargets, exampleNotReadyTarget)
 		return false, nil
 	}
-	klog.Infof("All %d expected targets are ready", minReadyTargets)
+	klog.V(2).Infof("All %d expected targets are ready", minReadyTargets)
 	return true, nil
 }
 

--- a/clusterloader2/pkg/test/simple_test_executor.go
+++ b/clusterloader2/pkg/test/simple_test_executor.go
@@ -53,7 +53,7 @@ func createSimpleExecutor() Executor {
 // ExecuteTest executes test based on provided configuration.
 func (ste *simpleExecutor) ExecuteTest(ctx Context, conf *api.Config) *errors.ErrorList {
 	ctx.GetClusterFramework().SetAutomanagedNamespacePrefix(conf.Namespace.Prefix)
-	klog.Infof("AutomanagedNamespacePrefix: %s", ctx.GetClusterFramework().GetAutomanagedNamespacePrefix())
+	klog.V(2).Infof("AutomanagedNamespacePrefix: %s", ctx.GetClusterFramework().GetAutomanagedNamespacePrefix())
 
 	defer cleanupResources(ctx, conf)
 	ctx.GetFactory().Init(conf.TuningSets)
@@ -69,14 +69,14 @@ func (ste *simpleExecutor) ExecuteTest(ctx Context, conf *api.Config) *errors.Er
 
 	if chaosMonkeyWaitGroup != nil {
 		// Wait for the Chaos Monkey subroutine to end
-		klog.Info("Waiting for the chaos monkey subroutine to end...")
+		klog.V(2).Info("Waiting for the chaos monkey subroutine to end...")
 		chaosMonkeyWaitGroup.Wait()
-		klog.Info("Chaos monkey ended.")
+		klog.V(2).Info("Chaos monkey ended.")
 	}
 
 	for _, summary := range ctx.GetManager().GetSummaries() {
 		if ctx.GetClusterLoaderConfig().ReportDir == "" {
-			klog.Infof("%v: %v", summary.SummaryName(), summary.SummaryContent())
+			klog.V(2).Infof("%v: %v", summary.SummaryName(), summary.SummaryContent())
 		} else {
 			testDistinctor := ""
 			if ctx.GetClusterLoaderConfig().TestScenario.Identifier != "" {
@@ -91,7 +91,7 @@ func (ste *simpleExecutor) ExecuteTest(ctx Context, conf *api.Config) *errors.Er
 			}
 		}
 	}
-	klog.Infof(ctx.GetChaosMonkey().Summary())
+	klog.V(2).Infof(ctx.GetChaosMonkey().Summary())
 	return errList
 }
 
@@ -132,7 +132,7 @@ func (ste *simpleExecutor) ExecuteTestSteps(ctx Context, conf *api.Config) *erro
 // ExecuteStep executes single test step based on provided step configuration.
 func (ste *simpleExecutor) ExecuteStep(ctx Context, step *api.Step) *errors.ErrorList {
 	if step.Name != "" {
-		klog.Infof("Step %q started", step.Name)
+		klog.V(2).Infof("Step %q started", step.Name)
 	}
 	var wg wait.Group
 	errList := errors.NewErrorList()
@@ -159,7 +159,7 @@ func (ste *simpleExecutor) ExecuteStep(ctx Context, step *api.Step) *errors.Erro
 	}
 	wg.Wait()
 	if step.Name != "" {
-		klog.Infof("Step %q ended", step.Name)
+		klog.V(2).Infof("Step %q ended", step.Name)
 	}
 	if !errList.IsEmpty() {
 		klog.Warningf("Got errors during step execution: %v", errList)
@@ -381,7 +381,7 @@ func cleanupResources(ctx Context, conf *api.Config) {
 			return
 		}
 	}
-	klog.Infof("Resources cleanup time: %v", time.Since(cleanupStartTime))
+	klog.V(2).Infof("Resources cleanup time: %v", time.Since(cleanupStartTime))
 }
 
 func getReplicaCountOfNewObject(ctx Context, namespace string, object *api.Object) (int32, error) {

--- a/clusterloader2/pkg/util/ssh.go
+++ b/clusterloader2/pkg/util/ssh.go
@@ -43,6 +43,6 @@ func (e *GCloudSSHExecutor) Exec(command string, node *v1.Node, stdin io.Reader)
 	cmd := exec.Command("gcloud", "compute", "ssh", "--zone", zone, "--command", command, node.Name)
 	cmd.Stdin = stdin
 	output, err := cmd.CombinedOutput()
-	klog.Infof("ssh to %q finished with %q: %v", node.Name, string(output), err)
+	klog.V(2).Infof("ssh to %q finished with %q: %v", node.Name, string(output), err)
 	return err
 }


### PR DESCRIPTION
According to [sig-instrumentation logging convention](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/logging.md) the `Info` logs was instrumented with the verbosity function. 

Resolves #980 