### PR TITLE
Make schedulerThroughput measurement SLO violation failing a test customizable (release-1.19)

### DIFF
--- a/clusterloader2/pkg/measurement/common/scheduling_throughput.go
+++ b/clusterloader2/pkg/measurement/common/scheduling_throughput.go
@@ -82,7 +82,21 @@ func (s *schedulingThroughputMeasurement) Execute(config *measurement.Config) ([
 		if err != nil {
 			klog.Warningf("error while getting threshold param: %v", err)
 		}
-		return s.gather(threshold)
+		enableViolations, err := util.GetBoolOrDefault(config.Params, "enableViolations", true)
+		if err != nil {
+			klog.Warningf("error while getting enableViolations param: %v", err)
+		}
+		summary, err := s.gather(threshold)
+		if err != nil {
+			if !errors.IsMetricViolationError(err) {
+				klog.Errorf("%s gathering error: %v", config.Identifier, err)
+				return nil, err
+			}
+			if !enableViolations {
+				err = nil
+			}
+		}
+		return summary, err
 	default:
 		return nil, fmt.Errorf("unknown action %v", action)
 	}
@@ -128,7 +142,7 @@ func (s *schedulingThroughputMeasurement) start(clientSet clientset.Interface, s
 
 func (s *schedulingThroughputMeasurement) gather(threshold float64) ([]measurement.Summary, error) {
 	if !s.isRunning {
-		klog.Errorf("%s: measurementis nor running", s)
+		klog.Errorf("%s: measurement is not running", s)
 		return nil, fmt.Errorf("measurement is not running")
 	}
 	s.stop()

--- a/clusterloader2/testing/density/config.yaml
+++ b/clusterloader2/testing/density/config.yaml
@@ -26,6 +26,7 @@
 {{$ENABLE_RESTART_COUNT_CHECK := DefaultParam .ENABLE_RESTART_COUNT_CHECK false}}
 {{$RESTART_COUNT_THRESHOLD_OVERRIDES:= DefaultParam .RESTART_COUNT_THRESHOLD_OVERRIDES ""}}
 {{$ALLOWED_SLOW_API_CALLS := DefaultParam .CL2_ALLOWED_SLOW_API_CALLS 0}}
+{{$ENABLE_VIOLATIONS_FOR_SCHEDULING_THROUGHPUT := DefaultParam .CL2_ENABLE_VIOLATIONS_FOR_SCHEDULING_THROUGHPUT true}}
 #Variables
 {{$namespaces := DivideInt .Nodes $NODES_PER_NAMESPACE}}
 {{$podsPerNamespace := MultiplyInt $PODS_PER_NODE $NODES_PER_NAMESPACE}}
@@ -145,6 +146,7 @@ steps:
     Method: SchedulingThroughput
     Params:
       action: gather
+      enableViolations: {{$ENABLE_VIOLATIONS_FOR_SCHEDULING_THROUGHPUT}}
       threshold: {{$SCHEDULER_THROUGHPUT_THRESHOLD}}
 
 - name: Starting latency pod measurements


### PR DESCRIPTION
Backport of https://github.com/kubernetes/perf-tests/pull/1401.

/sig scalability
/cc jkaniuk
/cc wojtek-t