### PR TITLE
Make schedulerThroughput measurement SLO violation failing a test customizable (release-1.18)

### DIFF
--- a/clusterloader2/testing/density/config.yaml
+++ b/clusterloader2/testing/density/config.yaml
@@ -26,6 +26,7 @@
 {{$ENABLE_RESTART_COUNT_CHECK := DefaultParam .ENABLE_RESTART_COUNT_CHECK false}}
 {{$RESTART_COUNT_THRESHOLD_OVERRIDES:= DefaultParam .RESTART_COUNT_THRESHOLD_OVERRIDES ""}}
 {{$ALLOWED_SLOW_API_CALLS := DefaultParam .CL2_ALLOWED_SLOW_API_CALLS 0}}
+{{$ENABLE_VIOLATIONS_FOR_SCHEDULING_THROUGHPUT := DefaultParam .CL2_ENABLE_VIOLATIONS_FOR_SCHEDULING_THROUGHPUT true}}
 #Variables
 {{$namespaces := DivideInt .Nodes $NODES_PER_NAMESPACE}}
 {{$podsPerNamespace := MultiplyInt $PODS_PER_NODE $NODES_PER_NAMESPACE}}
@@ -139,6 +140,7 @@ steps:
     Method: SchedulingThroughput
     Params:
       action: gather
+      enableViolations: {{$ENABLE_VIOLATIONS_FOR_SCHEDULING_THROUGHPUT}}
       threshold: {{$SCHEDULER_THROUGHPUT_THRESHOLD}}
 
 - name: Starting latency pod measurements


### PR DESCRIPTION
Backport of https://github.com/kubernetes/perf-tests/pull/1401.

/sig scalability
/cc jkaniuk
/cc wojtek-t