### PR TITLE
Fix typo in Github Bearer Token and remove redundant check for ignoring non-yaml files in config.go

### DIFF
--- a/perfdash/config.go
+++ b/perfdash/config.go
@@ -23,9 +23,8 @@ import (
 	"strconv"
 	"strings"
 
-	"k8s.io/klog"
-
 	"github.com/ghodss/yaml"
+	"k8s.io/klog"
 )
 
 // To add new e2e test support, you need to:
@@ -407,11 +406,6 @@ func getProwConfig(configPaths []string) (Jobs, error) {
 
 	for _, configPath := range configPaths {
 		klog.Infof("Fetching config %s", configPath)
-		// Perfdash supports only yamls.
-		if !strings.HasSuffix(configPath, ".yaml") {
-			klog.Warningf("%s is not an yaml file!", configPath)
-			continue
-		}
 		var content []byte
 		var err error
 		switch {

--- a/perfdash/github-configs-fetcher.go
+++ b/perfdash/github-configs-fetcher.go
@@ -19,12 +19,12 @@ package main
 import (
 	"fmt"
 	"io/ioutil"
-	"k8s.io/klog"
 	"net/http"
 	"os"
 	"strings"
 
 	"gopkg.in/yaml.v2"
+	"k8s.io/klog"
 )
 
 type githubDirContent struct {
@@ -65,7 +65,7 @@ func getGithubDirContents(url string) ([]githubDirContent, error) {
 		return nil, err
 	}
 	if token := os.Getenv("GITHUB_TOKEN"); len(token) != 0 {
-		req.Header.Add("Authorization", fmt.Sprintf("Bearer: %s", token))
+		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", token))
 	}
 	client := &http.Client{}
 	resp, err := client.Do(req)


### PR DESCRIPTION
I was running into an auth issue despite setting my Github token properly. Upon investigation, I found that the request header for auth should look like: `Authorization: Bearer <token>`. In the current code, we have a colon after Bearer leading to my auth issues. Once removed, I was authenticated properly. 

Unfortunately, this breaks retrieving the prow config because a bearer token adds some extra auth chars after the [downloadURL](`https://github.com/kubernetes/perf-tests/blob/master/perfdash/github-configs-fetcher.go#L55). (e.g: `https://raw.githubusercontent.com/kubernetes/test-infra/master/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml?token=AXXXXXXXXXXXXXXXXXXXXZ`). In the code: 
- To ensure that we are only working with strings that end in `.yaml`, [we check if the `githubDirContent.Name`](https://github.com/kubernetes/perf-tests/blob/master/perfdash/github-configs-fetcher.go#L54) has the suffix `.yaml` prior to adding it to our list of config paths in `GetConfigsFromGithub()`
- [We do this same HasSuffix check again](https://github.com/kubernetes/perf-tests/blob/master/perfdash/config.go#L411) in `getProwConfig()` with `githubDirContent.DownloadURL` which fails because the downloadURL adds the auth chars as mentioned above

In this PR:
* I fix the bearer token typo
* I remove the redundant check in `getProwConfig()` since we already guarantee we're working with **only** yaml files in the first check in `GetConfigsFromGithub()`
