### PR TITLE
Add per step reporting in CL2

### DIFF
--- a/clusterloader2/cmd/clusterloader.go
+++ b/clusterloader2/cmd/clusterloader.go
@@ -22,9 +22,6 @@ import (
 	"path"
 	"time"
 
-	ginkgoconfig "github.com/onsi/ginkgo/config"
-	ginkgoreporters "github.com/onsi/ginkgo/reporters"
-	ginkgotypes "github.com/onsi/ginkgo/types"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog"
@@ -297,13 +294,8 @@ func main() {
 		klog.Exitf("Error while preloading images: %v", err)
 	}
 
-	suiteSummary := &ginkgotypes.SuiteSummary{
-		SuiteDescription:           "ClusterLoaderV2",
-		NumberOfSpecsThatWillBeRun: len(testConfigPaths),
-	}
-	junitReporter := ginkgoreporters.NewJUnitReporter(path.Join(clusterLoaderConfig.ReportDir, "junit.xml"))
-	junitReporter.SpecSuiteWillBegin(ginkgoconfig.GinkgoConfig, suiteSummary)
-	testsStart := time.Now()
+	testReporter := test.CreateSimpleReporter(path.Join(clusterLoaderConfig.ReportDir, "junit.xml"), "ClusterLoaderV2")
+	testReporter.BeginTestSuite()
 	if testSuiteConfigPath != "" {
 		testSuite, err := config.LoadTestSuite(testSuiteConfigPath)
 		if err != nil {
@@ -311,17 +303,16 @@ func main() {
 		}
 		for i := range testSuite {
 			clusterLoaderConfig.TestScenario = testSuite[i]
-			runSingleTest(f, prometheusFramework, junitReporter, suiteSummary)
+			runSingleTest(f, prometheusFramework, testReporter)
 		}
 	} else {
 		for i := range testConfigPaths {
 			clusterLoaderConfig.TestScenario.ConfigPath = testConfigPaths[i]
 			clusterLoaderConfig.TestScenario.OverridePaths = testOverridePaths
-			runSingleTest(f, prometheusFramework, junitReporter, suiteSummary)
+			runSingleTest(f, prometheusFramework, testReporter)
 		}
 	}
-	suiteSummary.RunTime = time.Since(testsStart)
-	junitReporter.SpecSuiteDidEnd(suiteSummary)
+	testReporter.EndTestSuite()
 
 	if clusterLoaderConfig.PrometheusConfig.EnableServer && clusterLoaderConfig.PrometheusConfig.TearDownServer {
 		if err := prometheusController.TearDownPrometheusStack(); err != nil {
@@ -333,36 +324,27 @@ func main() {
 			klog.Errorf("Error while tearing down exec service: %v", err)
 		}
 	}
-	if suiteSummary.NumberOfFailedSpecs > 0 {
-		klog.Exitf("%d tests have failed!", suiteSummary.NumberOfFailedSpecs)
+	if failedTestItems := testReporter.GetNumberOfFailedTestItems(); failedTestItems > 0 {
+		klog.Exitf("%d tests have failed!", failedTestItems)
 	}
 }
 
 func runSingleTest(
 	f *framework.Framework,
 	prometheusFramework *framework.Framework,
-	junitReporter *ginkgoreporters.JUnitReporter,
-	suiteSummary *ginkgotypes.SuiteSummary,
+	testReporter test.Reporter,
 ) {
 	testID := getTestID(clusterLoaderConfig.TestScenario)
 	testStart := time.Now()
-	specSummary := &ginkgotypes.SpecSummary{
-		ComponentTexts: []string{suiteSummary.SuiteDescription, testID},
-	}
 	printTestStart(testID)
-	if errList := test.RunTest(f, prometheusFramework, &clusterLoaderConfig); !errList.IsEmpty() {
-		suiteSummary.NumberOfFailedSpecs++
-		specSummary.State = ginkgotypes.SpecStateFailed
-		specSummary.Failure = ginkgotypes.SpecFailure{
-			Message: errList.String(),
-		}
+	errList := test.RunTest(f, prometheusFramework, &clusterLoaderConfig, testReporter)
+	if !errList.IsEmpty() {
 		printTestResult(testID, "Fail", errList.String())
 	} else {
-		specSummary.State = ginkgotypes.SpecStatePassed
 		printTestResult(testID, "Success", "")
 	}
-	specSummary.RunTime = time.Since(testStart)
-	junitReporter.SpecDidComplete(specSummary)
+	testConfigPath := clusterLoaderConfig.TestScenario.ConfigPath
+	testReporter.ReportTestFinish(time.Since(testStart), testConfigPath, errList)
 }
 
 func getTestID(ts api.TestScenario) string {

--- a/clusterloader2/pkg/test/interface.go
+++ b/clusterloader2/pkg/test/interface.go
@@ -17,6 +17,8 @@ limitations under the License.
 package test
 
 import (
+	"time"
+
 	"k8s.io/perf-tests/clusterloader2/api"
 	"k8s.io/perf-tests/clusterloader2/pkg/chaos"
 	"k8s.io/perf-tests/clusterloader2/pkg/config"
@@ -49,6 +51,7 @@ type Context interface {
 	GetClusterLoaderConfig() *config.ClusterLoaderConfig
 	GetClusterFramework() *framework.Framework
 	GetPrometheusFramework() *framework.Framework
+	GetTestReporter() Reporter
 	GetState() *state.State
 	GetTemplateMappingCopy() map[string]interface{}
 	GetTemplateProvider() *config.TemplateProvider
@@ -63,4 +66,14 @@ type Executor interface {
 	ExecuteStep(ctx Context, step *api.Step) *errors.ErrorList
 	ExecutePhase(ctx Context, phase *api.Phase) *errors.ErrorList
 	ExecuteObject(ctx Context, object *api.Object, namespace string, replicaIndex int32, operation OperationType) *errors.ErrorList
+}
+
+// Reporter is an interface for reporting tests results.
+type Reporter interface {
+	SetTestName(name string)
+	GetNumberOfFailedTestItems() int
+	BeginTestSuite()
+	EndTestSuite()
+	ReportTestStepFinish(duration time.Duration, stepName string, errList *errors.ErrorList)
+	ReportTestFinish(duration time.Duration, testConfigPath string, errList *errors.ErrorList)
 }

--- a/clusterloader2/pkg/test/simple_context.go
+++ b/clusterloader2/pkg/test/simple_context.go
@@ -32,6 +32,7 @@ type simpleContext struct {
 	clusterLoaderConfig *config.ClusterLoaderConfig
 	clusterFramework    *framework.Framework
 	prometheusFramework *framework.Framework
+	testReporter        Reporter
 	state               *state.State
 	templateMapping     map[string]interface{}
 	templateProvider    *config.TemplateProvider
@@ -40,12 +41,13 @@ type simpleContext struct {
 	chaosMonkey         *chaos.Monkey
 }
 
-func createSimpleContext(c *config.ClusterLoaderConfig, f, p *framework.Framework, s *state.State, templateMapping map[string]interface{}) Context {
+func createSimpleContext(c *config.ClusterLoaderConfig, f, p *framework.Framework, s *state.State, testReporter Reporter, templateMapping map[string]interface{}) Context {
 	templateProvider := config.NewTemplateProvider(filepath.Dir(c.TestScenario.ConfigPath))
 	return &simpleContext{
 		clusterLoaderConfig: c,
 		clusterFramework:    f,
 		prometheusFramework: p,
+		testReporter:        testReporter,
 		state:               s,
 		templateMapping:     util.CloneMap(templateMapping),
 		templateProvider:    templateProvider,
@@ -68,6 +70,11 @@ func (sc *simpleContext) GetClusterFramework() *framework.Framework {
 // GetFramework returns prometheus framework.
 func (sc *simpleContext) GetPrometheusFramework() *framework.Framework {
 	return sc.prometheusFramework
+}
+
+// GetTestReporter returns test items reporter.
+func (sc *simpleContext) GetTestReporter() Reporter {
+	return sc.testReporter
 }
 
 // GetState returns current test state.

--- a/clusterloader2/pkg/test/simple_reporter.go
+++ b/clusterloader2/pkg/test/simple_reporter.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"fmt"
+	"time"
+
+	ginkgoconfig "github.com/onsi/ginkgo/config"
+	ginkgoreporters "github.com/onsi/ginkgo/reporters"
+	ginkgotypes "github.com/onsi/ginkgo/types"
+	"k8s.io/perf-tests/clusterloader2/pkg/errors"
+)
+
+type simpleReporter struct {
+	testName       string
+	suiteStart     time.Time
+	junitReporter  *ginkgoreporters.JUnitReporter
+	suiteSummary   *ginkgotypes.SuiteSummary
+	stepsSummaries []*ginkgotypes.SpecSummary
+}
+
+func CreateSimpleReporter(reportFilename, testSuiteDescription string) Reporter {
+	return &simpleReporter{
+		junitReporter: ginkgoreporters.NewJUnitReporter(reportFilename),
+		suiteSummary: &ginkgotypes.SuiteSummary{
+			SuiteDescription: testSuiteDescription,
+		},
+	}
+}
+
+func (str *simpleReporter) SetTestName(name string) {
+	str.testName = name
+}
+
+func (str *simpleReporter) GetNumberOfFailedTestItems() int {
+	return str.suiteSummary.NumberOfFailedSpecs
+}
+
+func (str *simpleReporter) BeginTestSuite() {
+	str.junitReporter.SpecSuiteWillBegin(ginkgoconfig.GinkgoConfig, str.suiteSummary)
+	str.suiteStart = time.Now()
+}
+
+func (str *simpleReporter) EndTestSuite() {
+	str.suiteSummary.RunTime = time.Since(str.suiteStart)
+	str.junitReporter.SpecSuiteDidEnd(str.suiteSummary)
+}
+
+func (str *simpleReporter) ReportTestStepFinish(duration time.Duration, stepName string, errList *errors.ErrorList) {
+	stepSummary := &ginkgotypes.SpecSummary{
+		ComponentTexts: []string{str.suiteSummary.SuiteDescription, fmt.Sprintf("%s: %s", str.testName, stepName)},
+		RunTime:        duration,
+	}
+	str.handleSummary(stepSummary, errList)
+	str.stepsSummaries = append(str.stepsSummaries, stepSummary)
+}
+
+func (str *simpleReporter) ReportTestFinish(duration time.Duration, testConfigPath string, errList *errors.ErrorList) {
+	testSummary := &ginkgotypes.SpecSummary{
+		ComponentTexts: []string{str.suiteSummary.SuiteDescription, fmt.Sprintf("%s overall (%s)", str.testName, testConfigPath)},
+		RunTime:        duration,
+	}
+	str.handleSummary(testSummary, errList)
+
+	str.junitReporter.SpecDidComplete(testSummary)
+	for _, stepSummary := range str.stepsSummaries {
+		str.junitReporter.SpecDidComplete(stepSummary)
+	}
+	str.stepsSummaries = nil
+}
+
+func (str *simpleReporter) handleSummary(summary *ginkgotypes.SpecSummary, errList *errors.ErrorList) {
+	if errList.IsEmpty() {
+		summary.State = ginkgotypes.SpecStatePassed
+	} else {
+		summary.State = ginkgotypes.SpecStateFailed
+		summary.Failure = ginkgotypes.SpecFailure{
+			Message: errList.String(),
+		}
+		str.suiteSummary.NumberOfFailedSpecs++
+	}
+}

--- a/clusterloader2/pkg/test/simple_test_executor.go
+++ b/clusterloader2/pkg/test/simple_test_executor.go
@@ -136,6 +136,7 @@ func (ste *simpleExecutor) ExecuteStep(ctx Context, step *api.Step) *errors.Erro
 	}
 	var wg wait.Group
 	errList := errors.NewErrorList()
+	stepStart := time.Now()
 	if len(step.Measurements) > 0 {
 		for i := range step.Measurements {
 			// index is created to make i value unchangeable during thread execution.
@@ -164,6 +165,7 @@ func (ste *simpleExecutor) ExecuteStep(ctx Context, step *api.Step) *errors.Erro
 	if !errList.IsEmpty() {
 		klog.Warningf("Got errors during step execution: %v", errList)
 	}
+	ctx.GetTestReporter().ReportTestStepFinish(time.Since(stepStart), step.Name, errList)
 	return errList
 }
 


### PR DESCRIPTION
Introduce a level of granularity in the performance tests reporting that is shown in the Prow job test results. Every step in each of the test configs will be reported separately.