### PR TITLE
Clean up steps in density test config

### DIFF
--- a/clusterloader2/testing/density/config.yaml
+++ b/clusterloader2/testing/density/config.yaml
@@ -133,18 +133,19 @@ steps:
         CpuRequest: 1m
         MemoryRequest: 10M
 
-- name: Collecting saturation pod measurements
+- name: Waiting for saturation pods to be running
   measurements:
   - Identifier: WaitForRunningSaturationDeployments
     Method: WaitForControlledPodsRunning
     Params:
       action: gather
-- measurements:
+
+- name: Collecting saturation pod measurements
+  measurements:
   - Identifier: SaturationPodStartupLatency
     Method: PodStartupLatency
     Params:
       action: gather
-- measurements:
   - Identifier: SchedulingThroughput
     Method: SchedulingThroughput
     Params:


### PR DESCRIPTION
Merge two saturation pods steps into one and fix the names of saturation-related steps.

/assign mm4tt