### PR TITLE
Increase page size to 5000 in slo-monitor

### DIFF
--- a/slo-monitor/Makefile
+++ b/slo-monitor/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 PACKAGE = k8s.io/perf-tests/slo-monitor
-TAG = 0.12.0
+TAG = 0.13.0
 # Image should be pulled from k8s.gcr.io, which will auto-detect
 # region (us, eu, asia, ...) and pull from the closest.
 REPOSITORY?=k8s.gcr.io
@@ -28,7 +28,7 @@ build: src/monitors/pod_monitor.go src/monitors/util.go src/monitors/store.go sr
 container: build
 	docker build --pull . -t $(REPOSITORY)/slo-monitor:$(TAG)
 
-push:
+push: container
 	docker tag $(REPOSITORY)/slo-monitor:$(TAG) $(PUSH_REPOSITORY)/slo-monitor:$(TAG)
 	docker push $(PUSH_REPOSITORY)/slo-monitor:$(TAG)
 

--- a/slo-monitor/src/monitors/pod_monitor.go
+++ b/slo-monitor/src/monitors/pod_monitor.go
@@ -183,6 +183,9 @@ func (pm *PodStartupLatencyDataMonitor) Run(stopCh chan struct{}) error {
 				pg := pager.New(pager.SimplePageFunc(func(opts metav1.ListOptions) (runtime.Object, error) {
 					return pm.kubeClient.CoreV1().Events(v1.NamespaceAll).List(opts)
 				}))
+				// Increase page size from default 500 to 5000 to increase listing throughput.
+				// In our test setup 5000 objects, should have total size of ~4MB, which seems to be acceptable page size.
+				pg.PageSize = 5000
 				return pg.List(context.Background(), options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {


### PR DESCRIPTION
Change page size in slo-monitor from 500 to 5000.

kube-apiserver internally uses the page size as a chunk size for a single etcd requests. In cases like this one (a fieldSelector that matches only a tiny fraction of all obects) it needs to scan all objects which takes a lot of time when 500 page size is used.

In my benchmark with 200k events, this change seems to decrease request latency 3x.

/assign @wojtek-t  