### PR TITLE
perfdash: add scheduler throughput/latency labels

### DIFF
--- a/perfdash/Makefile
+++ b/perfdash/Makefile
@@ -1,7 +1,7 @@
 all: push
 
 # See deployment.yaml for the version currently running-- bump this ahead before rebuilding!
-TAG = 2.25
+TAG = 2.26
 
 REPO = gcr.io/k8s-testimages
 

--- a/perfdash/config.go
+++ b/perfdash/config.go
@@ -179,16 +179,30 @@ var (
 			}},
 		},
 		"Scheduler": {
-			"SchedulingLatency": []TestDescription{{
-				Name:             "density",
-				OutputFilePrefix: "SchedulingMetrics",
-				Parser:           parseSchedulingLatency,
-			}},
-			"SchedulingThroughput": []TestDescription{{
-				Name:             "density",
-				OutputFilePrefix: "SchedulingThroughput",
-				Parser:           parseSchedulingThroughputCL,
-			}},
+			"SchedulingLatency": []TestDescription{
+				// `density_*` items need to be before the `density` item because of
+				// how data file prefixes work. Same applies to SchedulingThroughput.
+				{
+					Name:             "density_pod-anti-affinity",
+					OutputFilePrefix: "SchedulingMetrics",
+					Parser:           parseSchedulingLatency("pod-anti-affinity"),
+				}, {
+					Name:             "density",
+					OutputFilePrefix: "SchedulingMetrics",
+					Parser:           parseSchedulingLatency("density"),
+				},
+			},
+			"SchedulingThroughput": []TestDescription{
+				{
+					Name:             "density_pod-anti-affinity",
+					OutputFilePrefix: "SchedulingThroughput",
+					Parser:           parseSchedulingThroughputCL("pod-anti-affinity"),
+				}, {
+					Name:             "density",
+					OutputFilePrefix: "SchedulingThroughput",
+					Parser:           parseSchedulingThroughputCL("density"),
+				},
+			},
 		},
 		"Etcd": {
 			"DensityBackendCommitDuration": []TestDescription{{

--- a/perfdash/deployment.yaml
+++ b/perfdash/deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: perfdash
-        image: gcr.io/k8s-testimages/perfdash:2.25
+        image: gcr.io/k8s-testimages/perfdash:2.26
         command:
           - /perfdash
           -   --www=true


### PR DESCRIPTION
This label will be used to view the graphs for data generated by
different tests defined in cl2/testing/density/scheduler.

Related to #1414