### PR TITLE
Exclude proxy subresource from API responsiveness

### DIFF
--- a/clusterloader2/pkg/measurement/common/slos/api_responsiveness_prometheus.go
+++ b/clusterloader2/pkg/measurement/common/slos/api_responsiveness_prometheus.go
@@ -44,7 +44,7 @@ const (
 
 	currentAPICallMetricsVersion = "v1"
 
-	filters = `verb!~"WATCH|WATCHLIST|PROXY|CONNECT"`
+	filters = `verb!="WATCH", subresource!="proxy"`
 
 	// latencyQuery matches description of the API call latency SLI and measure 99th percentaile over 5m windows
 	//
@@ -63,7 +63,7 @@ const (
 	countFastQuery = "sum(increase(apiserver_request_duration_seconds_bucket{%v}[%v])) by (resource, subresource, scope, verb)"
 
 	// exclude all buckets of 1s and shorter
-	filterGetAndMutating = `verb!~"WATCH|WATCHLIST|PROXY|CONNECT|LIST", le="1"`
+	filterGetAndMutating = `verb!~"WATCH|LIST", subresource!="proxy", le="1"`
 	// exclude all buckets below or equal 5s
 	filterNamespaceList = `scope!="cluster", verb="LIST", scope!="cluster", le="5"`
 	// exclude all buckets below or equal 30s


### PR DESCRIPTION
Exclude proxy subresource from API responsiveness.
Remove also outdated WATCHILIST, PROXY and CONNECT verbs as they don't seem to used sine 1.11.

Fix: https://github.com/kubernetes/kubernetes/issues/94368

/cc @wojtek-t 

I will run some manual tests first
/hold