### PR TITLE
Fix benchmark Makefile after migration to go modules

### DIFF
--- a/benchmark/Makefile
+++ b/benchmark/Makefile
@@ -18,16 +18,13 @@ TESTS := $(shell find pkg -name '*_test.go')
 
 all: benchmark
 
-godep:
-	go get -u github.com/tools/godep
+benchmark: cmd/benchmark.go $(SOURCES)
+	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -a -o $(BINARY) cmd/benchmark.go
 
-benchmark: godep cmd/benchmark.go $(SOURCES)
-	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 godep go build -a -o $(BINARY) cmd/benchmark.go
-
-test: godep $(TESTS)
-	godep go test k8s.io/perf-tests/benchmark/pkg/... -v
+test: $(TESTS)
+	go test k8s.io/perf-tests/benchmark/pkg/... -v
 
 clean:
 	rm -f $(BINARY)
 
-.PHONY: all godep benchmark test clean
+.PHONY: all benchmark test clean


### PR DESCRIPTION
Tests: https://k8s-testgrid.appspot.com/sig-scalability-perf-tests#kubemark-100-benchmark

were broken by: https://github.com/kubernetes/perf-tests/pull/1447

```
I0902 22:03:20.536] GOOS=linux GOARCH=amd64 CGO_ENABLED=0 godep go build -a -o build/benchmark cmd/benchmark.go
W0902 22:03:20.637] godep: No Godeps found (or in any parent directory)
W0902 22:03:20.638] make: *** [Makefile:25: benchmark] Error 1
```

/cc @kushthedude
/cc @wojtek-t 