### PR TITLE
Use kubernetes.io/os after graduation from beta

### DIFF
--- a/clusterloader2/pkg/prometheus/manifests/0prometheus-operator-deployment.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/0prometheus-operator-deployment.yaml
@@ -41,7 +41,7 @@ spec:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       securityContext:
         runAsNonRoot: true
         runAsUser: 65534

--- a/clusterloader2/pkg/prometheus/manifests/grafana-deployment.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/grafana-deployment.yaml
@@ -57,7 +57,7 @@ spec:
           - name: GF_AUTH_ANONYMOUS_ORG_ROLE
             value: "Admin"
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       securityContext:
         runAsNonRoot: true
         runAsUser: 65534

--- a/clusterloader2/pkg/prometheus/manifests/prometheus-prometheus.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/prometheus-prometheus.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   baseImage: gcr.io/k8s-testimages/quay.io/prometheus/prometheus
   nodeSelector:
-    beta.kubernetes.io/os: linux
+    kubernetes.io/os: linux
   replicas: 1
   resources:
     requests:


### PR DESCRIPTION
Use kubernetes.io/os instead of beta.kubernetes.io/os

/cc @jkaniuk 