### PR TITLE
Add a test config for "max pods per service" test

### DIFF
--- a/clusterloader2/testing/service-size/config.yaml
+++ b/clusterloader2/testing/service-size/config.yaml
@@ -1,0 +1,94 @@
+{{$ITERATIONS := DefaultParam .Iterations 50}}
+{{$UPDATES := DefaultParam .Updates 10}}
+{{$STEP := DefaultParam .Step 50}}
+
+name: service-size
+namespace:
+    number: 1
+tuningSets:
+- name: qps
+  GlobalQPSLoad:
+    qps: 1
+    burst: 1
+steps:
+- name: Starting measurements
+  measurements:
+    - Identifier: APIResponsivenessPrometheus
+      Method: APIResponsivenessPrometheus
+      Params:
+        action: start
+- name: Starting measurement for waiting for pods
+  measurements:
+  - Method: WaitForControlledPodsRunning
+    Instances:
+    - Identifier: WaitForRunningDeployments
+      Params:
+        apiVersion: apps/v1
+        kind: Deployment
+    Params:
+      action: start
+      labelSelector: group = load
+      operationTimeout: 15m
+- name: Creating SVC
+  phases:
+  - namespaceRange:
+      min: 1
+      max: 1
+    replicasPerNamespace: 1
+    tuningSet: qps
+    objectBundle:
+    - basename: service
+      objectTemplatePath: service.yaml
+{{$revision := 1}}
+{{range $i := Loop $ITERATIONS}}
+{{$size := MultiplyInt (AddInt $i 1) $STEP}}
+- name: Sleep
+  measurements:
+  - Identifier: Sleep
+    Method: Sleep
+    Params:
+      duration: 20s
+- name: Scaling Deployment to {{$size}}
+  phases:
+  - namespaceRange:
+      min: 1
+      max: 1
+    replicasPerNamespace: 1
+    tuningSet: qps
+    objectBundle:
+    - basename: deployment
+      objectTemplatePath: deployment.yaml
+      templateFillMap:
+        InstanceCount: {{$size}}
+        Revision: "r{{$revision}}"
+- name: Waiting for pods to be running
+  measurements:
+  - Method: WaitForControlledPodsRunning
+    Instances:
+     - Identifier: WaitForRunningDeployments
+    Params:
+      action: gather
+{{range $j := Loop $UPDATES}}
+{{$revision = AddInt $revision 1}}
+- name: Rolling update {{$j}} of size {{$size}} with revision {{$revision}}
+  phases:
+  - namespaceRange:
+      min: 1
+      max: 1
+    replicasPerNamespace: 1
+    tuningSet: qps
+    objectBundle:
+    - basename: deployment
+      objectTemplatePath: deployment.yaml
+      templateFillMap:
+        InstanceCount: {{$size}}
+        Revision: "r{{$revision}}"
+- name: Waiting for pods to be running
+  measurements:
+  - Method: WaitForControlledPodsRunning
+    Instances:
+     - Identifier: WaitForRunningDeployments
+    Params:
+      action: gather
+{{end}}
+{{end}}

--- a/clusterloader2/testing/service-size/deployment-readiness.yaml
+++ b/clusterloader2/testing/service-size/deployment-readiness.yaml
@@ -1,0 +1,57 @@
+{{$CpuRequest := DefaultParam .CpuRequest "10m"}}
+{{$MemoryRequest := DefaultParam .MemoryRequest "10M"}}
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{.Name}}
+  labels:
+    group: load
+spec:
+  replicas: {{.InstanceCount}}
+  selector:
+    matchLabels:
+      name: {{.Name}}
+  template:
+    metadata:
+      labels:
+        name: {{.Name}}
+        svc: svc
+    spec:
+      containers:
+      - image: alpine:3.7
+        name: {{.Name}}
+        command: ["/bin/sh"]
+        args:
+          - -c
+          - "sleep 10h"
+        env:
+        - name: REVISION
+          value: {{.Revision}}
+        resources:
+          requests:
+            cpu: {{$CpuRequest}}
+            memory: {{$MemoryRequest}}
+        # Approx. 50% of all pods is unhealthy. Changes every 30s.
+        readinessProbe:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - "test 5 -lt $((RANDOM%10))"
+          periodSeconds: 30
+          failureThreshold: 1
+          successThreshold: 1
+      dnsPolicy: Default
+      terminationGracePeriodSeconds: 1
+      # Add not-ready/unreachable tolerations for 15 minutes so that node
+      # failure doesn't trigger pod deletion.
+      tolerations:
+      - key: "node.kubernetes.io/not-ready"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 900
+      - key: "node.kubernetes.io/unreachable"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 900

--- a/clusterloader2/testing/service-size/deployment.yaml
+++ b/clusterloader2/testing/service-size/deployment.yaml
@@ -1,0 +1,43 @@
+{{$CpuRequest := DefaultParam .CpuRequest "10m"}}
+{{$MemoryRequest := DefaultParam .MemoryRequest "10M"}}
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{.Name}}
+  labels:
+    group: load
+spec:
+  replicas: {{.InstanceCount}}
+  selector:
+    matchLabels:
+      name: {{.Name}}
+  template:
+    metadata:
+      labels:
+        name: {{.Name}}
+        svc: svc
+    spec:
+      containers:
+      - image: k8s.gcr.io/pause:3.1
+        name: {{.Name}}
+        env:
+        - name: REVISION
+          value: {{.Revision}}
+        resources:
+          requests:
+            cpu: {{$CpuRequest}}
+            memory: {{$MemoryRequest}}
+      dnsPolicy: Default
+      terminationGracePeriodSeconds: 1
+      # Add not-ready/unreachable tolerations for 15 minutes so that node
+      # failure doesn't trigger pod deletion.
+      tolerations:
+      - key: "node.kubernetes.io/not-ready"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 900
+      - key: "node.kubernetes.io/unreachable"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 900

--- a/clusterloader2/testing/service-size/service.yaml
+++ b/clusterloader2/testing/service-size/service.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{.Name}}
+spec:
+  selector:
+    svc: svc
+  ports:
+  - port: 80
+    targetPort: 80


### PR DESCRIPTION
/kind feature

**What this PR does / why we need it**:
This adds a new test for validating "max pods per service" dimension
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```