### PR TITLE
cl2/density: add pod affinty, pod topology spreading workloads to scheduler suite

### DIFF
--- a/clusterloader2/testing/density/scheduler-suite.yaml
+++ b/clusterloader2/testing/density/scheduler-suite.yaml
@@ -11,3 +11,8 @@
   configPath: testing/density/config.yaml
   overridePaths:
   - testing/density/scheduler/pod-anti-affinity/overrides.yaml
+
+- identifier: pod-topology-spread
+  configPath: testing/density/config.yaml
+  overridePaths:
+  - testing/density/scheduler/pod-topology-spread/overrides.yaml

--- a/clusterloader2/testing/density/scheduler-suite.yaml
+++ b/clusterloader2/testing/density/scheduler-suite.yaml
@@ -1,3 +1,8 @@
+- identifier: pod-affinity
+  configPath: testing/density/config.yaml
+  overridePaths:
+  - testing/density/scheduler/pod-affinity/overrides.yaml
+
 - identifier: pod-anti-affinity
   configPath: testing/density/config.yaml
   overridePaths:

--- a/clusterloader2/testing/density/scheduler-suite.yaml
+++ b/clusterloader2/testing/density/scheduler-suite.yaml
@@ -1,3 +1,7 @@
+- identifier: vanilla
+  configPath: testing/density/config.yaml
+  overridePaths: []
+
 - identifier: pod-affinity
   configPath: testing/density/config.yaml
   overridePaths:

--- a/clusterloader2/testing/density/scheduler/pod-affinity/deployment.yaml
+++ b/clusterloader2/testing/density/scheduler/pod-affinity/deployment.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{.Name}}
+  labels:
+    group: {{.Group}}
+spec:
+  replicas: {{.Replicas}}
+  selector:
+    matchLabels:
+      name: {{.Name}}
+  template:
+    metadata:
+      labels:
+        name: {{.Name}}
+        group: {{.Group}}
+    spec:
+      affinity:
+        podAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  group: {{.Group}}
+              topologyKey: "kubernetes.io/hostname"
+            weight: 1
+      containers:
+      - image: k8s.gcr.io/pause:3.1
+        imagePullPolicy: IfNotPresent
+        name: {{.Name}}
+        ports:
+        resources:
+          requests:
+            cpu: {{.CpuRequest}}
+            memory: {{.MemoryRequest}}
+      # Add not-ready/unreachable tolerations for 15 minutes so that node
+      # failure doesn't trigger pod deletion.
+      tolerations:
+      - key: "node.kubernetes.io/not-ready"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 900
+      - key: "node.kubernetes.io/unreachable"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 900

--- a/clusterloader2/testing/density/scheduler/pod-affinity/overrides.yaml
+++ b/clusterloader2/testing/density/scheduler/pod-affinity/overrides.yaml
@@ -1,0 +1,2 @@
+SATURATION_DEPLOYMENT_SPEC: scheduler/pod-affinity/deployment.yaml
+LATENCY_DEPLOYMENT_SPEC: scheduler/pod-affinity/deployment.yaml

--- a/clusterloader2/testing/density/scheduler/pod-topology-spread/deployment.yaml
+++ b/clusterloader2/testing/density/scheduler/pod-topology-spread/deployment.yaml
@@ -1,0 +1,48 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{.Name}}
+  labels:
+    group: {{.Group}}
+spec:
+  replicas: {{.Replicas}}
+  selector:
+    matchLabels:
+      name: {{.Name}}
+  template:
+    metadata:
+      labels:
+        name: {{.Name}}
+        group: {{.Group}}
+    spec:
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        # Cannot be DoNotSchedule because the there's no way to differentiate
+        # the master node from a hollow node; as a result, the global minimum
+        # matching number will always be zero (since pods cannot be scheduled
+        # on to the master).
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            group: {{.Group}}
+      containers:
+      - image: k8s.gcr.io/pause:3.1
+        imagePullPolicy: IfNotPresent
+        name: {{.Name}}
+        ports:
+        resources:
+          requests:
+            cpu: {{.CpuRequest}}
+            memory: {{.MemoryRequest}}
+      # Add not-ready/unreachable tolerations for 15 minutes so that node
+      # failure doesn't trigger pod deletion.
+      tolerations:
+      - key: "node.kubernetes.io/not-ready"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 900
+      - key: "node.kubernetes.io/unreachable"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 900

--- a/clusterloader2/testing/density/scheduler/pod-topology-spread/overrides.yaml
+++ b/clusterloader2/testing/density/scheduler/pod-topology-spread/overrides.yaml
@@ -1,0 +1,2 @@
+SATURATION_DEPLOYMENT_SPEC: scheduler/pod-topology-spread/deployment.yaml
+LATENCY_DEPLOYMENT_SPEC: scheduler/pod-topology-spread/deployment.yaml


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**: This PR adds the pod-affinity test to the suite of scheduler benchmark(s) we have.

**Which issue(s) this PR fixes**:

Related to https://github.com/kubernetes/perf-tests/issues/1414

**Special notes for your reviewer**: No.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

/sig scheduling
/sig testing
/cc @ahg-g @mm4tt 