### PR TITLE
Bump timeout for the linter test job

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,5 @@
 run:
-  timeout: 5m
+  timeout: 10m
 
 linters-settings:
   golint:

--- a/verify/verify-lint.sh
+++ b/verify/verify-lint.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -euo pipefail
+set -euxo pipefail
 
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 cd "$KUBE_ROOT"


### PR DESCRIPTION
Increase the timeout for the linter job after recent changes to `pull-perf-tests-verify-lint` CPU limits.

Fixes #1469.