### PR TITLE
Introduce SchedulerInsecurePortDisabled

### DIFF
--- a/clusterloader2/pkg/measurement/common/scheduler_latency.go
+++ b/clusterloader2/pkg/measurement/common/scheduler_latency.go
@@ -103,7 +103,7 @@ func (s *schedulerLatencyMeasurement) Execute(config *measurement.Config) ([]mea
 		}
 	}
 
-	if !SSHToMasterSupported && !masterRegistered {
+	if provider.Features().SchedulerInsecurePortDisabled || (!SSHToMasterSupported && !masterRegistered) {
 		klog.Warningf("unable to fetch scheduler metrics for provider: %s", provider.Name())
 		return nil, nil
 	}

--- a/clusterloader2/pkg/provider/provider.go
+++ b/clusterloader2/pkg/provider/provider.go
@@ -53,6 +53,9 @@ type Features struct {
 
 	// ShouldPrometheusScrapeApiserverOnly determines if we should set PROMETHEUS_SCRAPE_APISERVER_ONLY by default.
 	ShouldPrometheusScrapeApiserverOnly bool
+
+	// SchedulerInsecurePortDisabled determines if kube-scheduler listens on insecure port.
+	SchedulerInsecurePortDisabled bool
 }
 
 // Config is the config of the provider.


### PR DESCRIPTION
Some providers can support ssh to master, but not expose
scheduler metrics on insecure port.

/kind feature
cc @Catramen 