### PR TITLE
Collect resource usage from non-joined master nodes

### DIFF
--- a/clusterloader2/go.mod
+++ b/clusterloader2/go.mod
@@ -52,6 +52,7 @@ replace k8s.io/sample-controller => k8s.io/sample-controller v0.18.0
 
 require (
 	github.com/go-errors/errors v1.0.1
+	github.com/google/go-cmp v0.3.0
 	github.com/onsi/ginkgo v1.11.0
 	github.com/prometheus/client_model v0.2.0
 	github.com/prometheus/common v0.4.1

--- a/clusterloader2/pkg/measurement/common/resource_usage.go
+++ b/clusterloader2/pkg/measurement/common/resource_usage.go
@@ -113,6 +113,7 @@ func (e *resourceUsageMetricMeasurement) Execute(config *measurement.Config) ([]
 				Nodes:                             nodesSet,
 				ResourceDataGatheringPeriod:       60 * time.Second,
 				MasterResourceDataGatheringPeriod: 10 * time.Second,
+				MasterIPs:                         config.ClusterFramework.GetClusterConfig().MasterIPs,
 			}, namespace)
 		if err != nil {
 			return nil, err

--- a/clusterloader2/pkg/measurement/util/gatherers/container_resource_gatherer_test.go
+++ b/clusterloader2/pkg/measurement/util/gatherers/container_resource_gatherer_test.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gatherers
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func Test_collectMachines(t *testing.T) {
+	nodeList := &corev1.NodeList{Items: []corev1.Node{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "node1"},
+			Status: corev1.NodeStatus{
+				Addresses: []corev1.NodeAddress{
+					{Address: "10.0.0.1"},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "node2"},
+			Status: corev1.NodeStatus{
+				Addresses: []corev1.NodeAddress{
+					{Address: "10.0.0.2"},
+					{Address: "10.0.0.3"},
+				},
+			},
+		},
+	}}
+	testcases := []struct {
+		name      string
+		nodeList  *corev1.NodeList
+		masterIPs []string
+		expResult []machine
+	}{
+		{
+			name:      "empty lists",
+			nodeList:  &corev1.NodeList{Items: nil},
+			expResult: nil,
+		},
+		{
+			name:     "some nodes",
+			nodeList: nodeList,
+			expResult: []machine{
+				{nodeName: "node1", addresses: []string{"10.0.0.1"}},
+				{nodeName: "node2", addresses: []string{"10.0.0.2", "10.0.0.3"}},
+			},
+		},
+		{
+			name:      "nodes mentioned in masters",
+			nodeList:  nodeList,
+			masterIPs: []string{"10.0.0.1"},
+			expResult: []machine{
+				{nodeName: "node1", addresses: []string{"10.0.0.1"}},
+				{nodeName: "node2", addresses: []string{"10.0.0.2", "10.0.0.3"}},
+			},
+		},
+		{
+			name:      "unjoined masters",
+			nodeList:  nodeList,
+			masterIPs: []string{"10.0.1.1"},
+			expResult: []machine{
+				{nodeName: "node1", addresses: []string{"10.0.0.1"}},
+				{nodeName: "node2", addresses: []string{"10.0.0.2", "10.0.0.3"}},
+				{nodeName: "", sshIP: "10.0.1.1", addresses: []string{"10.0.1.1"}},
+			},
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			res := collectMachines(tc.nodeList, tc.masterIPs)
+			if !cmp.Equal(res, tc.expResult, cmp.AllowUnexported(machine{})) {
+				t.Errorf("machines did not match expected, diff (-want, +got): %v", cmp.Diff(res, tc.expResult, cmp.AllowUnexported(machine{})))
+			}
+		})
+	}
+}


### PR DESCRIPTION
Some providers do not have master nodes joined to a cluster, so
fallback to SSH is added for such providers.

Resource gatherer will merge nodes registered in a cluster with
master ips, deduplicating by address, and will use old method of
collecting container ids and gathering metrics, when possible.

For master ips that are not joined to a cluster as a node, gatherer
will use provider's SSH method, and will collect metrics of all
containers registered on that node, including ones running
as part of static pods.

Kubelet package is extended with ssh stats gatherer, and generalized
way to provide container filtering (either list based, or match-all).