### PR TITLE
Add Python specific test suite to allow migration to Python3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,9 @@ verify-all: test verify-boilerplate verify-flags
 .PHONY: verify-all-dev
 verify-all-dev: verify-all verify-dashboard verify-lint
 
+.PHONY: verify-all-python
+verify-all: verify-boilerplate verify-flags
+
 # TODO(oxddr): go-build.sh doesn't work at the moment decide whether we need this at all
 # .PHONY: build
 # build:


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

Optionally add one or more of the following kinds if applicable:

**What this PR does / why we need it**:
Allow migration to Python3 - we want to split presubmit verify-all to a language dependent presubmits.

**Special notes for your reviewer**:
Related to #1470 