### PR TITLE
Reimplement scheduling throughput to prometheus metric

### DIFF
--- a/clusterloader2/pkg/measurement/common/scheduling_throughput_prometheus.go
+++ b/clusterloader2/pkg/measurement/common/scheduling_throughput_prometheus.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"fmt"
+	"time"
+
+	"k8s.io/klog"
+	"k8s.io/perf-tests/clusterloader2/pkg/errors"
+	"k8s.io/perf-tests/clusterloader2/pkg/measurement"
+	measurementutil "k8s.io/perf-tests/clusterloader2/pkg/measurement/util"
+	"k8s.io/perf-tests/clusterloader2/pkg/util"
+)
+
+const (
+	schedulingThroughputPrometheusMeasurementName = "SchedulingThroughputPrometheus"
+
+	maxSchedulingThroughputQuery = `max_over_time(sum(irate(apiserver_request_total{verb="POST", resource="pods", subresource="binding",code="201"}[1m]))[%v:5s])`
+)
+
+func init() {
+	create := func() measurement.Measurement { return CreatePrometheusMeasurement(&schedulingThroughputGatherer{}) }
+	if err := measurement.Register(schedulingThroughputPrometheusMeasurementName, create); err != nil {
+		klog.Fatalf("Cannot register %s: %v", schedulingThroughputMeasurementName, err)
+	}
+}
+
+type schedulingThroughputGatherer struct{}
+
+func (a *schedulingThroughputGatherer) Gather(executor QueryExecutor, startTime time.Time, config *measurement.Config) ([]measurement.Summary, error) {
+	throughputSummary, err := a.getThroughputSummary(executor, startTime, config)
+	if err != nil {
+		return nil, err
+	}
+
+	content, err := util.PrettyPrintJSON(throughputSummary)
+	if err != nil {
+		return nil, err
+	}
+
+	threshold, err := util.GetFloat64OrDefault(config.Params, "threshold", 0)
+	if threshold > 0 && throughputSummary.Max < threshold {
+		err = errors.NewMetricViolationError(
+			"scheduler throughput_prometheus",
+			fmt.Sprintf("actual throughput %f lower than threshold %f", throughputSummary.Max, threshold))
+	}
+
+	summaries := []measurement.Summary{
+		measurement.CreateSummary(a.String(), "json", content),
+	}
+
+	return summaries, err
+}
+
+func (a *schedulingThroughputGatherer) getThroughputSummary(executor QueryExecutor, startTime time.Time, config *measurement.Config) (*schedulingThroughputPrometheus, error) {
+	measurementEnd := time.Now()
+	measurementDuration := measurementEnd.Sub(startTime)
+	promDuration := measurementutil.ToPrometheusTime(measurementDuration)
+	query := fmt.Sprintf(maxSchedulingThroughputQuery, promDuration)
+
+	samples, err := executor.Query(query, measurementEnd)
+	if err != nil {
+		return nil, err
+	}
+	if len(samples) != 1 {
+		return nil, fmt.Errorf("got unexpected number of samples: %d", len(samples))
+	}
+
+	maxSchedulingThroughput := samples[0].Value
+	throughputSummary := &schedulingThroughputPrometheus{
+		Max: float64(maxSchedulingThroughput),
+	}
+
+	return throughputSummary, nil
+}
+
+func (a *schedulingThroughputGatherer) String() string {
+	return schedulingThroughputPrometheusMeasurementName
+}
+
+func (a *schedulingThroughputGatherer) IsEnabled(config *measurement.Config) bool {
+	return true
+}
+
+type schedulingThroughputPrometheus struct {
+	Max float64 `json:"max"`
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
Before SchedulingThroughput measurement was doing expensive calls to apiserver. Currently, it will only use prometheus metric to calculate scheduling throughput. 
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```