### PR TITLE
Add scheduling throughput/latency for load test in perf dash and add …

### DIFF
--- a/perfdash/Makefile
+++ b/perfdash/Makefile
@@ -1,7 +1,7 @@
 all: push
 
 # See deployment.yaml for the version currently running-- bump this ahead before rebuilding!
-TAG = 2.28
+TAG = 2.29
 
 REPO = gcr.io/k8s-testimages
 

--- a/perfdash/config.go
+++ b/perfdash/config.go
@@ -225,6 +225,20 @@ var (
 					Parser:           parseSchedulingThroughputCL("load"),
 				},
 			},
+			"LoadSchedulingLatency": []TestDescription{
+				{
+					Name:             "load",
+					OutputFilePrefix: "SchedulingMetrics",
+					Parser:           parseSchedulingLatency("load"),
+				},
+			},
+			"LoadSchedulingThroughput": []TestDescription{
+				{
+					Name:             "load",
+					OutputFilePrefix: "SchedulingThroughput",
+					Parser:           parseSchedulingThroughputCL("load"),
+				},
+			},
 		},
 		"Etcd": {
 			"DensityBackendCommitDuration": []TestDescription{{

--- a/perfdash/deployment.yaml
+++ b/perfdash/deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: perfdash
-        image: gcr.io/k8s-testimages/perfdash:2.28
+        image: gcr.io/k8s-testimages/perfdash:2.29
         command:
           - /perfdash
           -   --www=true

--- a/perfdash/parser.go
+++ b/perfdash/parser.go
@@ -291,6 +291,7 @@ func parseSchedulingLatency(testName string) func([]byte, int, *BuildData) {
 
 type schedulingThroughputMetric struct {
 	Average float64 `json:"average"`
+	Max     float64 `json:"max"`
 	Perc50  float64 `json:"perc50"`
 	Perc90  float64 `json:"perc90"`
 	Perc99  float64 `json:"perc99"`
@@ -310,6 +311,7 @@ func parseSchedulingThroughputCL(testName string) func([]byte, int, *BuildData) 
 		perfData.Data["Perc90"] = obj.Perc90
 		perfData.Data["Perc99"] = obj.Perc99
 		perfData.Data["Average"] = obj.Average
+		perfData.Data["Max"] = obj.Max
 		testResult.Builds[build] = append(testResult.Builds[build], perfData)
 	}
 }


### PR DESCRIPTION
…max to scheduling throughput

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
Adds SchedulingThroughput and SchedulingLatency in load test to perfdash and adds max SchedulingThroughput.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```