### PR TITLE
[Cherrypick 1.18] Decouple deletion test throughput from load test throughput.

### DIFF
--- a/clusterloader2/testing/load/config.yaml
+++ b/clusterloader2/testing/load/config.yaml
@@ -9,6 +9,7 @@
 {{$NODES_PER_NAMESPACE := DefaultParam .NODES_PER_NAMESPACE 100}}
 {{$PODS_PER_NODE := DefaultParam .PODS_PER_NODE 30}}
 {{$LOAD_TEST_THROUGHPUT := DefaultParam .LOAD_TEST_THROUGHPUT 10}}
+{{$DELETE_TEST_THROUGHPUT := DefaultParam .CL2_DELETE_TEST_THROUGHPUT $LOAD_TEST_THROUGHPUT}}
 {{$BIG_GROUP_SIZE := 250}}
 {{$MEDIUM_GROUP_SIZE := 30}}
 {{$SMALL_GROUP_SIZE := 5}}
@@ -36,6 +37,7 @@
 {{$totalPods := MultiplyInt $namespaces $NODES_PER_NAMESPACE $PODS_PER_NODE}}
 {{$podsPerNamespace := DivideInt $totalPods $namespaces}}
 {{$saturationTime := DivideInt $totalPods $LOAD_TEST_THROUGHPUT}}
+{{$deletionTime := DivideInt $totalPods $DELETE_TEST_THROUGHPUT}}
 # bigDeployments - 1/4 of namespace pods should be in big Deployments.
 {{$bigDeploymentsPerNamespace := DivideInt $podsPerNamespace (MultiplyInt 4 $BIG_GROUP_SIZE)}}
 # mediumDeployments - 1/4 of namespace pods should be in medium Deployments.
@@ -72,6 +74,9 @@ tuningSets:
     # as each RS changes its size from X to a uniform random value in [X/2, 3X/2].
     # To match 10 [pods/s] requirement, we need to divide saturationTime by 4.
     timeLimit: {{DivideInt $saturationTime 4}}s
+- name: RandomizedDeletionTimeLimited
+  RandomizedTimeLimitedLoad:
+    timeLimit: {{$deletionTime}}s
 {{if $ENABLE_CHAOSMONKEY}}
 chaosMonkey:
   nodeFailure:
@@ -532,7 +537,7 @@ steps:
       min: 1
       max: {{$namespaces}}
     replicasPerNamespace: 0
-    tuningSet: RandomizedSaturationTimeLimited
+    tuningSet: RandomizedDeletionTimeLimited
     objectBundle:
     - basename: big-deployment
       objectTemplatePath: deployment.yaml
@@ -552,7 +557,7 @@ steps:
       min: 1
       max: {{$namespaces}}
     replicasPerNamespace: 0
-    tuningSet: RandomizedSaturationTimeLimited
+    tuningSet: RandomizedDeletionTimeLimited
     objectBundle:
     - basename: medium-deployment
       objectTemplatePath: deployment.yaml
@@ -572,7 +577,7 @@ steps:
       min: 1
       max: {{$namespaces}}
     replicasPerNamespace: 0
-    tuningSet: RandomizedSaturationTimeLimited
+    tuningSet: RandomizedDeletionTimeLimited
     objectBundle:
     - basename: small-deployment
       objectTemplatePath: deployment.yaml
@@ -593,7 +598,7 @@ steps:
       min: 1
       max: {{$namespaces}}
     replicasPerNamespace: 0
-    tuningSet: RandomizedSaturationTimeLimited
+    tuningSet: RandomizedDeletionTimeLimited
     objectBundle:
       - basename: small-statefulset
         objectTemplatePath: statefulset.yaml
@@ -603,7 +608,7 @@ steps:
       min: 1
       max: {{$namespaces}}
     replicasPerNamespace: 0
-    tuningSet: RandomizedSaturationTimeLimited
+    tuningSet: RandomizedDeletionTimeLimited
     objectBundle:
       - basename: medium-statefulset
         objectTemplatePath: statefulset.yaml
@@ -615,7 +620,7 @@ steps:
       min: 1
       max: 1
     replicasPerNamespace: 0
-    tuningSet: RandomizedSaturationTimeLimited
+    tuningSet: RandomizedDeletionTimeLimited
     objectBundle:
       - basename: daemonset
         objectTemplatePath: daemonset.yaml
@@ -625,7 +630,7 @@ steps:
       min: 1
       max: {{$namespaces}}
     replicasPerNamespace: 0
-    tuningSet: RandomizedSaturationTimeLimited
+    tuningSet: RandomizedDeletionTimeLimited
     objectBundle:
       - basename: small-job
         objectTemplatePath: job.yaml
@@ -633,7 +638,7 @@ steps:
       min: 1
       max: {{$namespaces}}
     replicasPerNamespace: 0
-    tuningSet: RandomizedSaturationTimeLimited
+    tuningSet: RandomizedDeletionTimeLimited
     objectBundle:
       - basename: medium-job
         objectTemplatePath: job.yaml
@@ -641,7 +646,7 @@ steps:
       min: 1
       max: {{$namespaces}}
     replicasPerNamespace: 0
-    tuningSet: RandomizedSaturationTimeLimited
+    tuningSet: RandomizedDeletionTimeLimited
     objectBundle:
       - basename: big-job
         objectTemplatePath: job.yaml
@@ -652,7 +657,7 @@ steps:
       min: 1
       max: {{$namespaces}}
     replicasPerNamespace: 0
-    tuningSet: RandomizedSaturationTimeLimited
+    tuningSet: RandomizedDeletionTimeLimited
     objectBundle:
       {{range $ssIndex := Seq $SMALL_STATEFUL_SETS_PER_NAMESPACE}}
       - basename: pv-small-statefulset-{{$ssIndex}}
@@ -666,7 +671,7 @@ steps:
       min: 1
       max: {{$namespaces}}
     replicasPerNamespace: 0
-    tuningSet: RandomizedSaturationTimeLimited
+    tuningSet: RandomizedDeletionTimeLimited
     objectBundle:
       {{range $ssIndex := Seq $MEDIUM_STATEFUL_SETS_PER_NAMESPACE}}
       - basename: pv-medium-statefulset-{{$ssIndex}}


### PR DESCRIPTION
Cherry pick of https://github.com/kubernetes/perf-tests/pull/1520
/assign @wojtek-t 