### PR TITLE
clusterloader2: -provider is required

### DIFF
--- a/clusterloader2/README.md
+++ b/clusterloader2/README.md
@@ -20,6 +20,7 @@ These flags are required for any test to be run.
  - kubeconfig - path to the kubeconfig file.
  - testconfig - path to the test config file. This flag can be used multiple times
 if more than one test should be run.
+ - provider - Cluster provider, options are: gce, gke, kubemark, aws, local, vsphere, skeleton
 
 #### Optional
 
@@ -27,7 +28,6 @@ if more than one test should be run.
 If not provided, test will assign the number of schedulable cluster nodes.
  - report-dir - path to directory, where summaries files should be stored.
 If not specified, summaries are printed to standard log.
- - provider - Cluster provider, options are: gce, gke, kubemark, aws, local, vsphere, skeleton
  - mastername - Name of the master node
  - masterip - DNS Name / IP of the master node
  - testoverrides - path to file with overrides.


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

The default is the empty string which raises an error:

```
$ go run cmd/clusterloader.go --kubeconfig=$KUBECONFIG --testconfig=testing/experimental/storage/pod-startup/config.yaml
F1005 11:07:26.997733   67200 clusterloader.go:242] Error init provider: unsupported provider name:
exit status 1
```

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
