### PR TITLE
WIP: clusterloader2: switch to kube-scheduler secure port

### DIFF
--- a/clusterloader2/pkg/framework/config/client_config.go
+++ b/clusterloader2/pkg/framework/config/client_config.go
@@ -18,6 +18,7 @@ package config
 
 import (
 	"fmt"
+	"io/ioutil"
 	"net"
 	"net/http"
 	"time"
@@ -53,6 +54,11 @@ func PrepareConfig(path string) (config *restclient.Config, err error) {
 }
 
 func restclientConfig(path string) (*clientcmdapi.Config, error) {
+	kubeconfigBytes, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	fmt.Printf("kubeconfigBytes: %v\n", string(kubeconfigBytes))
 	c, err := clientcmd.LoadFromFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("error loading kubeconfig: %v", err)

--- a/clusterloader2/pkg/measurement/common/scheduler_latency.go
+++ b/clusterloader2/pkg/measurement/common/scheduler_latency.go
@@ -301,7 +301,7 @@ func (s *schedulerLatencyMeasurement) sendRequestToScheduler(c clientset.Interfa
 		body, err := c.CoreV1().RESTClient().Verb(opUpper).
 			Namespace(metav1.NamespaceSystem).
 			Resource("pods").
-			Name(fmt.Sprintf("kube-scheduler-%v:%v", masterName, ports.InsecureSchedulerPort)).
+			Name(fmt.Sprintf("kube-scheduler-%v:%v", masterName, ports.KubeSchedulerPort)).
 			SubResource("proxy").
 			Suffix("metrics").
 			Do(ctx).Raw()
@@ -312,7 +312,7 @@ func (s *schedulerLatencyMeasurement) sendRequestToScheduler(c clientset.Interfa
 		}
 		responseText = string(body)
 	} else {
-		cmd := "curl -X " + opUpper + " http://localhost:10251/metrics"
+		cmd := "curl -X " + opUpper + " https://localhost:10259/metrics"
 		sshResult, err := measurementutil.SSH(cmd, host+":22", provider)
 		if err != nil || sshResult.Code != 0 {
 			return "", fmt.Errorf("unexpected error (code: %d) in ssh connection to master: %#v", sshResult.Code, err)

--- a/clusterloader2/pkg/prometheus/manifests/master-ip/master-endpoints.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/master-ip/master-endpoints.yaml
@@ -25,7 +25,7 @@ subsets:
       - name: kubelet
         port: 10250
       - name: kube-scheduler
-        port: 10251
+        port: 10259
       - name: kube-controller-manager
         port: 10252
       {{end}}

--- a/clusterloader2/pkg/prometheus/manifests/master-ip/master-service.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/master-ip/master-service.yaml
@@ -23,7 +23,7 @@ spec:
     - name: kubelet
       port: 10250
     - name: kube-scheduler
-      port: 10251
+      port: 10259
     - name: kube-controller-manager
       port: 10252
     {{end}}

--- a/clusterloader2/pkg/prometheus/manifests/master-ip/master-serviceMonitor.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/master-ip/master-serviceMonitor.yaml
@@ -42,7 +42,10 @@ spec:
     port: kube-scheduler
     scheme: https
     tlsConfig:
+      caFile: /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
+      serverName: kubernetes
       insecureSkipVerify: true
+    bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
   - interval: 5s
     port: kube-controller-manager
   selector:

--- a/clusterloader2/pkg/prometheus/manifests/master-ip/master-serviceMonitor.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/master-ip/master-serviceMonitor.yaml
@@ -40,6 +40,9 @@ spec:
       insecureSkipVerify: true
   - interval: 5s
     port: kube-scheduler
+    scheme: https
+    tlsConfig:
+      insecureSkipVerify: true
   - interval: 5s
     port: kube-controller-manager
   selector:

--- a/clusterloader2/pkg/prometheus/util.go
+++ b/clusterloader2/pkg/prometheus/util.go
@@ -68,6 +68,7 @@ func CheckTargetsReady(k8sClient kubernetes.Interface, selector func(Target) boo
 	if err := json.Unmarshal(raw, &response); err != nil {
 		return false, err // This shouldn't happen, return error.
 	}
+	// fmt.Printf("\n\nraw: %v\n\n", string(raw))
 	nReady, nTotal := 0, 0
 	var exampleNotReadyTarget Target
 	for _, t := range response.Data.ActiveTargets {
@@ -79,6 +80,7 @@ func CheckTargetsReady(k8sClient kubernetes.Interface, selector func(Target) boo
 			nReady++
 			continue
 		}
+		// fmt.Printf("exampleNotReadyTarget: %v\n", t)
 		exampleNotReadyTarget = t
 	}
 	if nTotal < minActiveTargets {

--- a/clusterloader2/pkg/provider/util.go
+++ b/clusterloader2/pkg/provider/util.go
@@ -34,7 +34,7 @@ func getComponentProtocolAndPort(componentName string) (string, int, error) {
 	case "kube-controller-manager":
 		return "http://", 10252, nil
 	case "kube-scheduler":
-		return "http://", 10251, nil
+		return "https://", 10259, nil
 	}
 	return "", -1, fmt.Errorf("port for component %v unknown", componentName)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup
/kind deprecation

**What this PR does / why we need it**:
Switch to using kube-scheduler's secure port. The insecure one is deprecated.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```