### PR TITLE
Replace references to old topology labels with the new ones

### DIFF
--- a/clusterloader2/pkg/prometheus/experimental.go
+++ b/clusterloader2/pkg/prometheus/experimental.go
@@ -86,7 +86,7 @@ func (pc *Controller) tryRetrievePrometheusDiskMetadata() (bool, error) {
 		}
 		klog.V(2).Infof("Found Prometheus' PV with name: %s", pv.Name)
 		pdName = pv.Spec.GCEPersistentDisk.PDName
-		zone = pv.ObjectMeta.Labels["failure-domain.beta.kubernetes.io/zone"]
+		zone = pv.ObjectMeta.Labels["topology.kubernetes.io/zone"]
 		klog.V(2).Infof("PD name=%s, zone=%s", pdName, zone)
 	}
 	if pdName == "" || zone == "" {

--- a/clusterloader2/pkg/util/ssh.go
+++ b/clusterloader2/pkg/util/ssh.go
@@ -36,9 +36,9 @@ type GCloudSSHExecutor struct{}
 // Exec executes command on a given node with stdin provided.
 // If stdin is nil, the process reads from null device.
 func (e *GCloudSSHExecutor) Exec(command string, node *v1.Node, stdin io.Reader) error {
-	zone, ok := node.Labels["failure-domain.beta.kubernetes.io/zone"]
+	zone, ok := node.Labels["topology.kubernetes.io/zone"]
 	if !ok {
-		return fmt.Errorf("unknown zone for %q node: no failure-domain.beta.kubernetes.io/zone label", node.Name)
+		return fmt.Errorf("unknown zone for %q node: no topology.kubernetes.io/zone label", node.Name)
 	}
 	cmd := exec.Command("gcloud", "compute", "ssh", "--zone", zone, "--command", command, node.Name)
 	cmd.Stdin = stdin


### PR DESCRIPTION
Output of grepping `failure-domain.beta.kubernetes.io` at the top-level perf-tests repo directory, `master` branch:
```
./clusterloader2/vendor/k8s.io/api/core/v1/well_known_labels.go:22:	LabelZoneFailureDomain       = "failure-domain.beta.kubernetes.io/zone"
./clusterloader2/vendor/k8s.io/api/core/v1/well_known_labels.go:23:	LabelZoneRegion              = "failure-domain.beta.kubernetes.io/region"
./clusterloader2/pkg/util/ssh.go:39:	zone, ok := node.Labels["failure-domain.beta.kubernetes.io/zone"]
./clusterloader2/pkg/util/ssh.go:41:		return fmt.Errorf("unknown zone for %q node: no failure-domain.beta.kubernetes.io/zone label", node.Name)
./clusterloader2/pkg/prometheus/experimental.go:89:		zone = pv.ObjectMeta.Labels["failure-domain.beta.kubernetes.io/zone"]
./compare/vendor/k8s.io/apimachinery/pkg/apis/meta/v1/well_known_labels.go:23:	LabelZoneFailureDomain = "failure-domain.beta.kubernetes.io/zone"
./compare/vendor/k8s.io/apimachinery/pkg/apis/meta/v1/well_known_labels.go:24:	LabelZoneRegion        = "failure-domain.beta.kubernetes.io/region"
```

Not seeing any references to `LabelZoneFailureDomain` nor `LabelZoneRegion` in the non-vendored code.

Fixes #1554.

/sig scalability
/assign @mm4tt @wojtek-t 