### PR TITLE
Revert "Replace references to old topology labels with the new ones"

### DIFF
--- a/clusterloader2/pkg/prometheus/experimental.go
+++ b/clusterloader2/pkg/prometheus/experimental.go
@@ -86,7 +86,7 @@ func (pc *Controller) tryRetrievePrometheusDiskMetadata() (bool, error) {
 		}
 		klog.V(2).Infof("Found Prometheus' PV with name: %s", pv.Name)
 		pdName = pv.Spec.GCEPersistentDisk.PDName
-		zone = pv.ObjectMeta.Labels["topology.kubernetes.io/zone"]
+		zone = pv.ObjectMeta.Labels["failure-domain.beta.kubernetes.io/zone"]
 		klog.V(2).Infof("PD name=%s, zone=%s", pdName, zone)
 	}
 	if pdName == "" || zone == "" {

--- a/clusterloader2/pkg/util/ssh.go
+++ b/clusterloader2/pkg/util/ssh.go
@@ -36,9 +36,9 @@ type GCloudSSHExecutor struct{}
 // Exec executes command on a given node with stdin provided.
 // If stdin is nil, the process reads from null device.
 func (e *GCloudSSHExecutor) Exec(command string, node *v1.Node, stdin io.Reader) error {
-	zone, ok := node.Labels["topology.kubernetes.io/zone"]
+	zone, ok := node.Labels["failure-domain.beta.kubernetes.io/zone"]
 	if !ok {
-		return fmt.Errorf("unknown zone for %q node: no topology.kubernetes.io/zone label", node.Name)
+		return fmt.Errorf("unknown zone for %q node: no failure-domain.beta.kubernetes.io/zone label", node.Name)
 	}
 	cmd := exec.Command("gcloud", "compute", "ssh", "--zone", zone, "--command", command, node.Name)
 	cmd.Stdin = stdin


### PR DESCRIPTION
Reverts kubernetes/perf-tests#1563

This seems to be causing https://github.com/kubernetes/kubernetes/issues/96509

/assign @wojtek-t 
 