### PR TITLE
Cherrypick of #1526 into 1.18 - Adding a new DNS workload in load tests

### DIFF
--- a/clusterloader2/testing/load/config.yaml
+++ b/clusterloader2/testing/load/config.yaml
@@ -25,6 +25,7 @@
 {{$ENABLE_SECRETS := DefaultParam .ENABLE_SECRETS false}}
 {{$ENABLE_STATEFULSETS := DefaultParam .ENABLE_STATEFULSETS false}}
 {{$ENABLE_NETWORKPOLICIES := DefaultParam .ENABLE_NETWORKPOLICIES false}}
+{{$ENABLE_DNSTESTS := DefaultParam .CL2_ENABLE_DNSTESTS false}}
 {{$ENABLE_DENSITY_TEST := DefaultParam .CL2_ENABLE_DENSITY_TEST false}}
 # LATENCY_POD_MEMORY and LATENCY_POD_CPU are calculated for 1-core 4GB node.
 # Increasing allocation of both memory and cpu by 10%
@@ -294,6 +295,8 @@ steps:
     - basename: big-deployment
       objectTemplatePath: deployment.yaml
       templateFillMap:
+        # DNS Test clients are enabled only in the medium-size deployment.
+        EnableDNSTests: false
         ReplicasMin: {{$BIG_GROUP_SIZE}}
         ReplicasMax: {{$BIG_GROUP_SIZE}}
         SvcName: big-service
@@ -321,6 +324,7 @@ steps:
     - basename: medium-deployment
       objectTemplatePath: deployment.yaml
       templateFillMap:
+        EnableDNSTests: {{$ENABLE_DNSTESTS}}
         ReplicasMin: {{$MEDIUM_GROUP_SIZE}}
         ReplicasMax: {{$MEDIUM_GROUP_SIZE}}
         SvcName: medium-service
@@ -348,6 +352,8 @@ steps:
     - basename: small-deployment
       objectTemplatePath: deployment.yaml
       templateFillMap:
+        # DNS Test clients are enabled only in the medium-size deployment.
+        EnableDNSTests: false
         ReplicasMin: {{$SMALL_GROUP_SIZE}}
         ReplicasMax: {{$SMALL_GROUP_SIZE}}
         SvcName: small-service
@@ -611,6 +617,8 @@ steps:
     - basename: big-deployment
       objectTemplatePath: deployment.yaml
       templateFillMap:
+        # DNS Test clients are enabled only in the medium-size deployment.
+        EnableDNSTests: false
         ReplicasMin: {{MultiplyInt $BIG_GROUP_SIZE 0.5}}
         ReplicasMax: {{MultiplyInt $BIG_GROUP_SIZE 1.5}}
         SvcName: big-service
@@ -626,6 +634,7 @@ steps:
     - basename: medium-deployment
       objectTemplatePath: deployment.yaml
       templateFillMap:
+        EnableDNSTests: {{$ENABLE_DNSTESTS}}
         ReplicasMin: {{MultiplyInt $MEDIUM_GROUP_SIZE 0.5}}
         ReplicasMax: {{MultiplyInt $MEDIUM_GROUP_SIZE 1.5}}
         SvcName: medium-service
@@ -641,6 +650,8 @@ steps:
     - basename: small-deployment
       objectTemplatePath: deployment.yaml
       templateFillMap:
+        # DNS Test clients are enabled only in the medium-size deployment.
+        EnableDNSTests: false
         ReplicasMin: {{MultiplyInt $SMALL_GROUP_SIZE 0.5}}
         ReplicasMax: {{MultiplyInt $SMALL_GROUP_SIZE 1.5}}
         SvcName: small-service

--- a/clusterloader2/testing/load/configmap.yaml
+++ b/clusterloader2/testing/load/configmap.yaml
@@ -2,8 +2,36 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{.Name}}
+{{if not (eq (Mod .Index 20) 0 19) }} # .Index % 20 in {0,19} - only 10% deployments will have non-immutable ConfigMap.
+immutable: true
+{{end}}
+# Every pod that needs its own configmap entry should be unconditionally
+# added below. That allows us to avoid complicating it with ifs.
 data:
-  data.yaml: |-
-    a: 1
-    b: 2
-    c: 3
+  # all-queries is used by DNS tests.
+  all-queries: |
+    kubernetes A
+    kubernetes AAAA
+    kubernetes.cluster.local A
+    kubernetes.cluster.local AAAA
+    kubernetes.svc.cluster.local A
+    kubernetes.svc.cluster.local AAAA
+    kubernetes.default.svc.cluster.local A
+    kubernetes.default.svc.cluster.local AAAA
+    google.com.svc.cluster.local A
+    google.com.svc.cluster.local AAAA
+    google.com.default.svc.cluster.local A
+    google.com.default.svc.cluster.local AAAA
+    google.com.cluster.local A
+    google.com.cluster.local AAAA
+    google.com A
+    google.com AAAA
+    1-2-3-4.default.pod.cluster.local A
+    metrics-server A
+    metrics-server AAAA
+    metrics-server.cluster.local A
+    metrics-server.cluster.local AAAA
+    metrics-server.svc.cluster.local A
+    metrics-server.svc.cluster.local AAAA
+    metrics-server.kube-system.svc.cluster.local A
+    metrics-server.kube-system.svc.cluster.local AAAA

--- a/clusterloader2/testing/load/deployment.yaml
+++ b/clusterloader2/testing/load/deployment.yaml
@@ -23,8 +23,24 @@ spec:
         svc: {{.SvcName}}-{{.Index}}
     spec:
       containers:
+{{if .EnableDNSTests}}
+      - image: k8s.gcr.io/kube-dns-perf-client-amd64:1.1
+      # Fetches the dns server from /etc/resolv.conf and
+      # runs as 5 clients and 2 threads sending 10 queries per second.
+      # dnsperf has a client timeout of 5s. It sends queries for 60s,
+      # then sleeps for 10s, to mimic bursts of DNS queries.
+        command:
+        - sh
+        - -c
+        - server=$(cat /etc/resolv.conf | grep nameserver | cut -d ' ' -f 2); echo
+          "Using nameserver ${server}"; while true; do ./dnsperf -s $server -l 60
+          -d /var/configmap/all-queries -c 5 -T 2 -Q 10; sleep 10; done
+        name: {{.Name}}-dnsperf
+        app: dns-perf-client
+{{else}}
       - image: k8s.gcr.io/pause:3.1
         name: {{.Name}}
+{{end}}
         resources:
           requests:
             cpu: {{$CpuRequest}}


### PR DESCRIPTION
**What type of PR is this?**
Cherrypick of https://github.com/kubernetes/perf-tests/pull/1526 and https://github.com/kubernetes/perf-tests/pull/1546
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
This will run dnsperf which will issue 10 queries per second.
The queries are specified via a configmap and include
searchpath-expanded queries to simulate a real application.

Rebased configmap changes that include dns queries.
Simplified config by removing extra template fillup.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/assign @wojtek-t @mborsz 