### PR TITLE
Move the sleep command to a separate step

### DIFF
--- a/clusterloader2/testing/load/config.yaml
+++ b/clusterloader2/testing/load/config.yaml
@@ -389,10 +389,13 @@ steps:
       {{range $EXEC_COMMAND}}
       - {{.}}
       {{end}}
+
+- name: Sleep
+  measurements:
   - Identifier: WaitAfterExec
     Method: Sleep
     Params:
-        duration: {{$SLEEP_AFTER_EXEC_DURATION}}
+      duration: {{$SLEEP_AFTER_EXEC_DURATION}}
 {{end}}
 {{if not $EXIT_AFTER_EXEC}}
 


### PR DESCRIPTION
As measurements in a single step are run in parallel, sleeping needs to be moved out to a separate step.

/sig scalability
/assign @mborsz 
/cc @marseel 