### PR TITLE
Adapt the event message regex in the OOM tracker (release-1.17)

### DIFF
--- a/clusterloader2/pkg/measurement/common/ooms_tracker.go
+++ b/clusterloader2/pkg/measurement/common/ooms_tracker.go
@@ -42,7 +42,7 @@ const (
 )
 
 var (
-	oomEventMsgRegex = regexp.MustCompile(`Kill process (\d+) \((.+)\) score \d+ or sacrifice child\nKilled process \d+ .+ total-vm:(\d+kB), anon-rss:\d+kB, file-rss:\d+kB.*`)
+	oomEventMsgRegex = regexp.MustCompile(`Killed process (\d+) \((.+)\) total-vm:(\d+kB), anon-rss:\d+kB, file-rss:\d+kB.*`)
 )
 
 func init() {


### PR DESCRIPTION
Get rid of `Kill process <PID> (<PROCESS_NAME>) score 0 or sacrifice child\n` part of the OOM event message regex as it's no longer printed out in the kernel logs.

Backports #1579.

/sig scalability
/assign @jkaniuk 