### PR TITLE
Add missing bash options to dns/run.sh

### DIFF
--- a/dns/run
+++ b/dns/run
@@ -13,6 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -o errexit
+set -o nounset
+
 # $1 - Test type.
 # $2 - Optional test output directory path. If not provided default "out" is used.
 # $3 - Optional json metrics directory path. If not provided metrics will not be created.


### PR DESCRIPTION
This is, among others, to properly propagate error status.

Ref. https://github.com/kubernetes/perf-tests/issues/1586
