### PR TITLE
Measure pod startup for stateless pods

### DIFF
--- a/clusterloader2/pkg/measurement/common/slos/pod_startup_latency.go
+++ b/clusterloader2/pkg/measurement/common/slos/pod_startup_latency.go
@@ -54,6 +54,7 @@ func createPodStartupLatencyMeasurement() measurement.Measurement {
 	return &podStartupLatencyMeasurement{
 		selector:          measurementutil.NewObjectSelector(),
 		podStartupEntries: measurementutil.NewObjectTransitionTimes(podStartupLatencyMeasurementName),
+		podMetadata:       measurementutil.NewPodsMetadata(podStartupLatencyMeasurementName),
 	}
 }
 
@@ -62,6 +63,7 @@ type podStartupLatencyMeasurement struct {
 	isRunning         bool
 	stopCh            chan struct{}
 	podStartupEntries *measurementutil.ObjectTransitionTimes
+	podMetadata       *measurementutil.PodsMetadata
 	threshold         time.Duration
 }
 
@@ -162,6 +164,11 @@ func podStartupTransitionsWithThreshold(threshold time.Duration) map[string]meas
 	return result
 }
 
+type podStartupLatencyCheck struct {
+	namePrefix string
+	filter     measurementutil.KeyFilterFunc
+}
+
 func (p *podStartupLatencyMeasurement) gather(c clientset.Interface, identifier string) ([]measurement.Summary, error) {
 	klog.V(2).Infof("%s: gathering pod startup latency measurement...", p)
 	if !p.isRunning {
@@ -174,21 +181,36 @@ func (p *podStartupLatencyMeasurement) gather(c clientset.Interface, identifier 
 		return nil, err
 	}
 
-	transitions := podStartupTransitionsWithThreshold(p.threshold)
-	podStartupLatency := p.podStartupEntries.CalculateTransitionsLatency(transitions, measurementutil.MatchAll)
+	checks := []podStartupLatencyCheck{
+		{
+			namePrefix: "",
+			filter:     measurementutil.MatchAll,
+		},
+		{
+			namePrefix: "Stateless",
+			filter:     p.podMetadata.FilterStateless,
+		},
+	}
 
+	var summaries []measurement.Summary
 	var err error
-	if slosErr := podStartupLatency["pod_startup"].VerifyThreshold(p.threshold); slosErr != nil {
-		err = errors.NewMetricViolationError("pod startup", slosErr.Error())
-		klog.Errorf("%s: %v", p, err)
-	}
+	for _, check := range checks {
+		transitions := podStartupTransitionsWithThreshold(p.threshold)
+		podStartupLatency := p.podStartupEntries.CalculateTransitionsLatency(transitions, check.filter)
 
-	content, jsonErr := util.PrettyPrintJSON(measurementutil.LatencyMapToPerfData(podStartupLatency))
-	if jsonErr != nil {
-		return nil, jsonErr
+		if slosErr := podStartupLatency["pod_startup"].VerifyThreshold(p.threshold); slosErr != nil {
+			err = errors.NewMetricViolationError("pod startup", slosErr.Error())
+			klog.Errorf("%s%s: %v", check.namePrefix, p, err)
+		}
+
+		content, jsonErr := util.PrettyPrintJSON(measurementutil.LatencyMapToPerfData(podStartupLatency))
+		if jsonErr != nil {
+			return nil, jsonErr
+		}
+		summaryName := fmt.Sprintf("%s%s_%s", check.namePrefix, podStartupLatencyMeasurementName, identifier)
+		summaries = append(summaries, measurement.CreateSummary(summaryName, "json", content))
 	}
-	summary := measurement.CreateSummary(fmt.Sprintf("%s_%s", podStartupLatencyMeasurementName, identifier), "json", content)
-	return []measurement.Summary{summary}, err
+	return summaries, err
 }
 
 func (p *podStartupLatencyMeasurement) gatherScheduleTimes(c clientset.Interface) error {
@@ -222,8 +244,11 @@ func (p *podStartupLatencyMeasurement) checkPod(_, obj interface{}) {
 	if !ok {
 		return
 	}
+
+	key := createMetaNamespaceKey(pod.Namespace, pod.Name)
+	p.podMetadata.SetStateless(key, isPodStateless(pod))
+
 	if pod.Status.Phase == corev1.PodRunning {
-		key := createMetaNamespaceKey(pod.Namespace, pod.Name)
 		if _, found := p.podStartupEntries.Get(key, createPhase); !found {
 			p.podStartupEntries.Set(key, watchPhase, time.Now())
 			p.podStartupEntries.Set(key, createPhase, pod.CreationTimestamp.Time)
@@ -246,4 +271,15 @@ func (p *podStartupLatencyMeasurement) checkPod(_, obj interface{}) {
 
 func createMetaNamespaceKey(namespace, name string) string {
 	return namespace + "/" + name
+}
+
+func isPodStateless(pod *corev1.Pod) bool {
+	for _, volume := range pod.Spec.Volumes {
+		if volume.EmptyDir != nil || volume.DownwardAPI != nil || volume.ConfigMap != nil || volume.Secret != nil {
+			continue
+		}
+		klog.V(4).Infof("pod %s/%s classified as stateful", pod.Namespace, pod.Name)
+		return false
+	}
+	return true
 }

--- a/clusterloader2/pkg/measurement/util/pods_metadata.go
+++ b/clusterloader2/pkg/measurement/util/pods_metadata.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"sync"
+)
+
+// podMetadata contains metadata about a single pod
+type podMetadata struct {
+	stateless bool
+}
+
+// PodsMetadata store metadata about pods.
+type PodsMetadata struct {
+	name     string
+	lock     sync.Mutex
+	metadata map[string]*podMetadata
+}
+
+// NewPodsMetadata created new PodsMetadata instance.
+func NewPodsMetadata(name string) *PodsMetadata {
+	return &PodsMetadata{
+		name:     name,
+		metadata: make(map[string]*podMetadata),
+	}
+}
+
+// SetStaless marks a given pod as stateless.
+func (o *PodsMetadata) SetStateless(key string, stateless bool) {
+	o.lock.Lock()
+	defer o.lock.Unlock()
+	if meta, ok := o.metadata[key]; ok {
+		meta.stateless = stateless
+		return
+	}
+	o.metadata[key] = &podMetadata{
+		stateless: stateless,
+	}
+}
+
+// FilterStateless returns true iff a pod associated with a given key is
+// marked as stateless.
+func (o *PodsMetadata) FilterStateless(key string) bool {
+	o.lock.Lock()
+	defer o.lock.Unlock()
+	meta, ok := o.metadata[key]
+	return ok && meta.stateless
+}


### PR DESCRIPTION
This is a step towards getting rid of latency phase from our test.
Pod startup from "CreatePhasePodStartupLatency":
```
    {
      "data": {
        "Perc50": 2203.834508,
        "Perc90": 2990.742296,
        "Perc99": 12677.203517
      },
      "unit": "ms",
      "labels": {
        "Metric": "pod_startup"
      }
    },
```
Pod startup from "Stateles CreatePhasePodStartupLatency":
```
    {
      "data": {
        "Perc50": 2199.278227,
        "Perc90": 2953.810973,
        "Perc99": 4251.361823
      },
      "unit": "ms",
      "labels": {
        "Metric": "pod_startup"
      }
    }
```