### PR TITLE
clusterloader2: completely switch to secure port

### DIFF
--- a/clusterloader2/pkg/measurement/common/scheduler_latency.go
+++ b/clusterloader2/pkg/measurement/common/scheduler_latency.go
@@ -301,7 +301,7 @@ func (s *schedulerLatencyMeasurement) sendRequestToScheduler(c clientset.Interfa
 		body, err := c.CoreV1().RESTClient().Verb(opUpper).
 			Namespace(metav1.NamespaceSystem).
 			Resource("pods").
-			Name(fmt.Sprintf("kube-scheduler-%v:%v", masterName, ports.KubeSchedulerPort)).
+			Name(fmt.Sprintf("https:kube-scheduler-%v:%v", masterName, ports.KubeSchedulerPort)).
 			SubResource("proxy").
 			Suffix("metrics").
 			Do(ctx).Raw()
@@ -312,7 +312,7 @@ func (s *schedulerLatencyMeasurement) sendRequestToScheduler(c clientset.Interfa
 		}
 		responseText = string(body)
 	} else {
-		cmd := "curl -X " + opUpper + " https://localhost:10259/metrics"
+		cmd := "curl -X " + opUpper + " -k https://localhost:10259/metrics"
 		sshResult, err := measurementutil.SSH(cmd, host+":22", provider)
 		if err != nil || sshResult.Code != 0 {
 			return "", fmt.Errorf("unexpected error (code: %d) in ssh connection to master: %#v", sshResult.Code, err)

--- a/clusterloader2/pkg/measurement/common/scheduler_latency.go
+++ b/clusterloader2/pkg/measurement/common/scheduler_latency.go
@@ -301,7 +301,7 @@ func (s *schedulerLatencyMeasurement) sendRequestToScheduler(c clientset.Interfa
 		body, err := c.CoreV1().RESTClient().Verb(opUpper).
 			Namespace(metav1.NamespaceSystem).
 			Resource("pods").
-			Name(fmt.Sprintf("kube-scheduler-%v:%v", masterName, ports.InsecureSchedulerPort)).
+			Name(fmt.Sprintf("kube-scheduler-%v:%v", masterName, ports.KubeSchedulerPort)).
 			SubResource("proxy").
 			Suffix("metrics").
 			Do(ctx).Raw()
@@ -312,7 +312,7 @@ func (s *schedulerLatencyMeasurement) sendRequestToScheduler(c clientset.Interfa
 		}
 		responseText = string(body)
 	} else {
-		cmd := "curl -X " + opUpper + " http://localhost:10251/metrics"
+		cmd := "curl -X " + opUpper + " https://localhost:10259/metrics"
 		sshResult, err := measurementutil.SSH(cmd, host+":22", provider)
 		if err != nil || sshResult.Code != 0 {
 			return "", fmt.Errorf("unexpected error (code: %d) in ssh connection to master: %#v", sshResult.Code, err)

--- a/clusterloader2/pkg/prometheus/manifests/master-ip/master-endpoints.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/master-ip/master-endpoints.yaml
@@ -27,7 +27,7 @@ subsets:
       - name: kube-scheduler
         port: 10259
       - name: kube-controller-manager
-        port: 10252
+        port: 10257
       {{end}}
       {{if $PROMETHEUS_SCRAPE_NODE_EXPORTER}}
       - name: node-exporter

--- a/clusterloader2/pkg/prometheus/manifests/master-ip/master-endpoints.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/master-ip/master-endpoints.yaml
@@ -25,7 +25,7 @@ subsets:
       - name: kubelet
         port: 10250
       - name: kube-scheduler
-        port: 10251
+        port: 10259
       - name: kube-controller-manager
         port: 10252
       {{end}}

--- a/clusterloader2/pkg/prometheus/manifests/master-ip/master-service.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/master-ip/master-service.yaml
@@ -25,7 +25,7 @@ spec:
     - name: kube-scheduler
       port: 10259
     - name: kube-controller-manager
-      port: 10252
+      port: 10257
     {{end}}
     {{if $PROMETHEUS_SCRAPE_NODE_EXPORTER}}
     - name: node-exporter

--- a/clusterloader2/pkg/prometheus/manifests/master-ip/master-service.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/master-ip/master-service.yaml
@@ -23,7 +23,7 @@ spec:
     - name: kubelet
       port: 10250
     - name: kube-scheduler
-      port: 10251
+      port: 10259
     - name: kube-controller-manager
       port: 10252
     {{end}}

--- a/clusterloader2/pkg/prometheus/manifests/master-ip/master-serviceMonitor.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/master-ip/master-serviceMonitor.yaml
@@ -45,5 +45,8 @@ spec:
       insecureSkipVerify: true
   - interval: 5s
     port: kube-controller-manager
+    scheme: https
+    tlsConfig:
+      insecureSkipVerify: true
   selector:
     k8s-app: master

--- a/clusterloader2/pkg/prometheus/manifests/master-ip/master-serviceMonitor.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/master-ip/master-serviceMonitor.yaml
@@ -40,6 +40,9 @@ spec:
       insecureSkipVerify: true
   - interval: 5s
     port: kube-scheduler
+    scheme: https
+    tlsConfig:
+      insecureSkipVerify: true
   - interval: 5s
     port: kube-controller-manager
   selector:

--- a/clusterloader2/pkg/provider/util.go
+++ b/clusterloader2/pkg/provider/util.go
@@ -32,7 +32,7 @@ func getComponentProtocolAndPort(componentName string) (string, int, error) {
 	case "kube-apiserver":
 		return "https://", 443, nil
 	case "kube-controller-manager":
-		return "http://", 10252, nil
+		return "https://", 10257, nil
 	case "kube-scheduler":
 		return "https://", 10259, nil
 	}

--- a/clusterloader2/pkg/provider/util.go
+++ b/clusterloader2/pkg/provider/util.go
@@ -34,7 +34,7 @@ func getComponentProtocolAndPort(componentName string) (string, int, error) {
 	case "kube-controller-manager":
 		return "http://", 10252, nil
 	case "kube-scheduler":
-		return "http://", 10251, nil
+		return "https://", 10259, nil
 	}
 	return "", -1, fmt.Errorf("port for component %v unknown", componentName)
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
/kind deprecation


**What this PR does / why we need it**:

Now both [controller-manager](https://github.com/kubernetes/kubernetes/pull/96216) and [scheduler](https://github.com/kubernetes/kubernetes/pull/96345) are migrating off the insecure port, and the progress is being blocked by the job `pull-kubernetes-e2e-gce-100-performance`, because `clusterloader2` in this job would fetch metrics from the insecure port of scheduler.

This PR picks up @ingvagabund 's great work #1562, and make `clusterloader2` no longer depend on the insecure port of controller-manager and scheduler.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
clusterloader2: grab metrics from the secure port of kube-controller-manager and kube-scheduler
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```