### PR TITLE
[Golang] Fix hollow node pods busybox image pulls issue

### DIFF
--- a/golang/build-kubernetes.sh
+++ b/golang/build-kubernetes.sh
@@ -66,10 +66,15 @@ function build_kubernetes {
   cd /go/src/k8s.io/kubernetes/build/build-image
   git checkout $K8S_COMMIT
 
-  # The git cherry-pick command below takes a commit from k8s v1.19 that
+  # Cherry-pick of https://github.com/kubernetes/kubernetes/pull/90806 which
   # artifically increases Kubemark cluster nodes objects.
-  # TODO: Get rid of this cherry-pick once we start testing aginst k8s v1.19+.
+  # TODO: Get rid of this cherry-pick once we start testing against k8s v1.19+.
   git cherry-pick -m 1 fc2c410a5a37aba7ab0a3635c6b1195245b77e2b
+  # Cherry-pick of https://github.com/kubernetes/kubernetes/pull/95494 which
+  # prevents from rate limiting by Docker Hub when pulling busybox image per
+  # hollow node pod.
+  # TODO: Get rid of this cherry-pick once we start testing against k8s v1.20+.
+  git cherry-pick -m 1 1698af78be83db748415d224ec1ea217755ea932
 
   # Change the base image of kube-build to our own kube-cross image.
   sed -i 's#FROM .*#FROM gcr.io/k8s-testimages/kube-cross-amd64:'"$TAG"'#' Dockerfile


### PR DESCRIPTION
Context: https://github.com/kubernetes/kubernetes/pull/95494 (this is what we miss in the k8s version used in Golang jobs). Two most recent job runs suffered from the lack of this PR:
* https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/ci-golang-tip-k8s-1-18/1349312930264387584,
* https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/ci-golang-tip-k8s-1-18/1349252286177611776.

/sig scalability
/assign @mm4tt 