### PR TITLE
Upgrade Prometheus to v2.24.0

### DIFF
--- a/clusterloader2/pkg/prometheus/manifests/prometheus-prometheus.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/prometheus-prometheus.yaml
@@ -46,7 +46,7 @@ spec:
   serviceMonitorSelector: {}
   podMonitorNamespaceSelector: {}
   podMonitorSelector: {}
-  version: v2.9.2
+  version: v2.24.0
   retention: 7d
   storage:
     volumeClaimTemplate:


### PR DESCRIPTION
Upgrade Prometheus to v2.24.0 to enable support for watch bookmarks

/cc @jkaniuk 