### PR TITLE
Change yaml.load() to safe_load()

### DIFF
--- a/dns/py/data_test.py
+++ b/dns/py/data_test.py
@@ -32,7 +32,7 @@ class DataTest(unittest.TestCase):
     self.assertEqual(1000, parser.results['queries_sent'])
 
   def test_result_db(self):
-    results = yaml.load(open('fixtures/results.yaml'))
+    results = yaml.safe_load(open('fixtures/results.yaml'))
 
     self.db.put(results)
     res = self.db.get_results(1234, 0)

--- a/dns/py/ingest.py
+++ b/dns/py/ingest.py
@@ -49,7 +49,7 @@ def go(args):
   db = ResultDb(args.db)
   for output in args.outputs:
     _log.info('Processing %s', output)
-    results = yaml.load(open(output))
+    results = yaml.safe_load(open(output))
     db.put(results)
   db.commit()
 

--- a/dns/py/params.py
+++ b/dns/py/params.py
@@ -247,7 +247,7 @@ class TestCases(object):
     """
     |filename| yaml file to read from.
     """
-    raw = yaml.load(open(filename, 'r'))
+    raw = yaml.safe_load(open(filename, 'r'))
     return TestCases(raw)
 
   def __init__(self, values):

--- a/dns/py/params_test.py
+++ b/dns/py/params_test.py
@@ -24,7 +24,7 @@ from params import Inputs, TestCases, ATTRIBUTE_CLUSTER_DNS, PARAMETERS
 
 
 def make_mock_yaml():
-  return yaml.load("""
+  return yaml.safe_load("""
 spec:
   template:
     spec:
@@ -43,7 +43,7 @@ spec:
 
 
 def make_mock_coredns_configmap_yaml():
-  return yaml.load("""
+  return yaml.safe_load("""
 data:
   Corefile: |
     .:53 {
@@ -64,7 +64,7 @@ data:
   """)
 
 def make_mock_coredns_deployment_yaml():
-  return yaml.load("""
+  return yaml.safe_load("""
 spec:
   template:
     spec:

--- a/dns/py/runner.py
+++ b/dns/py/runner.py
@@ -54,16 +54,16 @@ class Runner(object):
     |args| parsed command line args.
     """
     self.args = args
-    self.deployment_yaml = yaml.load(open(self.args.deployment_yaml, 'r'))
-    self.configmap_yaml = yaml.load(open(self.args.configmap_yaml, 'r')) if \
+    self.deployment_yaml = yaml.safe_load(open(self.args.deployment_yaml, 'r'))
+    self.configmap_yaml = yaml.safe_load(open(self.args.configmap_yaml, 'r')) if \
       self.args.configmap_yaml else None
-    self.service_yaml = yaml.load(open(self.args.service_yaml, 'r')) if \
+    self.service_yaml = yaml.safe_load(open(self.args.service_yaml, 'r')) if \
         self.args.service_yaml else None
-    self.dnsperf_yaml = yaml.load(open(self.args.dnsperf_yaml, 'r'))
+    self.dnsperf_yaml = yaml.safe_load(open(self.args.dnsperf_yaml, 'r'))
     self.test_params = TestCases.load_from_file(args.params)
     if self.args.run_large_queries:
       self.test_params.set_param(QueryFile().name, _dnsperf_qfile_name)
-    self.args.testsvc_yaml = yaml.load(open(self.args.testsvc_yaml, 'r')) if \
+    self.args.testsvc_yaml = yaml.safe_load(open(self.args.testsvc_yaml, 'r')) if \
         self.args.testsvc_yaml else None
 
 
@@ -311,7 +311,7 @@ class Runner(object):
     if code != 0:
       raise Exception('error gettings nodes: %d', code)
 
-    nodes = [n['metadata']['name'] for n in yaml.load(out)['items']
+    nodes = [n['metadata']['name'] for n in yaml.safe_load(out)['items']
              if not ('unschedulable' in n['spec'] \
                  and n['spec']['unschedulable'])]
     if len(nodes) < 2 and not self.args.single_node:
@@ -337,7 +337,7 @@ class Runner(object):
       raise Exception('error gettings dns ip for service %s: %d' %(svcname, code))
 
     try:
-      return yaml.load(out)['spec']['clusterIP']
+      return yaml.safe_load(out)['spec']['clusterIP']
     except:
       raise Exception('error parsing %s service, could not get dns ip' %(svcname))
 
@@ -432,7 +432,7 @@ class Runner(object):
       if code != 0:
         _log.error('Error: stderr\n%s', add_prefix('err | ', err))
         raise Exception('error getting pod information: %d', code)
-      pods = yaml.load(out)
+      pods = yaml.safe_load(out)
 
       _log.info('Waiting for server to be %s (%d pods active)',
                 'up' if active else 'deleted',


### PR DESCRIPTION
Hardening measure to prevent [issues] with parsing crafted yaml:

https://pyyaml.org/wiki/PyYAMLDocumentation#loading-yaml

`safe_load()` will become the default in [version 6.0]:

/kind cleanup

[issues]: https://nvd.nist.gov/vuln/search/results?form_type=Basic&results_type=overview&query=pyyaml&search_type=all
[version 6.0]: https://github.com/yaml/pyyaml/issues/420#issuecomment-696752389