### PR TITLE
Update node-exporter to 1.0.1

### DIFF
--- a/clusterloader2/pkg/prometheus/manifests/exporters/node-exporter.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/exporters/node-exporter.yaml
@@ -8,11 +8,14 @@ metadata:
 spec:
   containers:
     - name: prometheus-node-exporter
-      image: gcr.io/k8s-testimages/quay.io/prometheus/node-exporter:v0.18.1
+      image: gcr.io/k8s-testimages/quay.io/prometheus/node-exporter:v1.0.1
       imagePullPolicy: "IfNotPresent"
       args:
-        - --path.procfs=/host/proc
         - --path.sysfs=/host/sys
+        - --path.rootfs=/host/root
+        - --no-collector.wifi
+        - --no-collector.hwmon
+        - --collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/pods/.+)($|/)
         - --collector.netstat.fields=^.*$
         - --collector.qdisc
       ports:
@@ -20,11 +23,13 @@ spec:
           containerPort: 9100
           hostPort: 9100
       volumeMounts:
-        - name: proc
-          mountPath: /host/proc
-          readOnly:  true
-        - name: sys
-          mountPath: /host/sys
+        - mountPath: /host/sys
+          mountPropagation: HostToContainer
+          name: sys
+          readOnly: true
+        - mountPath: /host/root
+          mountPropagation: HostToContainer
+          name: root
           readOnly: true
       resources:
         limits:
@@ -36,9 +41,9 @@ spec:
   hostNetwork: true
   hostPID: true
   volumes:
-    - name: proc
-      hostPath:
-        path: /proc
-    - name: sys
-      hostPath:
+    - hostPath:
         path: /sys
+      name: sys
+    - hostPath:
+        path: /
+      name: root


### PR DESCRIPTION
Updates node-exporter to 1.0.1 and mounts "/" of host instead of only proc and sys (this is what is done in reference config for 1.0.1 version here: https://github.com/prometheus-operator/kube-prometheus/blob/master/manifests/node-exporter-daemonset.yaml) 

The goal is to include cpu schedstat which may be useful for debugging https://github.com/kubernetes/kubernetes/issues/97801

/assign @mm4tt 