### PR TITLE
Make Cl2 tests to work in <100 node clusters

### DIFF
--- a/clusterloader2/pkg/tuningset/randomized_time_limited.go
+++ b/clusterloader2/pkg/tuningset/randomized_time_limited.go
@@ -40,7 +40,10 @@ func (r *randomizedTimeLimitedLoad) Execute(actions []func()) {
 		index := i
 		wg.Start(func() {
 			// Sleeps for random duration in [0, TimeLimit].
-			time.Sleep(time.Duration(rand.Int63n(r.params.TimeLimit.ToTimeDuration().Nanoseconds())))
+			timeLimit := r.params.TimeLimit.ToTimeDuration().Nanoseconds()
+			if timeLimit > 0 {
+				time.Sleep(time.Duration(rand.Int63n(timeLimit)))
+			}
 			actions[index]()
 		})
 	}

--- a/clusterloader2/testing/density/config.yaml
+++ b/clusterloader2/testing/density/config.yaml
@@ -4,7 +4,8 @@
 
 #Constants
 {{$DENSITY_RESOURCE_CONSTRAINTS_FILE := DefaultParam .DENSITY_RESOURCE_CONSTRAINTS_FILE ""}}
-{{$NODES_PER_NAMESPACE := DefaultParam .NODES_PER_NAMESPACE 100}}
+# Cater for the case where the number of nodes is less than nodes per namespace. See https://github.com/kubernetes/perf-tests/issues/887
+{{$NODES_PER_NAMESPACE := MinInt .Nodes (DefaultParam .NODES_PER_NAMESPACE 100)}}
 {{$PODS_PER_NODE := DefaultParam .PODS_PER_NODE 30}}
 {{$DENSITY_TEST_THROUGHPUT := DefaultParam .DENSITY_TEST_THROUGHPUT 20}}
 {{$SCHEDULER_THROUGHPUT_THRESHOLD := DefaultParam .CL2_SCHEDULER_THROUGHPUT_THRESHOLD 0}}

--- a/clusterloader2/testing/density/high-density-config.yaml
+++ b/clusterloader2/testing/density/high-density-config.yaml
@@ -5,7 +5,8 @@
 
 #Constants
 {{$DENSITY_RESOURCE_CONSTRAINTS_FILE := DefaultParam .DENSITY_RESOURCE_CONSTRAINTS_FILE ""}}
-{{$NODES_PER_NAMESPACE := DefaultParam .NODES_PER_NAMESPACE 100}}
+# Cater for the case where the number of nodes is less than nodes per namespace. See https://github.com/kubernetes/perf-tests/issues/887
+{{$NODES_PER_NAMESPACE := MinInt .Nodes (DefaultParam .NODES_PER_NAMESPACE 100)}}
 {{$PODS_PER_NODE := DefaultParam .PODS_PER_NODE 30}}
 {{$DENSITY_TEST_THROUGHPUT := DefaultParam .DENSITY_TEST_THROUGHPUT 20}}
 {{$SCHEDULER_THROUGHPUT_THRESHOLD := DefaultParam .CL2_SCHEDULER_THROUGHPUT_THRESHOLD 0}}

--- a/clusterloader2/testing/experimental/storage/pod-startup/config.yaml
+++ b/clusterloader2/testing/experimental/storage/pod-startup/config.yaml
@@ -3,7 +3,8 @@
 # - If using Persistent Volumes, the default storage class must have volumeBindingMode: Immediate
 
 # Cluster Variables
-  {{$NODES_PER_NAMESPACE := DefaultParam .NODES_PER_NAMESPACE 100}}
+  # Cater for the case where the number of nodes is less than nodes per namespace. See https://github.com/kubernetes/perf-tests/issues/887
+  {{$NODES_PER_NAMESPACE := MinInt .Nodes (DefaultParam .NODES_PER_NAMESPACE 100)}} 
 
 # Test Variales
   {{$PODS_PER_NODE := .PODS_PER_NODE}}

--- a/clusterloader2/testing/load/config.yaml
+++ b/clusterloader2/testing/load/config.yaml
@@ -5,7 +5,10 @@
 # - Only half of Deployments will be assigned 1-1 to existing SVCs.
 
 #Constants
-{{$NODES_PER_NAMESPACE := DefaultParam .NODES_PER_NAMESPACE 100}}
+# Cater for the case where the number of nodes is less than nodes per namespace. See https://github.com/kubernetes/perf-tests/issues/887
+{{$NODES_PER_NAMESPACE := MinInt .Nodes (DefaultParam .NODES_PER_NAMESPACE 100)}}
+# See https://github.com/kubernetes/perf-tests/pull/1667#issuecomment-769642266
+{{$IS_SMALL_CLUSTER := lt .Nodes 100}}
 {{$PODS_PER_NODE := DefaultParam .PODS_PER_NODE 30}}
 {{$LOAD_TEST_THROUGHPUT := DefaultParam .CL2_LOAD_TEST_THROUGHPUT 10}}
 {{$DELETE_TEST_THROUGHPUT := DefaultParam .CL2_DELETE_TEST_THROUGHPUT $LOAD_TEST_THROUGHPUT}}
@@ -50,14 +53,21 @@
 {{$mediumDeploymentsPerNamespace := DivideInt $podsPerNamespace (MultiplyInt 4 $MEDIUM_GROUP_SIZE)}}
 # smallDeployments - 1/2 of namespace pods should be in small Deployments.
 {{$smallDeploymentsPerNamespace := DivideInt $podsPerNamespace (MultiplyInt 2 $SMALL_GROUP_SIZE)}}
-# Reduce the number of small and medium deployments per namespace
-{{$smallDeploymentsPerNamespace := SubtractInt $smallDeploymentsPerNamespace $SMALL_STATEFUL_SETS_PER_NAMESPACE}}
-{{$mediumDeploymentsPerNamespace := SubtractInt $mediumDeploymentsPerNamespace $MEDIUM_STATEFUL_SETS_PER_NAMESPACE}}
 
-# Reduce the number of small, medium, big deployments per namespace.
-{{$smallDeploymentsPerNamespace := SubtractInt $smallDeploymentsPerNamespace 1}}
-{{$mediumDeploymentsPerNamespace := SubtractInt $mediumDeploymentsPerNamespace 1}}
-{{$bigDeploymentsPerNamespace := SubtractInt $bigDeploymentsPerNamespace 1}}
+# Stateful sets are enabled. Reduce the number of small and medium deployments per namespace
+# See https://github.com/kubernetes/perf-tests/issues/1036#issuecomment-607631768
+# Ensure non zero or negative after subtraction.
+{{$smallDeploymentsPerNamespace := MaxInt 0 (SubtractInt $smallDeploymentsPerNamespace $SMALL_STATEFUL_SETS_PER_NAMESPACE)}}
+{{$mediumDeploymentsPerNamespace := MaxInt 0 (SubtractInt $mediumDeploymentsPerNamespace $MEDIUM_STATEFUL_SETS_PER_NAMESPACE)}}
+
+# Jobs are enabled. Reduce the number of small, medium, big deployments per namespace.
+# Ensure non zero or negative after subtraction.
+{{$smallDeploymentsPerNamespace := MaxInt 0 (SubtractInt $smallDeploymentsPerNamespace 1)}}
+{{$mediumDeploymentsPerNamespace := MaxInt 0 (SubtractInt $mediumDeploymentsPerNamespace 1)}}
+{{$bigDeploymentsPerNamespace := MaxInt 0 (SubtractInt $bigDeploymentsPerNamespace 1)}}
+
+# Disable big jobs on small clusters.
+{{$bigJobsPerNamespace := IfThenElse $IS_SMALL_CLUSTER 0 1}}
 
 # The minimal number of pods to be used to measure various things like
 # pod-startup-latency or scheduler-throughput. The purpose of it is to avoid
@@ -72,6 +82,10 @@
 {{$schedulerThroughputNamespaces := DivideInt $totalSchedulerThroughputPods $schedulerThroughputPodsPerDeployment}}
 {{$schedulerThroughputThreshold := DefaultParam .CL2_SCHEDULER_THROUGHPUT_THRESHOLD 100}}
 # END scheduler-throughput section
+
+# Set schedulerThroughputNamespaces to 0 on small clusters otherwise it will result
+# in an unnecessary number of namespaces.
+{{$schedulerThroughputNamespaces := IfThenElse $IS_SMALL_CLUSTER 0 $schedulerThroughputNamespaces}}
 
 # TODO(https://github.com/kubernetes/perf-tests/issues/1024): Investigate and get rid of this section.
 # BEGIN pod-startup-latency section
@@ -348,7 +362,7 @@ steps:
   - namespaceRange:
       min: 1
       max: {{$namespaces}}
-    replicasPerNamespace: 1
+    replicasPerNamespace: {{$bigJobsPerNamespace}}
     tuningSet: RandomizedSaturationTimeLimited
     objectBundle:
       - basename: big-job
@@ -388,6 +402,7 @@ steps:
 {{end}}
 {{if not $EXIT_AFTER_EXEC}}
 
+{{if not $IS_SMALL_CLUSTER}}
 # BEGIN scheduler throughput
 - name: Creating scheduler throughput measurements
   measurements:
@@ -463,7 +478,9 @@ steps:
     Params:
       action: gather
 # END scheduler throughput
+{{end}}
 
+{{if not $IS_SMALL_CLUSTER}}
 # TODO(https://github.com/kubernetes/perf-tests/issues/1024): Ideally, we wouldn't need this section.
 # BEGIN pod-startup-latency
 - name: Starting latency pod measurements
@@ -526,6 +543,7 @@ steps:
     Params:
       action: gather
 # END pod-startup-latency
+{{end}}
 
 - name: Scaling and updating objects
   phases:
@@ -630,7 +648,7 @@ steps:
   - namespaceRange:
       min: 1
       max: {{$namespaces}}
-    replicasPerNamespace: 1
+    replicasPerNamespace: {{$bigJobsPerNamespace}}
     tuningSet: RandomizedScalingTimeLimited
     objectBundle:
       - basename: big-job


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

**What this PR does / why we need it**:
Details: https://github.com/kubernetes/perf-tests/issues/887

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/perf-tests/issues/887

**Special notes for your reviewer**:
The type [conversion](https://github.com/kubernetes/perf-tests/blob/master/clusterloader2/pkg/config/template_functions.go#L133) was rounding fractions to 0. Hence when `.Nodes` passed in is less than `NODES_PER_NAMESPACE (defaults to 100)`, `namespaces = DivideInt .Nodes  NODES_PER_NAMESPACE = 0`. thereafter `namespace` is used as the denominator for several computations eg. https://github.com/kubernetes/perf-tests/blob/master/clusterloader2/testing/load/config.yaml#L7

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Users can now run load tests with < 100 nodes
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```