### PR TITLE
Set name in services module

### DIFF
--- a/clusterloader2/testing/load/modules/services.yaml
+++ b/clusterloader2/testing/load/modules/services.yaml
@@ -1,10 +1,10 @@
 ## Services modules provides a module for creating / deleting services.
 
 ## Input params
-{{$name := .actionName}}
+{{$name := .name}}
 {{$namespaces := .namespaces}}
 {{$smallServicesPerNamespace := .smallServicesPerNamespace}}
-{{$mediumServicesPerNamespace := .smallServicesPerNamespace}}
+{{$mediumServicesPerNamespace := .mediumServicesPerNamespace}}
 {{$bigServicesPerNamespace := .bigServicesPerNamespace}}
 
 steps:


### PR DESCRIPTION
It should use name 'name', not 'actionName': https://github.com/kubernetes/perf-tests/blob/master/clusterloader2/testing/load/config.yaml#L181

/assign @mm4tt 