### PR TITLE
[release-1.19] Custom thresholds param to APIResponsivenessSimple measurement

### DIFF
--- a/clusterloader2/testing/load/config.yaml
+++ b/clusterloader2/testing/load/config.yaml
@@ -911,6 +911,7 @@ steps:
       useSimpleLatencyQuery: true
       summaryName: APIResponsivenessPrometheus_simple
       allowedSlowCalls: {{$ALLOWED_SLOW_API_CALLS}}
+      customThresholds: {{YamlQuote $CUSTOM_API_CALL_THRESHOLDS 4}}
   {{if not $USE_SIMPLE_LATENCY_QUERY}}
   - Identifier: APIResponsivenessPrometheus
     Method: APIResponsivenessPrometheus


### PR DESCRIPTION
Backport of https://github.com/kubernetes/perf-tests/pull/1670.

/assign @mm4tt 