### PR TITLE
Dump instanceIDs for master nodes in clusterloader

### DIFF
--- a/clusterloader2/cmd/clusterloader.go
+++ b/clusterloader2/cmd/clusterloader.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/perf-tests/clusterloader2/pkg/flags"
 	"k8s.io/perf-tests/clusterloader2/pkg/framework"
 	"k8s.io/perf-tests/clusterloader2/pkg/imagepreload"
+	"k8s.io/perf-tests/clusterloader2/pkg/metadata"
 	"k8s.io/perf-tests/clusterloader2/pkg/modifier"
 	"k8s.io/perf-tests/clusterloader2/pkg/prometheus"
 	"k8s.io/perf-tests/clusterloader2/pkg/provider"
@@ -298,6 +299,10 @@ func main() {
 	}
 	if err := imagepreload.Setup(&clusterLoaderConfig, f); err != nil {
 		klog.Exitf("Error while preloading images: %v", err)
+	}
+
+	if err := metadata.Dump(f, path.Join(clusterLoaderConfig.ReportDir, "cl2-metadata.json")); err != nil {
+		klog.Errorf("Error while dumping metadata: %v", err)
 	}
 
 	testReporter := test.CreateSimpleReporter(path.Join(clusterLoaderConfig.ReportDir, "junit.xml"), "ClusterLoaderV2")

--- a/clusterloader2/pkg/metadata/metadata.go
+++ b/clusterloader2/pkg/metadata/metadata.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metadata
+
+import (
+	"encoding/json"
+	"io/ioutil"
+
+	"k8s.io/perf-tests/clusterloader2/pkg/framework"
+)
+
+// Dump writes file with data useful for debugging.
+// kubetest --metadata-sources should point to that file so that
+// it's merged into `finished.json` and available in prow and
+// bigquery tables.
+func Dump(f *framework.Framework, outputFile string) error {
+	output := make(map[string]string)
+
+	// Write any clusterloader-specific metadata here.
+
+	providerMetadata, err := f.GetClusterConfig().Provider.Metadata(f.GetClientSets().GetClient())
+	if err != nil {
+		return err
+	}
+
+	for k, v := range providerMetadata {
+		output[k] = v
+	}
+
+	return write(output, outputFile)
+}
+
+func write(obj map[string]string, outputFile string) error {
+	out, err := json.Marshal(obj)
+	if err != nil {
+		return err
+	}
+	return ioutil.WriteFile(outputFile, out, 0644)
+}

--- a/clusterloader2/pkg/provider/aks.go
+++ b/clusterloader2/pkg/provider/aks.go
@@ -16,6 +16,10 @@ limitations under the License.
 
 package provider
 
+import (
+	clientset "k8s.io/client-go/kubernetes"
+)
+
 type AKSProvider struct {
 	features Features
 }
@@ -49,4 +53,8 @@ func (p *AKSProvider) GetConfig() Config {
 
 func (p *AKSProvider) RunSSHCommand(cmd, host string) (string, string, int, error) {
 	return runSSHCommand(cmd, host)
+}
+
+func (p *AKSProvider) Metadata(client clientset.Interface) (map[string]string, error) {
+	return nil, nil
 }

--- a/clusterloader2/pkg/provider/aws.go
+++ b/clusterloader2/pkg/provider/aws.go
@@ -17,6 +17,7 @@ limitations under the License.
 package provider
 
 import (
+	clientset "k8s.io/client-go/kubernetes"
 	sshutil "k8s.io/kubernetes/pkg/ssh"
 )
 
@@ -60,4 +61,8 @@ func (p *AWSProvider) RunSSHCommand(cmd, host string) (string, string, int, erro
 	}
 	user := defaultSSHUser()
 	return sshutil.RunSSHCommand(cmd, user, host, signer)
+}
+
+func (p *AWSProvider) Metadata(client clientset.Interface) (map[string]string, error) {
+	return nil, nil
 }

--- a/clusterloader2/pkg/provider/eks.go
+++ b/clusterloader2/pkg/provider/eks.go
@@ -17,6 +17,7 @@ limitations under the License.
 package provider
 
 import (
+	clientset "k8s.io/client-go/kubernetes"
 	sshutil "k8s.io/kubernetes/pkg/ssh"
 )
 
@@ -59,4 +60,8 @@ func (p *EKSProvider) RunSSHCommand(cmd, host string) (string, string, int, erro
 	}
 	user := defaultSSHUser()
 	return sshutil.RunSSHCommand(cmd, user, host, signer)
+}
+
+func (p *EKSProvider) Metadata(client clientset.Interface) (map[string]string, error) {
+	return nil, nil
 }

--- a/clusterloader2/pkg/provider/gke.go
+++ b/clusterloader2/pkg/provider/gke.go
@@ -17,6 +17,7 @@ limitations under the License.
 package provider
 
 import (
+	clientset "k8s.io/client-go/kubernetes"
 	sshutil "k8s.io/kubernetes/pkg/ssh"
 )
 
@@ -62,4 +63,8 @@ func (p *GKEProvider) RunSSHCommand(cmd, host string) (string, string, int, erro
 	}
 	user := defaultSSHUser()
 	return sshutil.RunSSHCommand(cmd, user, host, signer)
+}
+
+func (p *GKEProvider) Metadata(client clientset.Interface) (map[string]string, error) {
+	return nil, nil
 }

--- a/clusterloader2/pkg/provider/kubemark.go
+++ b/clusterloader2/pkg/provider/kubemark.go
@@ -17,6 +17,7 @@ limitations under the License.
 package provider
 
 import (
+	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/klog"
 	sshutil "k8s.io/kubernetes/pkg/ssh"
 )
@@ -66,4 +67,9 @@ func (p *KubemarkProvider) RunSSHCommand(cmd, host string) (string, string, int,
 	}
 	user := defaultSSHUser()
 	return sshutil.RunSSHCommand(cmd, user, host, signer)
+}
+
+// TODO(mborsz): Dump instanceIDs for master nodes (as in gce).
+func (p *KubemarkProvider) Metadata(client clientset.Interface) (map[string]string, error) {
+	return nil, nil
 }

--- a/clusterloader2/pkg/provider/local.go
+++ b/clusterloader2/pkg/provider/local.go
@@ -17,6 +17,7 @@ limitations under the License.
 package provider
 
 import (
+	clientset "k8s.io/client-go/kubernetes"
 	sshutil "k8s.io/kubernetes/pkg/ssh"
 )
 
@@ -60,4 +61,8 @@ func (p *LocalProvider) RunSSHCommand(cmd, host string) (string, string, int, er
 	}
 	user := defaultSSHUser()
 	return sshutil.RunSSHCommand(cmd, user, host, signer)
+}
+
+func (p *LocalProvider) Metadata(client clientset.Interface) (map[string]string, error) {
+	return nil, nil
 }

--- a/clusterloader2/pkg/provider/provider.go
+++ b/clusterloader2/pkg/provider/provider.go
@@ -19,6 +19,8 @@ package provider
 import (
 	"fmt"
 	"strings"
+
+	clientset "k8s.io/client-go/kubernetes"
 )
 
 // InitOptions encapsulates the fields needed to init provider.
@@ -79,6 +81,9 @@ type Provider interface {
 	GetComponentProtocolAndPort(componentName string) (string, int, error)
 
 	RunSSHCommand(cmd, host string) (string, string, int, error)
+
+	// Metadata returns provider-specific test run metadata.
+	Metadata(client clientset.Interface) (map[string]string, error)
 }
 
 // NewProvider creates a new provider from init options. It will return an error if provider name is not supported.

--- a/clusterloader2/pkg/provider/skeleton.go
+++ b/clusterloader2/pkg/provider/skeleton.go
@@ -17,6 +17,7 @@ limitations under the License.
 package provider
 
 import (
+	clientset "k8s.io/client-go/kubernetes"
 	sshutil "k8s.io/kubernetes/pkg/ssh"
 )
 
@@ -64,4 +65,8 @@ func (p *SkeletonProvider) RunSSHCommand(cmd, host string) (string, string, int,
 	}
 	user := defaultSSHUser()
 	return sshutil.RunSSHCommand(cmd, user, host, signer)
+}
+
+func (p *SkeletonProvider) Metadata(client clientset.Interface) (map[string]string, error) {
+	return nil, nil
 }

--- a/clusterloader2/pkg/provider/vsphere.go
+++ b/clusterloader2/pkg/provider/vsphere.go
@@ -17,6 +17,7 @@ limitations under the License.
 package provider
 
 import (
+	clientset "k8s.io/client-go/kubernetes"
 	sshutil "k8s.io/kubernetes/pkg/ssh"
 )
 
@@ -60,4 +61,8 @@ func (p *VsphereProvider) RunSSHCommand(cmd, host string) (string, string, int, 
 	}
 	user := defaultSSHUser()
 	return sshutil.RunSSHCommand(cmd, user, host, signer)
+}
+
+func (p *VsphereProvider) Metadata(client clientset.Interface) (map[string]string, error) {
+	return nil, nil
 }


### PR DESCRIPTION
Idea:

If we start dumping instanceIDs for master nodes in gce tests and write it to 'finished.json' this information will be then available in `k8s-gubernator.build.all` and can be used for programmatically analyzing runs.

Usage: this PR writes 'cl2-metadata.json' file. If we include this file in --metadata-sources, it should be merged into finished.json which is what we need.