### PR TITLE
Add kube-state-metrics latency measurement 

### DIFF
--- a/clusterloader2/pkg/measurement/common/kube_state_metrics_measurement.go
+++ b/clusterloader2/pkg/measurement/common/kube_state_metrics_measurement.go
@@ -1,0 +1,213 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"k8s.io/perf-tests/clusterloader2/pkg/measurement"
+	measurementutil "k8s.io/perf-tests/clusterloader2/pkg/measurement/util"
+	"k8s.io/perf-tests/clusterloader2/pkg/util"
+
+	"github.com/prometheus/common/model"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/klog"
+)
+
+const (
+	ksmLatencyName               = "KubeStateMetricsLatency"
+	ksmRequestDurationMetricName = model.LabelValue("http_request_duration_seconds_bucket")
+	probeIntervalDefault         = 30 * time.Second
+	ksmNamespace                 = "kube-state-metrics-perf-test"
+	ksmServiceName               = "kube-state-metrics"
+	ksmSelfPort                  = 8081
+	ksmMetricsPort               = 8080
+)
+
+type ksmLatencyMeasurement struct {
+	ctx            context.Context
+	cancel         func()
+	isRunning      bool
+	namespace      string
+	serviceName    string
+	metricsPort    int
+	selfPort       int
+	initialLatency *measurementutil.Histogram
+	wg             sync.WaitGroup
+}
+
+func init() {
+	if err := measurement.Register(ksmLatencyName, CreateKSMLatencyMeasurement); err != nil {
+		klog.Fatalf("Cannot register %s: %v", ksmLatencyName, err)
+	}
+}
+
+// CreateKSMLatencyMeasurement creates a new Kube State
+// Metrics Measurement.
+func CreateKSMLatencyMeasurement() measurement.Measurement {
+	ctx, cancel := context.WithCancel(context.Background())
+	return &ksmLatencyMeasurement{
+		namespace:   ksmNamespace,
+		serviceName: ksmServiceName,
+		selfPort:    ksmSelfPort,
+		metricsPort: ksmMetricsPort,
+		ctx:         ctx,
+		cancel:      cancel,
+	}
+}
+
+// Execute supports two actions:
+// - start - starts goroutine and queries /metrics every probeIntervalDefault interval,
+// it also collects initial latency metrics.
+// - gather - gathers latency metrics and creates a latency summary.
+func (m *ksmLatencyMeasurement) Execute(config *measurement.Config) ([]measurement.Summary, error) {
+	action, err := util.GetString(config.Params, "action")
+	if err != nil {
+		return nil, err
+	}
+	client := config.ClusterFramework.GetClientSets().GetClient()
+	switch action {
+	case "start":
+		if m.isRunning {
+			klog.V(2).Infof("%s: measurement already running", m)
+			return nil, nil
+		}
+		// Start executing calls towards the kube-state-metrics /metrics endpoint
+		// every probeIntervalDefault until gather is called.
+		// probeIntervalDefault equals the scrapping interval we suggest.
+		// If we cannot get metrics for two minutes we are already going over
+		// the scrape interval so we should cancel.
+		m.startQuerying(m.ctx, client, probeIntervalDefault)
+		// Retrieve initial latency when first call is done.
+		m.initialLatency, err = m.retrieveKSMLatencyMetrics(m.ctx, client)
+		return nil, err
+	case "gather":
+		defer m.cancel()
+		return m.createKSMLatencySummary(m.ctx, client)
+	default:
+		return nil, fmt.Errorf("unknown action %v", action)
+	}
+}
+
+func (m *ksmLatencyMeasurement) stop() error {
+	if !m.isRunning {
+		return fmt.Errorf("%s: measurement was not running", m)
+	}
+	m.cancel()
+	m.wg.Wait()
+	return nil
+}
+
+// createKSMLatencyReport gathers the latency one last time and creates the summary based on the Quantile from the sub histograms.
+// Afterwards it creates the Summary Report.
+func (m *ksmLatencyMeasurement) createKSMLatencySummary(ctx context.Context, client clientset.Interface) ([]measurement.Summary, error) {
+	latestLatency, err := m.retrieveKSMLatencyMetrics(ctx, client)
+	if err != nil {
+		return nil, err
+	}
+	if err = m.stop(); err != nil {
+		return nil, err
+	}
+	// We want to subtract the latest histogram from the first one we collect.
+	finalLatency := HistogramSub(latestLatency, m.initialLatency)
+	// Pretty Print the report.
+	result := &measurementutil.LatencyMetric{}
+	if err = SetQuantileFromHistogram(result, finalLatency); err != nil {
+		return nil, err
+	}
+	content, err := util.PrettyPrintJSON(result)
+	if err != nil {
+		return nil, err
+	}
+	// Create Summary.
+	return []measurement.Summary{measurement.CreateSummary(ksmLatencyName, "json", content)}, nil
+}
+
+// startQuerying queries /metrics endpoint of kube-state-metrics kube_ metrics every interval
+// and stops when stop is called.
+func (m *ksmLatencyMeasurement) startQuerying(ctx context.Context, client clientset.Interface, interval time.Duration) {
+	m.isRunning = true
+	m.wg.Add(1)
+	go m.queryLoop(ctx, client, interval)
+}
+
+func (m *ksmLatencyMeasurement) queryLoop(ctx context.Context, client clientset.Interface, interval time.Duration) {
+	defer m.wg.Done()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(interval):
+			var output string
+			output, err := m.getMetricsFromService(ctx, client, m.metricsPort)
+			if err != nil {
+				klog.V(2).Infof("error during fetching metrics from service: %v", err)
+			}
+			if output == "" {
+				klog.V(2).Infof("/metrics endpoint of kube-state-metrics returned no data in namespace: %s from service: %s port: %d", m.namespace, m.serviceName, m.metricsPort)
+			}
+
+		}
+	}
+}
+
+func (m *ksmLatencyMeasurement) retrieveKSMLatencyMetrics(ctx context.Context, c clientset.Interface) (*measurementutil.Histogram, error) {
+	ksmHist := measurementutil.NewHistogram(nil)
+	output, err := m.getMetricsFromService(ctx, c, m.selfPort)
+	if err != nil {
+		return ksmHist, err
+	}
+	samples, err := measurementutil.ExtractMetricSamples(output)
+	if err != nil {
+		return ksmHist, err
+	}
+	for _, sample := range samples {
+		switch sample.Metric[model.MetricNameLabel] {
+		case ksmRequestDurationMetricName:
+			measurementutil.ConvertSampleToHistogram(sample, ksmHist)
+		}
+	}
+	return ksmHist, nil
+}
+
+func (m *ksmLatencyMeasurement) getMetricsFromService(ctx context.Context, client clientset.Interface, port int) (string, error) {
+	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
+	defer cancel()
+	out, err := client.CoreV1().RESTClient().Get().
+		Resource("services").
+		SubResource("proxy").
+		Namespace(m.namespace).
+		Name(fmt.Sprintf("%v:%v", m.serviceName, port)).
+		Suffix("metrics").
+		Do(ctx).Raw()
+	return string(out), err
+}
+
+// Dispose cleans up after the measurement.
+func (m *ksmLatencyMeasurement) Dispose() {
+	if err := m.stop(); err != nil {
+		klog.V(2).Infof("error during dispose call: %v", err)
+	}
+}
+
+// String returns string representation of this measurement.
+func (m *ksmLatencyMeasurement) String() string {
+	return ksmLatencyName
+}

--- a/clusterloader2/pkg/measurement/common/scheduler_latency.go
+++ b/clusterloader2/pkg/measurement/common/scheduler_latency.go
@@ -144,8 +144,8 @@ func (*schedulerLatencyMeasurement) String() string {
 	return schedulerLatencyMetricName
 }
 
-// histogramSub is a helper function to substract two histograms
-func histogramSub(finalHist, initialHist *measurementutil.Histogram) *measurementutil.Histogram {
+// HistogramSub is a helper function to substract two histograms
+func HistogramSub(finalHist, initialHist *measurementutil.Histogram) *measurementutil.Histogram {
 	for k := range finalHist.Buckets {
 		finalHist.Buckets[k] = finalHist.Buckets[k] - initialHist.Buckets[k]
 	}
@@ -154,17 +154,17 @@ func histogramSub(finalHist, initialHist *measurementutil.Histogram) *measuremen
 
 func (m *schedulerLatencyMetrics) substract(sub schedulerLatencyMetrics) {
 	if sub.preemptionEvaluationHist != nil {
-		m.preemptionEvaluationHist = histogramSub(m.preemptionEvaluationHist, sub.preemptionEvaluationHist)
+		m.preemptionEvaluationHist = HistogramSub(m.preemptionEvaluationHist, sub.preemptionEvaluationHist)
 	}
 	if sub.schedulingAlgorithmDurationHist != nil {
-		m.schedulingAlgorithmDurationHist = histogramSub(m.schedulingAlgorithmDurationHist, sub.schedulingAlgorithmDurationHist)
+		m.schedulingAlgorithmDurationHist = HistogramSub(m.schedulingAlgorithmDurationHist, sub.schedulingAlgorithmDurationHist)
 	}
 	if sub.e2eSchedulingDurationHist != nil {
-		m.e2eSchedulingDurationHist = histogramSub(m.e2eSchedulingDurationHist, sub.e2eSchedulingDurationHist)
+		m.e2eSchedulingDurationHist = HistogramSub(m.e2eSchedulingDurationHist, sub.e2eSchedulingDurationHist)
 	}
 	for _, ep := range extentionsPoints {
 		if sub.frameworkExtensionPointDurationHist[ep] != nil {
-			m.frameworkExtensionPointDurationHist[ep] = histogramSub(m.frameworkExtensionPointDurationHist[ep], sub.frameworkExtensionPointDurationHist[ep])
+			m.frameworkExtensionPointDurationHist[ep] = HistogramSub(m.frameworkExtensionPointDurationHist[ep], sub.frameworkExtensionPointDurationHist[ep])
 		}
 	}
 }
@@ -177,20 +177,20 @@ func (s *schedulerLatencyMeasurement) setQuantiles(metrics schedulerLatencyMetri
 		result.FrameworkExtensionPointDuration[ePoint] = &measurementutil.LatencyMetric{}
 	}
 
-	if err := s.setQuantileFromHistogram(&result.E2eSchedulingLatency, metrics.e2eSchedulingDurationHist); err != nil {
+	if err := SetQuantileFromHistogram(&result.E2eSchedulingLatency, metrics.e2eSchedulingDurationHist); err != nil {
 		return result, err
 	}
-	if err := s.setQuantileFromHistogram(&result.SchedulingLatency, metrics.schedulingAlgorithmDurationHist); err != nil {
+	if err := SetQuantileFromHistogram(&result.SchedulingLatency, metrics.schedulingAlgorithmDurationHist); err != nil {
 		return result, err
 	}
 
 	for _, ePoint := range extentionsPoints {
-		if err := s.setQuantileFromHistogram(result.FrameworkExtensionPointDuration[ePoint], metrics.frameworkExtensionPointDurationHist[ePoint]); err != nil {
+		if err := SetQuantileFromHistogram(result.FrameworkExtensionPointDuration[ePoint], metrics.frameworkExtensionPointDurationHist[ePoint]); err != nil {
 			return result, err
 		}
 	}
 
-	if err := s.setQuantileFromHistogram(&result.PreemptionEvaluationLatency, metrics.preemptionEvaluationHist); err != nil {
+	if err := SetQuantileFromHistogram(&result.PreemptionEvaluationLatency, metrics.preemptionEvaluationHist); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -268,8 +268,8 @@ func (s *schedulerLatencyMeasurement) getSchedulingMetrics(c clientset.Interface
 	return latencyMetrics, nil
 }
 
-// setQuantileFromHistogram sets quantile of LatencyMetric from Histogram
-func (s *schedulerLatencyMeasurement) setQuantileFromHistogram(metric *measurementutil.LatencyMetric, hist *measurementutil.Histogram) error {
+// SetQuantileFromHistogram sets quantile of LatencyMetric from Histogram
+func SetQuantileFromHistogram(metric *measurementutil.LatencyMetric, hist *measurementutil.Histogram) error {
 	quantiles := []float64{0.5, 0.9, 0.99}
 	for _, quantile := range quantiles {
 		histQuantile, err := hist.Quantile(quantile)

--- a/clusterloader2/pkg/measurement/summary.go
+++ b/clusterloader2/pkg/measurement/summary.go
@@ -28,7 +28,7 @@ type genericSummary struct {
 	content   string
 }
 
-// CreateSummary creates gneric summary.
+// CreateSummary creates generic summary.
 func CreateSummary(name, ext, content string) Summary {
 	return &genericSummary{
 		name:      name,


### PR DESCRIPTION
Hello, as discussed and asked on the SIG scalability [mailing list](https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/kubernetes-sig-scale/UHx_ISEHT24/TEeAyVn7CAAJ), we need a performance test for kube-state-metrics. I followed the suggestions there, and hopefully, this is correct!

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This is needed as the last step of https://github.com/kubernetes/kube-state-metrics 2.0 release. As mentioned in the mailing list, we want to run performance and scale tests to ensure we can run on a certain amount of nodes, but also to give our users some expectations on the number of resources needed, but also the latency they can expect.

kube-state-metrics has two /metrics endpoints, one /metrics that serve metrics about Kubernetes objects and one that is a self metrics about kube-state-metrics itself. In this test we first query the main /metrics endpoint and after that get the latency metrics on the self /metrics endpoint. We do this every 10 seconds, and until the gather action is called. When gather is called we create a summary report based on the collected latency metrics quantiles.

**Which issue(s) this PR fixes**:

Fixes https://github.com/kubernetes/kube-state-metrics/issues/1341.

**Special notes for your reviewer**:

- I deployed kube-state-metrics as part of exports, this was just initial thought, open to whatever you suggest here, thanks!
- I can move the exposed functions I reused from other tests to util package, any thoughts on this? Or leave as is?
- Finally how do we test these? I tested it locally against my cluster by importing the newly created `CreateKSMLatencyMeasurement ` function and running start and gather actions and got summary correctly. Is that enough?

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links that point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

Thank you!! 🎉 

cc @brancz as mantainer of kube-state-metrics, as discussed a while ago here are the perf tests.