### PR TITLE
API availability measurement revamp - backport to release-1.19

### DIFF
--- a/clusterloader2/cmd/clusterloader.go
+++ b/clusterloader2/cmd/clusterloader.go
@@ -104,7 +104,7 @@ func validateClusterFlags() *errors.ErrorList {
 
 func initFlags() {
 	flags.StringVar(&clusterLoaderConfig.ReportDir, "report-dir", "", "Path to the directory where the reports should be saved. Default is empty, which cause reports being written to standard output.")
-	flags.BoolEnvVar(&clusterLoaderConfig.EnableExecService, "enable-exec-service", "ENABLE_EXEC_SERVICE", false, "Whether to enable exec service that allows executing arbitrary commands from a pod running in the cluster.")
+	flags.BoolEnvVar(&clusterLoaderConfig.EnableExecService, "enable-exec-service", "ENABLE_EXEC_SERVICE", true, "Whether to enable exec service that allows executing arbitrary commands from a pod running in the cluster.")
 	// TODO(https://github.com/kubernetes/perf-tests/issues/641): Remove testconfig and testoverrides flags when test suite is fully supported.
 	flags.StringArrayVar(&testConfigPaths, "testconfig", []string{}, "Paths to the test config files")
 	flags.StringArrayVar(&testOverridePaths, "testoverrides", []string{}, "Paths to the config overrides file. The latter overrides take precedence over changes in former files.")

--- a/clusterloader2/pkg/measurement/common/api_availability_measurement.go
+++ b/clusterloader2/pkg/measurement/common/api_availability_measurement.go
@@ -1,0 +1,173 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"context"
+	"fmt"
+	"k8s.io/perf-tests/clusterloader2/pkg/errors"
+	"k8s.io/perf-tests/clusterloader2/pkg/provider"
+	"sync"
+	"time"
+
+	goerrors "github.com/go-errors/errors"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/klog"
+	"k8s.io/perf-tests/clusterloader2/pkg/measurement"
+	measurementutil "k8s.io/perf-tests/clusterloader2/pkg/measurement/util"
+	"k8s.io/perf-tests/clusterloader2/pkg/util"
+)
+
+const (
+	apiAvailabilityName = "APIAvailability"
+)
+
+func init() {
+	if err := measurement.Register(apiAvailabilityName, createAPIAvailabilityMeasurement); err != nil {
+		klog.Fatalf("Cannot register %s: %v", apiAvailabilityName, err)
+	}
+}
+
+func createAPIAvailabilityMeasurement() measurement.Measurement {
+	return &apiAvailabilityMeasurement{}
+}
+
+type apiAvailabilityMeasurement struct {
+	isRunning           bool
+	stopCh              chan struct{}
+	hosts               []string
+	summaries           []measurement.Summary
+	clusterLevelMetrics *apiAvailabilityMetrics
+	hostLevelMetrics    map[string]*apiAvailabilityMetrics
+	wg                  sync.WaitGroup
+}
+
+func (a *apiAvailabilityMeasurement) updateMasterAvailabilityMetrics(c clientset.Interface, config *measurement.Config, provider provider.Provider) {
+	for _, host := range a.hosts {
+		// SSH and check the health of the host
+		command := fmt.Sprintf("curl -f -s -k %slocalhost:%v/healthz", "https://", 443)
+		sshResult, err := measurementutil.SSH(command, host+":22", provider)
+		availability := err != nil || sshResult.Code != 0
+		a.updateAvailabilityMetrics(availability, a.hostLevelMetrics[host])
+	}
+}
+
+func (a *apiAvailabilityMeasurement) updateClusterAvailabilityMetrics(c clientset.Interface) {
+	// Check the availability of the cluster by issuing a REST call to /healthz end point
+	result := c.CoreV1().RESTClient().Get().AbsPath("/healthz").Do(context.TODO())
+	status := 0
+	result.StatusCode(&status)
+	a.updateAvailabilityMetrics(status == 200, a.clusterLevelMetrics)
+}
+
+func (a *apiAvailabilityMeasurement) start(config *measurement.Config, SSHToMasterSupported bool, probeDuration int) error {
+	a.hosts = config.ClusterFramework.GetClusterConfig().MasterIPs
+	if len(a.hosts) < 1 {
+		return goerrors.Errorf("APIAvailability measurement can't start due to lack of master IPs")
+	}
+
+	k8sClient := config.ClusterFramework.GetClientSets().GetClient()
+	provider := config.ClusterFramework.GetClusterConfig().Provider
+
+	a.isRunning = true
+	a.stopCh = make(chan struct{})
+	a.wg.Add(1)
+
+	go func() {
+		defer a.wg.Done()
+		for {
+			select {
+			case <-a.stopCh:
+				return
+			case <-time.After(time.Duration(probeDuration)):
+				a.updateClusterAvailabilityMetrics(k8sClient)
+				if SSHToMasterSupported {
+					a.updateMasterAvailabilityMetrics(k8sClient, config, provider)
+				}
+			}
+		}
+	}()
+	return nil
+}
+
+// Execute starts the api-server healthz probe end point from start action and
+// collects availability metrics in gather.
+func (a *apiAvailabilityMeasurement) Execute(config *measurement.Config) ([]measurement.Summary, error) {
+	SSHToMasterSupported := !config.ClusterFramework.GetClusterConfig().Provider.Features().SupportSSHToMaster
+
+	if !SSHToMasterSupported {
+		klog.Infof("ssh to master nodes not supported. Measurement would have only Cluster Level Metrics")
+	}
+
+	action, err := util.GetString(config.Params, "action")
+	if err != nil {
+		return nil, err
+	}
+	probeFrequency, err := util.GetIntOrDefault(config.Params, "frequency", 1)
+	if err != nil {
+		return nil, err
+	}
+
+	switch action {
+	case "start":
+		if a.isRunning {
+			klog.Infof("%s: measurement already running", a)
+			return nil, nil
+		}
+		return nil, a.start(config, SSHToMasterSupported, probeFrequency)
+	case "gather":
+		err := a.stopAndSummarize(SSHToMasterSupported, probeFrequency)
+		if err != nil {
+			return nil, err
+		}
+		return a.summaries, nil
+	default:
+		return nil, fmt.Errorf("unknown action %v", action)
+	}
+}
+
+func (a *apiAvailabilityMeasurement) stopAndSummarize(SSHToMasterSupported bool, probeFrequency int) error {
+	if !a.isRunning {
+		return nil
+	}
+	close(a.stopCh)
+	a.wg.Wait()
+
+	output := apiAvailabilityOutput{}
+	output.createClusterSummary(a.clusterLevelMetrics, probeFrequency)
+	if SSHToMasterSupported {
+		output.createMastersSummary(a.hostLevelMetrics, a.hosts, probeFrequency)
+	}
+
+	errList := errors.NewErrorList()
+	content, err := util.PrettyPrintJSON(output)
+	if err != nil {
+		errList.Append(errList, err)
+	} else {
+		summary := measurement.CreateSummary(apiAvailabilityName, "json", content)
+		a.summaries = append(a.summaries, summary)
+	}
+	return errList
+}
+
+// Dispose cleans up after the measurement.
+func (a apiAvailabilityMeasurement) Dispose() {}
+
+// String returns string representation of this measurement.
+func (a apiAvailabilityMeasurement) String() string {
+	return apiAvailabilityName
+}

--- a/clusterloader2/pkg/measurement/common/api_availability_metrics.go
+++ b/clusterloader2/pkg/measurement/common/api_availability_metrics.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"time"
+)
+
+type apiAvailabilityMetrics struct {
+	numSuccesses               int
+	numFailures                int
+	maxConsecutiveFailedProbes int
+	consecutiveFailedProbes    int
+}
+
+type apiAvailabilitySummary struct {
+	IP                         string        `json:"IP"`
+	AvailabilityPercentage     float32       `json:"availabilityPercentage"`
+	LongestUnavailableDuration time.Duration `json:"longestUnavailableDuration"`
+}
+
+type apiAvailabilityOutput struct {
+	ClusterMetrics *apiAvailabilitySummary   `json:"clusterMetrics"`
+	MasterMetrics  []*apiAvailabilitySummary `json:"masterMetrics"`
+}
+
+func (output apiAvailabilityOutput) createClusterSummary(metrics *apiAvailabilityMetrics, probeFrequency int) {
+	metrics.buildAPIAvailabilityMetricsSummary(probeFrequency, true, "")
+}
+
+func (output apiAvailabilityOutput) createMastersSummary(metrics map[string]*apiAvailabilityMetrics, hosts []string, probeFrequency int) {
+	for _, host := range hosts {
+		masterHostAvailabilitySummary := metrics[host].buildAPIAvailabilityMetricsSummary(probeFrequency, false, host)
+		output.MasterMetrics = append(output.MasterMetrics, masterHostAvailabilitySummary)
+	}
+
+}
+
+// updateMaxConsecutiveFailuresIfNeeded checks if the recently concluded consecutive failed number of probes is
+// higher than the max consecutive failed number of probes so far
+// if yes, then Update max consecutive failed probes
+func (a *apiAvailabilityMetrics) updateMaxConsecutiveFailuresIfNeeded() {
+	if a.consecutiveFailedProbes > a.maxConsecutiveFailedProbes {
+		a.maxConsecutiveFailedProbes = a.consecutiveFailedProbes
+	}
+}
+
+func (a *apiAvailabilityMetrics) updateFailureMetrics() {
+	a.numFailures++
+	a.consecutiveFailedProbes++
+	a.updateMaxConsecutiveFailuresIfNeeded()
+}
+
+func (a *apiAvailabilityMetrics) updateSuccessMetrics() {
+	a.numSuccesses++
+	a.consecutiveFailedProbes = 0
+}
+
+func (a *apiAvailabilityMeasurement) updateAvailabilityMetrics(apiServerAvailable bool, metrics *apiAvailabilityMetrics) {
+	if apiServerAvailable {
+		metrics.updateSuccessMetrics()
+	} else {
+		metrics.updateFailureMetrics()
+	}
+}
+
+func (a *apiAvailabilityMetrics) buildAPIAvailabilityMetricsSummary(probeFrequency int, clusterMetrics bool, hostIP string) *apiAvailabilitySummary {
+	// Gather availability a
+	availabilityPercentage := (float32(a.numSuccesses) / float32(a.numSuccesses+a.numFailures)) * 100
+	longestUnavailableDuration := time.Duration(a.maxConsecutiveFailedProbes * probeFrequency)
+
+	apiAvailabilitySummary := &apiAvailabilitySummary{}
+	apiAvailabilitySummary.AvailabilityPercentage = availabilityPercentage
+	apiAvailabilitySummary.LongestUnavailableDuration = longestUnavailableDuration
+
+	return apiAvailabilitySummary
+}

--- a/clusterloader2/testing/load/config.yaml
+++ b/clusterloader2/testing/load/config.yaml
@@ -39,6 +39,7 @@
 {{$CUSTOM_API_CALL_THRESHOLDS := DefaultParam .CUSTOM_API_CALL_THRESHOLDS ""}}
 {{$ENABLE_VIOLATIONS_FOR_API_CALL_PROMETHEUS := DefaultParam .CL2_ENABLE_VIOLATIONS_FOR_API_CALL_PROMETHEUS false}}
 {{$ENABLE_VIOLATIONS_FOR_API_CALL_PROMETHEUS_SIMPLE := DefaultParam .CL2_ENABLE_VIOLATIONS_FOR_API_CALL_PROMETHEUS_SIMPLE true}}
+{{$ENABLE_API_AVAILABILITY_MEASUREMENT := DefaultParam .CL2_ENABLE_API_AVAILABILITY_MEASUREMENT false}}
 #Variables
 {{$namespaces := DivideInt .Nodes $NODES_PER_NAMESPACE}}
 {{$totalPods := MultiplyInt $namespaces $NODES_PER_NAMESPACE $PODS_PER_NODE}}
@@ -159,6 +160,14 @@ steps:
     Method: NetworkProgrammingLatency
     Params:
       action: start
+  {{end}}
+  {{if $ENABLE_API_AVAILABILITY_MEASUREMENT}}
+  - Identifier: APIAvailability
+    Method: APIAvailability
+    Params:
+      action: start
+      pollFrequency: "5s"
+      hostPollTimeoutSeconds: 5
   {{end}}
   - Identifier: TestMetrics
     Method: TestMetrics
@@ -407,6 +416,16 @@ steps:
       action: gather
 
 {{if $EXEC_COMMAND}}
+
+{{if $ENABLE_API_AVAILABILITY_MEASUREMENT}}
+- name: Pausing APIAvailability measurement
+  measurements:
+  - Identifier: APIAvailability
+    Method: APIAvailability
+    Params:
+      action: pause
+{{end}}
+
 - name: Exec command
   measurements:
   - Identifier: ExecCommand
@@ -416,6 +435,15 @@ steps:
       {{range $EXEC_COMMAND}}
       - {{.}}
       {{end}}
+
+{{if $ENABLE_API_AVAILABILITY_MEASUREMENT}}
+- name: Unpausing APIAvailability measurement
+  measurements:
+  - Identifier: APIAvailability
+    Method: APIAvailability
+    Params:
+      action: unpause
+{{end}}
 
 - name: Sleep
   measurements:
@@ -936,6 +964,12 @@ steps:
   {{if $PROMETHEUS_SCRAPE_KUBE_PROXY}}
   - Identifier: NetworkProgrammingLatency
     Method: NetworkProgrammingLatency
+    Params:
+      action: gather
+  {{end}}
+  {{if $ENABLE_API_AVAILABILITY_MEASUREMENT}}
+  - Identifier: APIAvailability
+    Method: APIAvailability
     Params:
       action: gather
   {{end}}


### PR DESCRIPTION
Backport https://github.com/kubernetes/perf-tests/pull/1162, https://github.com/kubernetes/perf-tests/pull/1679 and https://github.com/kubernetes/perf-tests/pull/1660 to release-1.19 branch.

/assign @mm4tt 