### PR TITLE
CL2 config validation

### DIFF
--- a/clusterloader2/api/default.go
+++ b/clusterloader2/api/default.go
@@ -18,6 +18,7 @@ package api
 
 import (
 	"fmt"
+
 	"k8s.io/perf-tests/clusterloader2/pkg/util"
 )
 
@@ -25,7 +26,7 @@ import (
 func (conf *Config) SetDefaults() {
 	conf.Namespace.SetDefaults()
 
-	// TODO: remove after deprecated automanagedNamespaces is disabled.
+	// TODO(#1696): Clean up after removing automanagedNamespaces
 	if conf.Namespace.Number == 1 && conf.AutomanagedNamespaces > 1 {
 		conf.Namespace.Number = conf.AutomanagedNamespaces
 	}

--- a/clusterloader2/api/types.go
+++ b/clusterloader2/api/types.go
@@ -42,8 +42,7 @@ type TestScenario struct {
 type Config struct {
 	// Name of the test case.
 	Name string `json:"name"`
-	// Deprecated: a number of automanaged namespaces.
-	// Use Namespace.Number instead.
+	// TODO(#1696): Clean up after removing automanagedNamespaces
 	AutomanagedNamespaces int32 `json:"automanagedNamespaces,omitempty"`
 	// Namespace is a structure for namespace configuration.
 	Namespace NamespaceConfig `json:"namespace"`

--- a/clusterloader2/api/validation.go
+++ b/clusterloader2/api/validation.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 The Kubernetes Authors.
+Copyright 2021 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -18,26 +18,230 @@ package api
 
 import (
 	"fmt"
+	"os"
 
+	"k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/perf-tests/clusterloader2/pkg/errors"
 )
 
-// Validate checks and verifies the configuration parameters.
-func (conf *Config) Validate() *errors.ErrorList {
-	// TODO(#1636): Validate other aspects of the api
-	return conf.Namespace.Validate()
+// ConfigValidator contains metadata for config validation.
+type ConfigValidator struct {
+	configDir string
+	config    *Config
 }
 
-// Validate checks and verifies the namespace parameters.
-func (ns *NamespaceConfig) Validate() *errors.ErrorList {
-	errList := errors.NewErrorList()
-	if ns.Number <= 0 {
-		errList.Append(fmt.Errorf("number of namespaces: %d was less than 1", ns.Number))
+// NewConfigValidator creates a new ConfigValidator object
+func NewConfigValidator(configDir string, config *Config) *ConfigValidator {
+	return &ConfigValidator{
+		configDir: configDir,
+		config:    config,
+	}
+}
+
+// Validate checks and verifies the configuration parameters.
+func (v *ConfigValidator) Validate() *errors.ErrorList {
+	allErrs := field.ErrorList{}
+	c := v.config
+
+	// TODO(#1696): Clean up after removing automanagedNamespaces
+	if c.AutomanagedNamespaces < 0 {
+		allErrs = append(allErrs, field.Invalid(field.NewPath("automanagedNamespaces"), c.AutomanagedNamespaces, "must be non-negative"))
 	}
 
-	if errList.IsEmpty() {
+	allErrs = append(allErrs, v.validateNamespace(&c.Namespace, field.NewPath("namespace"))...)
+
+	for i := range c.TuningSets {
+		allErrs = append(allErrs, v.validateTuningSet(c.TuningSets[i], field.NewPath("tuningSets").Index(i))...)
+	}
+
+	for i := range c.Steps {
+		allErrs = append(allErrs, v.validateStep(c.Steps[i], field.NewPath("steps").Index(i))...)
+	}
+
+	if len(allErrs) == 0 {
 		return nil
 	}
 
+	return v.toErrorList(allErrs)
+}
+
+func (v *ConfigValidator) toErrorList(fldErrors field.ErrorList) *errors.ErrorList {
+	errList := errors.NewErrorList()
+	for _, fldError := range fldErrors {
+		errList.Append(fldError)
+	}
 	return errList
+}
+
+func (v *ConfigValidator) validateNamespace(ns *NamespaceConfig, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if ns.Number <= 0 {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("number"), ns.Number, "must be positive"))
+	}
+	return allErrs
+}
+
+func (v *ConfigValidator) validateStep(s *Step, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	for i := range s.Phases {
+		allErrs = append(allErrs, v.validatePhase(s.Phases[i], fldPath.Child("phases").Index(i))...)
+	}
+	for i := range s.Measurements {
+		allErrs = append(allErrs, v.validateMeasurement(s.Measurements[i], fldPath.Child("measurements").Index(i))...)
+	}
+	isPhasesEmpty := len(s.Phases) == 0
+	isMeasurementsEmpty := len(s.Measurements) == 0
+	if isPhasesEmpty && isMeasurementsEmpty {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("measurements"), s.Measurements, "can't be empty with empty phases"))
+	}
+	if !isPhasesEmpty && !isMeasurementsEmpty {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("measurements"), s.Measurements, "can't be non-empty with non-empty phases"))
+	}
+	return allErrs
+}
+
+func (v *ConfigValidator) validatePhase(p *Phase, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	if p.NamespaceRange != nil {
+		allErrs = append(allErrs, v.validateNamespaceRange(p.NamespaceRange, fldPath.Child("namespaceRange"))...)
+	}
+	if p.ReplicasPerNamespace < 0 {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("replicasPerNamespace"), p.ReplicasPerNamespace, "must be non-negative"))
+	}
+	for i := range p.ObjectBundle {
+		allErrs = append(allErrs, v.validateObject(p.ObjectBundle[i], fldPath.Child("objectBundle").Index(i))...)
+	}
+	return allErrs
+}
+
+func (v *ConfigValidator) validateObject(o *Object, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	errs := validation.IsDNS1123Subdomain(o.Basename)
+	for i := range errs {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("basename"), o.Basename, errs[i]))
+	}
+	if !v.fileExists(o.ObjectTemplatePath) {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("objectTemplatePath"), o.ObjectTemplatePath, "file must exist"))
+	}
+	return allErrs
+}
+
+func (v *ConfigValidator) validateNamespaceRange(nr *NamespaceRange, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	if nr.Min < 0 {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("min"), nr.Min, "must be non-negative"))
+	}
+	if nr.Max < nr.Min {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("max"), nr.Max, "must be greater than min"))
+	}
+	return allErrs
+}
+
+func (v *ConfigValidator) validateTuningSet(ts *TuningSet, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	tuningSetsNumber := 0
+	if ts.QPSLoad != nil {
+		tuningSetsNumber++
+		allErrs = append(allErrs, v.validateQPSLoad(ts.QPSLoad, fldPath.Child("qpsLoad"))...)
+	}
+	if ts.RandomizedLoad != nil {
+		tuningSetsNumber++
+		allErrs = append(allErrs, v.validateRandomizedLoad(ts.RandomizedLoad, fldPath.Child("randomizedLoad"))...)
+	}
+	if ts.SteppedLoad != nil {
+		tuningSetsNumber++
+		allErrs = append(allErrs, v.validateSteppedLoad(ts.SteppedLoad, fldPath.Child("steppedLoad"))...)
+	}
+	if ts.TimeLimitedLoad != nil {
+		tuningSetsNumber++
+		allErrs = append(allErrs, v.validateTimeLimitedLoad(ts.TimeLimitedLoad, fldPath.Child("timeLimitedLoad"))...)
+	}
+	if ts.RandomizedTimeLimitedLoad != nil {
+		tuningSetsNumber++
+		allErrs = append(allErrs, v.validateRandomizedTimeLimitedLoad(ts.RandomizedTimeLimitedLoad, fldPath.Child("randomizedTimeLimitedLoad"))...)
+	}
+	if ts.ParallelismLimitedLoad != nil {
+		tuningSetsNumber++
+		allErrs = append(allErrs, v.validateParallelismTimeLimitedLoad(ts.ParallelismLimitedLoad, fldPath.Child("parallelismLimitedLoad"))...)
+	}
+	if ts.GlobalQPSLoad != nil {
+		tuningSetsNumber++
+		allErrs = append(allErrs, v.validateGlobalQPSLoad(ts.GlobalQPSLoad, fldPath.Child("globalQPSLoad"))...)
+	}
+	if tuningSetsNumber != 1 {
+		allErrs = append(allErrs, field.Forbidden(fldPath, "must specify exactly 1 tuning set type"))
+	}
+
+	return allErrs
+}
+
+func (v *ConfigValidator) validateMeasurement(_ *Measurement, _ *field.Path) field.ErrorList {
+	return nil
+}
+
+func (v *ConfigValidator) validateQPSLoad(ql *QPSLoad, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	if ql.QPS <= 0 {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("qps"), ql.QPS, "must have positive value"))
+	}
+	return allErrs
+}
+
+func (v *ConfigValidator) validateRandomizedLoad(rl *RandomizedLoad, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	if rl.AverageQPS <= 0 {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("averageQps"), rl.AverageQPS, "must have positive value"))
+	}
+	return allErrs
+}
+
+func (v *ConfigValidator) validateSteppedLoad(sl *SteppedLoad, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	if sl.BurstSize <= 0 {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("burstSize"), sl.BurstSize, "must have positive value"))
+	}
+	return allErrs
+}
+
+func (v *ConfigValidator) validateTimeLimitedLoad(tll *TimeLimitedLoad, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	if tll.TimeLimit <= 0 {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("timeLimit"), tll.TimeLimit, "must have positive value"))
+	}
+	return allErrs
+}
+
+func (v *ConfigValidator) validateRandomizedTimeLimitedLoad(rtl *RandomizedTimeLimitedLoad, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	if rtl.TimeLimit <= 0 {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("timeLimit"), rtl.TimeLimit, "must have positive value"))
+	}
+	return allErrs
+}
+
+func (v *ConfigValidator) validateParallelismTimeLimitedLoad(ptl *ParallelismLimitedLoad, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	if ptl.ParallelismLimit <= 0 {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("parallelismLimit"), ptl.ParallelismLimit, "must have positive value"))
+	}
+	return allErrs
+}
+
+func (v *ConfigValidator) validateGlobalQPSLoad(gl *GlobalQPSLoad, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	if gl.QPS <= 0 {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("qps"), gl.QPS, "must have positive value"))
+	}
+	if gl.Burst <= 0 {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("burst"), gl.Burst, "must have positive value"))
+	}
+	return allErrs
+}
+
+func (v *ConfigValidator) fileExists(path string) bool {
+	cwd, _ := os.Getwd()
+	_, err := os.Stat(fmt.Sprintf("%s/%s/%s", cwd, v.configDir, path))
+	return !os.IsNotExist(err)
 }

--- a/clusterloader2/api/validation_test.go
+++ b/clusterloader2/api/validation_test.go
@@ -1,0 +1,386 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"fmt"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/perf-tests/clusterloader2/pkg/errors"
+)
+
+func isValid(errList field.ErrorList) bool {
+	return len(errList) == 0
+}
+
+func TestVerifyQPSLoad(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		input    QPSLoad
+		expected bool
+	}{
+		{
+			name: "positive qps",
+			input: QPSLoad{
+				QPS: 10,
+			},
+			expected: true,
+		},
+		{
+			name: "negative qps",
+			input: QPSLoad{
+				QPS: -1,
+			},
+			expected: false,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			v := NewConfigValidator("", &Config{})
+			got := isValid(v.validateQPSLoad(&test.input, field.NewPath("")))
+			if test.expected != got {
+				t.Errorf("wanted: %v, got: %v", test.expected, got)
+			}
+		})
+	}
+}
+
+func TestVerifyRandomizedLoad(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		input    RandomizedLoad
+		expected bool
+	}{
+		{
+			name: "positive average qps",
+			input: RandomizedLoad{
+				AverageQPS: 10,
+			},
+			expected: true,
+		},
+		{
+			name: "negative average qps",
+			input: RandomizedLoad{
+				AverageQPS: -1,
+			},
+			expected: false,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			v := NewConfigValidator("", &Config{})
+			got := isValid(v.validateRandomizedLoad(&test.input, field.NewPath("")))
+			if test.expected != got {
+				t.Errorf("wanted: %v, got: %v", test.expected, got)
+			}
+		})
+	}
+}
+
+func TestVerifySteppedLoad(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		input    SteppedLoad
+		expected bool
+	}{
+		{
+			name: "valid stepped load",
+			input: SteppedLoad{
+				BurstSize: 10,
+				StepDelay: 1000,
+			},
+			expected: true,
+		},
+		{
+			name: "negative burst size",
+			input: SteppedLoad{
+				BurstSize: -10,
+				StepDelay: 1000,
+			},
+			expected: false,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			v := NewConfigValidator("", &Config{})
+			got := isValid(v.validateSteppedLoad(&test.input, field.NewPath("")))
+			if test.expected != got {
+				t.Errorf("wanted: %v, got: %v", test.expected, got)
+			}
+		})
+	}
+}
+
+func TestVerifyTuningSet(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		input    TuningSet
+		expected bool
+	}{
+		{
+			name: "exactly one tuning set type",
+			input: TuningSet{
+				QPSLoad: &QPSLoad{
+					QPS: 10,
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "more than one tuning set type",
+			input: TuningSet{
+				QPSLoad: &QPSLoad{
+					QPS: 10,
+				},
+				RandomizedLoad: &RandomizedLoad{
+					AverageQPS: 10,
+				},
+			},
+			expected: false,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			v := NewConfigValidator("", &Config{})
+			got := isValid(v.validateTuningSet(&test.input, field.NewPath("")))
+			if test.expected != got {
+				t.Errorf("wanted: %v, got: %v", test.expected, got)
+			}
+		})
+	}
+}
+
+func TestVerifyNamespaceRange(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		input    NamespaceRange
+		expected bool
+	}{
+		{
+			name: "valid namespace range",
+			input: NamespaceRange{
+				Min: 0,
+				Max: 10,
+			},
+			expected: true,
+		},
+		{
+			name: "negative namespace range lower bound",
+			input: NamespaceRange{
+				Min: -1,
+				Max: 10,
+			},
+			expected: false,
+		},
+		{
+			name: "negative namespace range upper bound",
+			input: NamespaceRange{
+				Min: 10,
+				Max: -1,
+			},
+			expected: false,
+		},
+		{
+			name: "invalid namespace range",
+			input: NamespaceRange{
+				Min: 10,
+				Max: 1,
+			},
+			expected: false,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			v := NewConfigValidator("", &Config{})
+			got := isValid(v.validateNamespaceRange(&test.input, field.NewPath("")))
+			if test.expected != got {
+				t.Errorf("wanted: %v, got: %v", test.expected, got)
+			}
+		})
+	}
+}
+
+func TestVerifyPhase(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		input    Phase
+		expected bool
+	}{
+		{
+			name: "positive replicas",
+			input: Phase{
+				ReplicasPerNamespace: 10,
+			},
+			expected: true,
+		},
+		{
+			name: "negative replicas",
+			input: Phase{
+				ReplicasPerNamespace: -10,
+			},
+			expected: false,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			v := NewConfigValidator("", &Config{})
+			got := isValid(v.validatePhase(&test.input, field.NewPath("")))
+			if test.expected != got {
+				t.Errorf("wanted: %v, got: %v", test.expected, got)
+			}
+		})
+	}
+}
+
+func TestVerifyStep(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		input    Step
+		expected bool
+	}{
+		{
+			name: "has phases and no measurements",
+			input: Step{
+				Phases: []*Phase{
+					{
+						ReplicasPerNamespace: 10,
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "has measurements and no phases",
+			input: Step{
+				Measurements: []*Measurement{
+					{
+						Method: "test1",
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name:     "no phases and no measurements",
+			input:    Step{},
+			expected: false,
+		},
+		{
+			name: "has phases and measurements",
+			input: Step{
+				Phases: []*Phase{
+					{
+						ReplicasPerNamespace: 10,
+					},
+				},
+				Measurements: []*Measurement{
+					{
+						Method: "test1",
+					},
+				},
+			},
+			expected: false,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			v := NewConfigValidator("", &Config{})
+			got := isValid(v.validateStep(&test.input, field.NewPath("")))
+			if test.expected != got {
+				t.Errorf("wanted: %v, got: %v", test.expected, got)
+			}
+		})
+	}
+}
+
+// TODO(#1696): Remove deprecated automanagedNamespaces
+func TestFileExists(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		input    string
+		expected bool
+	}{
+		{
+			name:     "file exists",
+			input:    ".",
+			expected: true,
+		},
+		{
+			name:     "file does not exist",
+			input:    "..",
+			expected: false,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			v := NewConfigValidator(test.input, &Config{})
+			got := v.fileExists("validation.go")
+			if test.expected != got {
+				t.Errorf("wanted: %v, got: %v", test.expected, got)
+			}
+		})
+	}
+}
+
+func TestValidate(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		input    Config
+		expected *errors.ErrorList
+	}{
+		{
+			name: "valid config",
+			input: Config{
+				AutomanagedNamespaces: 10,
+				Namespace: NamespaceConfig{
+					Number: 1,
+				},
+			},
+			expected: nil,
+		},
+		{
+			name: "negative automanaged namespaces",
+			input: Config{
+				AutomanagedNamespaces: -10,
+				Namespace: NamespaceConfig{
+					Number: 1,
+				},
+			},
+			expected: errors.NewErrorList(fmt.Errorf("automanagedNamespaces: Invalid value: -10: must be non-negative")),
+		},
+		{
+			name: "non-positive number of namespaces",
+			input: Config{
+				AutomanagedNamespaces: 10,
+				Namespace: NamespaceConfig{
+					Number: 0,
+				},
+			},
+			expected: errors.NewErrorList(fmt.Errorf("namespace.number: Invalid value: 0: must be positive")),
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var failed bool
+			v := NewConfigValidator("", &test.input)
+			got := v.Validate()
+			if test.expected == nil {
+				if got != nil {
+					failed = true
+				}
+			} else if test.expected.Error() != got.Error() {
+				failed = true
+			}
+
+			if failed == true {
+				t.Errorf("wanted: %v, got: %v", test.expected, got)
+			}
+		})
+	}
+}

--- a/clusterloader2/cmd/clusterloader.go
+++ b/clusterloader2/cmd/clusterloader.go
@@ -71,6 +71,7 @@ func initClusterFlags() {
 	if err != nil {
 		klog.Fatalf("unable to mark flag delete-stale-namespaces deprecated %v", err)
 	}
+	// TODO(#1696): Clean up after removing automanagedNamespaces
 	flags.BoolEnvVar(&clusterLoaderConfig.ClusterConfig.DeleteAutomanagedNamespaces, "delete-automanaged-namespaces", "DELETE_AUTOMANAGED_NAMESPACES", true, "DEPRECATED: Whether to delete all automanaged namespaces after the test execution.")
 	err = flags.MarkDeprecated("delete-automanaged-namespaces", "specify deleteAutomanagedNamespaces in testconfig file instead.")
 	if err != nil {

--- a/clusterloader2/pkg/config/cluster.go
+++ b/clusterloader2/pkg/config/cluster.go
@@ -46,7 +46,7 @@ type ClusterConfig struct {
 	MasterName          string
 	// Deprecated: use NamespaceConfig.DeleteStaleNamespaces instead.
 	DeleteStaleNamespaces bool
-	// Deprecated: use NamespaceConfig.DeleteAutomanagedNamespaces instead.
+	// TODO(#1696): Clean up after removing automanagedNamespaces
 	DeleteAutomanagedNamespaces bool
 	// APIServerPprofByClientEnabled determines whether kube-apiserver pprof endpoint can be accessed
 	// using kubernetes client. If false, clusterloader will avoid collecting kube-apiserver profiles.

--- a/clusterloader2/pkg/test/test.go
+++ b/clusterloader2/pkg/test/test.go
@@ -71,7 +71,8 @@ func CompileTestConfig(ctx Context) (*api.Config, *errors.ErrorList) {
 	}
 
 	clusterLoaderConfig := ctx.GetClusterLoaderConfig()
-	testConfigFilename := filepath.Base(ctx.GetTestScenario().ConfigPath)
+	testScenario := ctx.GetTestScenario()
+	testConfigFilename := filepath.Base(testScenario.ConfigPath)
 	testConfig, err := ctx.GetTemplateProvider().TemplateToConfig(testConfigFilename, ctx.GetTemplateMappingCopy())
 	if err != nil {
 		return nil, errors.NewErrorList(fmt.Errorf("config reading error: %v", err))
@@ -98,7 +99,9 @@ func CompileTestConfig(ctx Context) (*api.Config, *errors.ErrorList) {
 	}
 
 	testConfig.SetDefaults()
-	if err := testConfig.Validate(); err != nil {
+	basePath := filepath.Dir(testScenario.ConfigPath)
+	configValidator := api.NewConfigValidator(basePath, testConfig)
+	if err := configValidator.Validate(); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

**What this PR does / why we need it**:
Refinement of https://github.com/kubernetes/perf-tests/pull/142. Validates more aspects of the CL2 config. 
Steps validation will automatically apply to modules once compilation is moved before test execution in https://github.com/kubernetes/perf-tests/pull/1680.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/perf-tests/issues/1636

**Special notes for your reviewer**:
Copy pasted the logic from https://github.com/kubernetes/perf-tests/pull/142 but placed it in the existing api/validation.go file. Had to do a conversion back to CL2 error types.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added CL2 config validation for namespaces, tuning sets and steps.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```