### PR TITLE
Bump cpu and memory requests in perfdash

### DIFF
--- a/perfdash/deployment.yaml
+++ b/perfdash/deployment.yaml
@@ -36,9 +36,9 @@ spec:
           timeoutSeconds: 1
         resources:
           requests:
-            cpu: 600m
-            memory: 8Gi
+            cpu: "3"
+            memory: 10Gi
           limits:
-            cpu: 600m
-            memory: 8Gi
+            cpu: "3"
+            memory: 10Gi
       restartPolicy: Always


### PR DESCRIPTION
perfdash is getting continuously OOMKilled with 8GiB memory limit.

Let's increase this to 10GiB (I can't set higher values as we use n1-standard-4 machine, see https://github.com/kubernetes/k8s.io/pull/1604), but this values seems to help.