### PR TITLE
Change defaultCheckProbesReadyTimeout to 15m

### DIFF
--- a/clusterloader2/pkg/measurement/common/probes/probes.go
+++ b/clusterloader2/pkg/measurement/common/probes/probes.go
@@ -39,7 +39,7 @@ const (
 
 	checkProbesReadyInterval = 15 * time.Second
 
-	defaultCheckProbesReadyTimeout = 5 * time.Minute
+	defaultCheckProbesReadyTimeout = 15 * time.Minute
 )
 
 var (


### PR DESCRIPTION
Changing defaultCheckProbesReadyTimeout to 15m as this is a minimum value that avoids breaking test in case of single node failure when probes are starting (this can delay starting probe up to 15 minutes, see https://github.com/kubernetes/perf-tests/pull/353 for similar change for waiting for deployments).

In the next PR I will remove known overrides in our tests which set this to 10m (still too low value to handel that case).

/assign @mm4tt 