### PR TITLE
Load test - latency pod measurements moved to pod-startup-latency.yaml

### DIFF
--- a/clusterloader2/testing/load/config.yaml
+++ b/clusterloader2/testing/load/config.yaml
@@ -24,13 +24,6 @@
 {{$ENABLE_NODE_LOCAL_DNS_LATENCY := DefaultParam .CL2_ENABLE_NODE_LOCAL_DNS_LATENCY false}}
 {{$NODE_LOCAL_DNS_LATENCY_THRESHOLD := DefaultParam .CL2_NODE_LOCAL_DNS_LATENCY_THRESHOLD "5s"}}
 {{$ENABLE_DNSTESTS := DefaultParam .CL2_ENABLE_DNSTESTS false}}
-# LATENCY_POD_MEMORY and LATENCY_POD_CPU are calculated for 1-core 4GB node.
-# Increasing allocation of both memory and cpu by 10%
-# decreases the value of priority function in scheduler by one point.
-# This results in decreased probability of choosing the same node again.
-# TODO(https://github.com/kubernetes/perf-tests/issues/1024): See whether we can get rid of this
-{{$LATENCY_POD_CPU := DefaultParam .CL2_LATENCY_POD_CPU 100}}
-{{$LATENCY_POD_MEMORY := DefaultParam .CL2_LATENCY_POD_MEMORY 350}}
 {{$ENABLE_SYSTEM_POD_METRICS:= DefaultParam .ENABLE_SYSTEM_POD_METRICS true}}
 {{$ENABLE_CLUSTER_OOMS_TRACKER := DefaultParam .CL2_ENABLE_CLUSTER_OOMS_TRACKER true}}
 {{$CLUSTER_OOMS_IGNORED_PROCESSES := DefaultParam .CL2_CLUSTER_OOMS_IGNORED_PROCESSES ""}}
@@ -88,13 +81,6 @@
 # Set schedulerThroughputNamespaces to 0 on small clusters otherwise it will result
 # in an unnecessary number of namespaces.
 {{$schedulerThroughputNamespaces := IfThenElse $IS_SMALL_CLUSTER 0 $schedulerThroughputNamespaces}}
-
-# TODO(https://github.com/kubernetes/perf-tests/issues/1024): Investigate and get rid of this section.
-# BEGIN pod-startup-latency section
-{{$totalLatencyPods := MaxInt $MIN_PODS_IN_SMALL_CLUSTERS .Nodes}}
-{{$latencyReplicas := DivideInt $totalLatencyPods $namespaces}}
-{{$podStartupLatencyThreshold := DefaultParam .CL2_POD_STARTUP_LATENCY_THRESHOLD "5s"}}
-# END pod-startup-latency section
 
 # Probe measurements shared parameter
 {{$PROBE_MEASUREMENTS_CHECK_PROBES_READY_TIMEOUT := DefaultParam .CL2_PROBE_MEASUREMENTS_CHECK_PROBES_READY_TIMEOUT "15m"}}
@@ -543,68 +529,12 @@ steps:
 {{end}}
 
 {{if not $IS_SMALL_CLUSTER}}
-# TODO(https://github.com/kubernetes/perf-tests/issues/1024): Ideally, we wouldn't need this section.
-# BEGIN pod-startup-latency
-- name: Starting latency pod measurements
-  measurements:
-  - Identifier: PodStartupLatency
-    Method: PodStartupLatency
-    Params:
-      action: start
-      labelSelector: group = latency
-      threshold: {{$podStartupLatencyThreshold}}
-  - Identifier: WaitForRunningLatencyDeployments
-    Method: WaitForControlledPodsRunning
-    Params:
-      action: start
-      apiVersion: apps/v1
-      kind: Deployment
-      labelSelector: group = latency
-      operationTimeout: 15m
-- name: Creating latency pods
-  phases:
-  - namespaceRange:
-      min: 1
-      max: {{$namespaces}}
-    replicasPerNamespace: {{$latencyReplicas}}
-    tuningSet: Uniform5qps
-    objectBundle:
-    - basename: latency-deployment
-      objectTemplatePath: simple-deployment.yaml
-      templateFillMap:
-        Replicas: 1
-        Group: latency
-        CpuRequest: {{$LATENCY_POD_CPU}}m
-        MemoryRequest: {{$LATENCY_POD_MEMORY}}M
-- name: Waiting for latency pods to be running
-  measurements:
-  - Identifier: WaitForRunningLatencyDeployments
-    Method: WaitForControlledPodsRunning
-    Params:
-      action: gather
-- name: Deleting latency pods
-  phases:
-  - namespaceRange:
-      min: 1
-      max: {{$namespaces}}
-    replicasPerNamespace: 0
-    tuningSet: Uniform5qps
-    objectBundle:
-    - basename: latency-deployment
-      objectTemplatePath: simple-deployment.yaml
-- name: Waiting for latency pods to be deleted
-  measurements:
-  - Identifier: WaitForRunningLatencyDeployments
-    Method: WaitForControlledPodsRunning
-    Params:
-      action: gather
-- name: Collecting pod startup latency
-  measurements:
-  - Identifier: PodStartupLatency
-    Method: PodStartupLatency
-    Params:
-      action: gather
-# END pod-startup-latency
+# TODO(kubernetes/perf-tests/issues/1024): We shouldn't have a dedicated module for measuring pod-startup-latency.
+- module:
+    path: modules/pod-startup-latency.yaml
+    params:
+      namespaces: {{$namespaces}}
+      minPodsInSmallCluster: {{$MIN_PODS_IN_SMALL_CLUSTERS}}
 {{end}}
 
 - name: Scaling and updating objects

--- a/clusterloader2/testing/load/modules/pod-startup-latency.yaml
+++ b/clusterloader2/testing/load/modules/pod-startup-latency.yaml
@@ -1,0 +1,80 @@
+## Pod-startup-latency module provides a module for latency pod measurements
+
+## Input Params
+{{$namespaces := .namespaces}}
+{{$minPodsInSmallCluster := .minPodsInSmallCluster}}
+
+## CL2 Params
+# LATENCY_POD_MEMORY and LATENCY_POD_CPU are calculated for 1-core 4GB node.
+# Increasing allocation of both memory and cpu by 10%
+# decreases the value of priority function in scheduler by one point.
+# This results in decreased probability of choosing the same node again.
+# TODO(https://github.com/kubernetes/perf-tests/issues/1024): See whether we can get rid of this
+{{$LATENCY_POD_CPU := DefaultParam .CL2_LATENCY_POD_CPU 100}}
+{{$LATENCY_POD_MEMORY := DefaultParam .CL2_LATENCY_POD_MEMORY 350}}
+
+## Variables
+{{$totalLatencyPods := MaxInt $minPodsInSmallCluster .Nodes}}
+{{$latencyReplicas := DivideInt $totalLatencyPods $namespaces}}
+{{$podStartupLatencyThreshold := DefaultParam .CL2_POD_STARTUP_LATENCY_THRESHOLD "5s"}}
+
+steps:
+- name: Starting latency pod measurements
+  measurements:
+    - Identifier: PodStartupLatency
+      Method: PodStartupLatency
+      Params:
+        action: start
+        labelSelector: group = latency
+        threshold: {{$podStartupLatencyThreshold}}
+    - Identifier: WaitForRunningLatencyDeployments
+      Method: WaitForControlledPodsRunning
+      Params:
+        action: start
+        apiVersion: apps/v1
+        kind: Deployment
+        labelSelector: group = latency
+        operationTimeout: 15m
+- name: Creating latency pods
+  phases:
+    - namespaceRange:
+        min: 1
+        max: {{$namespaces}}
+      replicasPerNamespace: {{$latencyReplicas}}
+      tuningSet: Uniform5qps
+      objectBundle:
+        - basename: latency-deployment
+          objectTemplatePath: simple-deployment.yaml
+          templateFillMap:
+            Replicas: 1
+            Group: latency
+            CpuRequest: {{$LATENCY_POD_CPU}}m
+            MemoryRequest: {{$LATENCY_POD_MEMORY}}M
+- name: Waiting for latency pods to be running
+  measurements:
+    - Identifier: WaitForRunningLatencyDeployments
+      Method: WaitForControlledPodsRunning
+      Params:
+        action: gather
+- name: Deleting latency pods
+  phases:
+    - namespaceRange:
+        min: 1
+        max: {{$namespaces}}
+      replicasPerNamespace: 0
+      tuningSet: Uniform5qps
+      objectBundle:
+        - basename: latency-deployment
+          objectTemplatePath: simple-deployment.yaml
+- name: Waiting for latency pods to be deleted
+  measurements:
+    - Identifier: WaitForRunningLatencyDeployments
+      Method: WaitForControlledPodsRunning
+      Params:
+        action: gather
+- name: Collecting pod startup latency
+  measurements:
+    - Identifier: PodStartupLatency
+      Method: PodStartupLatency
+      Params:
+        action: gather


### PR DESCRIPTION
Latency pod measurements moved from config.yaml to a separate module in pod-startup-latency.yaml

/kind cleanup
/hold

Part of #1659