### PR TITLE
Scratch image generation

### DIFF
--- a/util-images/scratch/Dockerfile
+++ b/util-images/scratch/Dockerfile
@@ -1,0 +1,4 @@
+FROM scratch
+ARG FILENAME
+
+COPY $FILENAME /

--- a/util-images/scratch/Makefile
+++ b/util-images/scratch/Makefile
@@ -1,0 +1,22 @@
+PROJECT ?= k8s-testimages
+IMG = gcr.io/$(PROJECT)/perf-tests-util/scratch
+NUM_IMAGES ?= 20
+
+all: push
+
+build: Dockerfile
+	TAG=1 ; while [[ $$TAG -le $(NUM_IMAGES) ]] ; do \
+		touch $$TAG ; \
+		docker build --build-arg FILENAME=$$TAG -t $(IMG):$$TAG . ; \
+		rm $$TAG ; \
+		echo Built $(IMG):$$TAG ; \
+		((TAG = TAG + 1)) ; \
+	done
+
+.PHONY: push
+push: build
+	TAG=1 ; while [[ $$TAG -le $(NUM_IMAGES) ]] ; do \
+		docker push $(IMG):$$TAG ; \
+		echo Pushed $(IMG) with :$$TAG tags ; \
+		((TAG = TAG + 1)) ; \
+	done

--- a/util-images/scratch/README.md
+++ b/util-images/scratch/README.md
@@ -1,0 +1,9 @@
+# scratch
+
+Utility image for padding kubemark hosts to achieve more realistic node object sizes. Refer to issue https://github.com/kubernetes/kubernetes/issues/90833.
+
+## Releasing
+
+1. Configure the number of images to build / push.
+1. Build with `make build`
+1. Release with `make push`


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

**What this PR does / why we need it**:
Adds a script to generate scratch images with different image IDs. These images can then be preloaded onto the kubemark nodes. Details in https://github.com/kubernetes/kubernetes/issues/90833.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of https://github.com/kubernetes/kubernetes/issues/90833

**Special notes for your reviewer**:
Build and push to gcr after merging.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```