### PR TITLE
Fix keyFile assignment for AWS provider

### DIFF
--- a/clusterloader2/pkg/measurement/util/ssh.go
+++ b/clusterloader2/pkg/measurement/util/ssh.go
@@ -94,7 +94,7 @@ func getSigner(provider string) (ssh.Signer, error) {
 			keyfile = "google_compute_engine"
 		}
 	case "aws", "eks":
-		keyfile := os.Getenv("AWS_SSH_KEY")
+		keyfile = os.Getenv("AWS_SSH_KEY")
 		if keyfile == "" {
 			keyfile = "kube_aws_rsa"
 		}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug


**What this PR does / why we need it**:
Original keyFile assignment is incorrect, it create a new variable under case scope and doesn't change keyFile defined earlier. 
This results in error reading SSH key even `AWS_SSH_KEY ` env is set.


**Which issue(s) this PR fixes**:

Fixes https://github.com/kubernetes/perf-tests/issues/1717

**Special notes for your reviewer**:
I will cherry-pick to previous version. release-1.19 and earlier branches are affected. 

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```