### PR TITLE
Support prometheus stacks deployment for different providers

### DIFF
--- a/clusterloader2/pkg/config/cluster.go
+++ b/clusterloader2/pkg/config/cluster.go
@@ -77,6 +77,8 @@ type PrometheusConfig struct {
 	DefaultServiceMonitors  string
 	MasterIPServiceMonitors string
 	NodeExporterPod         string
+	StorageClassProvisioner string
+	StorageClassVolumeType  string
 }
 
 // GetMasterIP returns the first master ip, added for backward compatibility.

--- a/clusterloader2/pkg/prometheus/manifests/0ssd-storage-class.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/0ssd-storage-class.yaml
@@ -1,10 +1,13 @@
+{{$PROMETHEUS_STORAGE_CLASS_PROVISIONER := DefaultParam .PROMETHEUS_STORAGE_CLASS_PROVISIONER "kubernetes.io/gce-pd"}}
+{{$PROMETHEUS_STORAGE_CLASS_VOLUME_TYPE := DefaultParam .PROMETHEUS_STORAGE_CLASS_VOLUME_TYPE "pd-ssd"}}
+
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
   name: ssd
-provisioner: kubernetes.io/gce-pd
+provisioner: {{$PROMETHEUS_STORAGE_CLASS_PROVISIONER}}
 parameters:
-  type: pd-ssd
+  type: {{$PROMETHEUS_STORAGE_CLASS_VOLUME_TYPE}}
 {{if .RetainPD}}
 reclaimPolicy: Retain
 {{end}}

--- a/clusterloader2/pkg/prometheus/prometheus.go
+++ b/clusterloader2/pkg/prometheus/prometheus.go
@@ -61,6 +61,8 @@ func InitFlags(p *config.PrometheusConfig) {
 	flags.BoolEnvVar(&p.ScrapeAnet, "prometheus-scrape-anet", "PROMETHEUS_SCRAPE_ANET", false, "Whether to scrape anet pods.")
 	flags.StringEnvVar(&p.SnapshotProject, "experimental-snapshot-project", "PROJECT", "", "GCP project used where disks and snapshots are located.")
 	flags.StringEnvVar(&p.ManifestPath, "prometheus-manifest-path", "PROMETHEUS_MANIFEST_PATH", "$GOPATH/src/k8s.io/perf-tests/clusterloader2/pkg/prometheus/manifests", "Path to the prometheus manifest files.")
+	flags.StringEnvVar(&p.StorageClassProvisioner, "prometheus-storage-class-provisioner", "PROMETHEUS_STORAGE_CLASS_PROVISIONER", "kubernetes.io/gce-pd", "Volumes plugin used to provision PVs for Prometheus")
+	flags.StringEnvVar(&p.StorageClassVolumeType, "prometheus-storage-class-volume-type", "PROMETHEUS_STORAGE_CLASS_VOLUME_TYPE", "pd-ssd", "Volume types of storage class, This will be different depending on the provisioner")
 }
 
 // ValidatePrometheusFlags validates prometheus flags.
@@ -146,6 +148,8 @@ func NewController(clusterLoaderConfig *config.ClusterLoaderConfig) (pc *Control
 	}
 	mapping["PROMETHEUS_SCRAPE_NODE_LOCAL_DNS"] = clusterLoaderConfig.PrometheusConfig.ScrapeNodeLocalDNS
 	mapping["PROMETHEUS_SCRAPE_KUBELETS"] = clusterLoaderConfig.PrometheusConfig.ScrapeKubelets
+	mapping["PROMETHEUS_STORAGE_CLASS_PROVISIONER"] = clusterLoaderConfig.PrometheusConfig.StorageClassProvisioner
+	mapping["PROMETHEUS_STORAGE_CLASS_VOLUME_TYPE"] = clusterLoaderConfig.PrometheusConfig.StorageClassVolumeType
 	snapshotEnabled, _ := pc.isEnabled()
 	mapping["RetainPD"] = snapshotEnabled
 


### PR DESCRIPTION
Introduce new arguments/envs PROMETHEUS_STORAGE_CLASS_PROVISIONER and PROMETHEUS_STORAGE_CLASS_VOLUME_TYPE that users can use to override prometheus storage class setting.

Signed-off-by: Jiaxin Shan <seedjeffwan@gmail.com>

Usage: 

1. env
```
PROMETHEUS_STORAGE_CLASS_PROVISIONER=kubernetes.io/aws-ebs PROMETHEUS_STORAGE_CLASS_VOLUME_TYPE=gp3 go run cmd/clusterloader.go
```

2. arg
```
--prometheus-storage-class-provisioner=kubernetes.io/aws-ebs --prometheus-storage-class-volume-type=gp3
```





<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:
Make storage_class manifest generic and all providers can customize the storage based on their needs. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1723 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```