### PR TITLE
Fix: only check label key in LegacyIsMasterNode

### DIFF
--- a/clusterloader2/pkg/util/cluster.go
+++ b/clusterloader2/pkg/util/cluster.go
@@ -168,9 +168,9 @@ func GetMasterIPs(c clientset.Interface, addressType corev1.NodeAddressType) ([]
 // node-roles may not be used for feature enablement.
 // DEPRECATED: this will be removed in Kubernetes 1.19
 func LegacyIsMasterNode(node *corev1.Node) bool {
-	for key, val := range node.GetLabels() {
+	for key := range node.GetLabels() {
 		if key == keyMasterNodeLabel {
-			return strings.ToLower(val) == "true"
+			return true
 		}
 	}
 

--- a/clusterloader2/pkg/util/cluster_test.go
+++ b/clusterloader2/pkg/util/cluster_test.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
+)
+
+func TestLegacyIsMasterNode(t *testing.T) {
+	testcases := map[string]struct {
+		Name   string
+		Labels map[string]string
+		expect bool
+	}{
+		"node with node label key": {
+			Labels: map[string]string{keyMasterNodeLabel: ""},
+			expect: true,
+		},
+		"node with node label key value": {
+			Labels: map[string]string{keyMasterNodeLabel: "true"},
+			expect: true,
+		},
+		"node without node label": {
+			Labels: map[string]string{},
+			expect: false,
+		},
+	}
+
+	for _, tc := range testcases {
+		node := &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{Labels: tc.Labels},
+		}
+		result := LegacyIsMasterNode(node)
+		assert.Equal(t, tc.expect, result)
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

**What this PR does / why we need it**:
Seems `LegacyIsMasterNode` can not correctly infer master node and ip in my environment. 

Could someone help verify your env? in my env, master only have `node-role.kubernetes.io/master=` (value is empty). I think node label key is enough to determinate a node is master. 


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/perf-tests/issues/1716

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```