### PR TITLE
Add huge services to load test - release-1.20

### DIFF
--- a/clusterloader2/testing/load/config.yaml
+++ b/clusterloader2/testing/load/config.yaml
@@ -70,6 +70,7 @@
 {{$schedulerThroughputPodsPerDeployment := .Nodes}}
 {{$schedulerThroughputNamespaces := DivideInt $totalSchedulerThroughputPods $schedulerThroughputPodsPerDeployment}}
 {{$schedulerThroughputThreshold := DefaultParam .CL2_SCHEDULER_THROUGHPUT_THRESHOLD 100}}
+{{$ENABLE_HUGE_SERVICES := DefaultParam .CL2_ENABLE_HUGE_SERVICES false}}
 # END scheduler-throughput section
 
 # TODO(https://github.com/kubernetes/perf-tests/issues/1024): Investigate and get rid of this section.
@@ -451,6 +452,18 @@ steps:
       action: start
       labelSelector: group = scheduler-throughput
       measurmentInterval: 1s
+{{if $ENABLE_HUGE_SERVICES}}
+- name: Creating huge services
+  phases:
+  - namespaceRange:
+      min: {{AddInt $namespaces 1}}
+      max: {{AddInt $namespaces $schedulerThroughputNamespaces}}
+    replicasPerNamespace: 1
+    tuningSet: Sequence
+    objectBundle:
+    - basename: huge-service
+      objectTemplatePath: service.yaml
+{{end}}
 - name: Creating scheduler throughput pods
   phases:
   - namespaceRange:
@@ -466,6 +479,9 @@ steps:
         Group: scheduler-throughput
         CpuRequest: 1m
         MemoryRequest: 10M
+{{if $ENABLE_HUGE_SERVICES}}
+        SvcName: huge-service
+{{end}}
 - name: Waiting for scheduler throughput pods to be created
   measurements:
   - Identifier: WaitForSchedulerThroughputDeployments
@@ -500,6 +516,24 @@ steps:
     Method: WaitForControlledPodsRunning
     Params:
       action: gather
+{{if $ENABLE_HUGE_SERVICES}}
+- name: Deleting huge services
+  phases:
+  - namespaceRange:
+      min: {{AddInt $namespaces 1}}
+      max: {{AddInt $namespaces $schedulerThroughputNamespaces}}
+    replicasPerNamespace: 0
+    tuningSet: Sequence
+    objectBundle:
+    - basename: huge-service
+      objectTemplatePath: service.yaml
+- name: Sleeping after deleting huge services
+  measurements:
+  - Identifier: WaitAfterHugeServicesDeletion
+    Method: Sleep
+    Params:
+      duration: "3m"
+{{end}}
 # END scheduler throughput
 
 # TODO(https://github.com/kubernetes/perf-tests/issues/1024): Ideally, we wouldn't need this section.

--- a/clusterloader2/testing/load/simple-deployment.yaml
+++ b/clusterloader2/testing/load/simple-deployment.yaml
@@ -16,6 +16,9 @@ spec:
       labels:
         name: {{.Name}}
         group: {{.Group}}
+{{if .SvcName}}
+        svc: {{.SvcName}}-{{.Index}}
+{{end}}
     spec:
       hostNetwork: {{$HostNetworkMode}}
       containers:


### PR DESCRIPTION
Backport https://github.com/kubernetes/perf-tests/pull/1681 to release-1.20.