### PR TITLE
test: update pause-win image to the new one k8s.gcr.io/pause:3.4.1

### DIFF
--- a/clusterloader2/testing/windows-tests/config.yaml
+++ b/clusterloader2/testing/windows-tests/config.yaml
@@ -4,7 +4,7 @@
 #Constants
 {{$POD_COUNT := DefaultParam .CL2_POD_COUNT 80}}
 {{$POD_THROUGHPUT := DefaultParam .CL2_POD_THROUGHPUT 0.03}}
-{{$CONTAINER_IMAGE := DefaultParam .CL2_CONTAINER_IMAGE "gcr.io/gke-release/pause-win:1.2.0"}}
+{{$CONTAINER_IMAGE := DefaultParam .CL2_CONTAINER_IMAGE "k8s.gcr.io/pause:3.4.1"}}
 {{$POD_STARTUP_LATENCY_THRESHOLD := DefaultParam .CL2_POD_STARTUP_LATENCY_THRESHOLD "60m"}}
 {{$OPERATION_TIMEOUT := DefaultParam .CL2_OPERATION_TIMEOUT "90m"}}
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

As part of the efforts described in this Issue: https://github.com/kubernetes/k8s.io/issues/1525 we are trying to move away from `gcp project gke-release`

Also the pause image was release with windows support as we can see in the merged or in k/k https://github.com/kubernetes/kubernetes/pull/98205

/assign @spiffxp @wojtek-t

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```