### PR TITLE
Add more descriptive error for github downloading issues

### DIFF
--- a/perfdash/github-configs-fetcher.go
+++ b/perfdash/github-configs-fetcher.go
@@ -79,7 +79,7 @@ func getGithubDirContents(url string) ([]githubDirContent, error) {
 	var decoded []githubDirContent
 	err = yaml.Unmarshal(b, &decoded)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error unmarshall github response %s: %v", string(b), err)
 	}
 	return decoded, nil
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
If there're Github failures,  `github-configs-fetcher.go` only shows `yaml: unmarshal errors:
line 1: cannot unmarshal !!map into []main.githubDirContent` which is not descriptive. 

This PR print github response if there's an unmarshal error. 

Example;

```
./perfdash \
--www
--address=0.0.0.0:8080
--builds=20
--force-builds
--githubConfigDir=https://api.github.com/repos/kubernetes/test-infra/contents/config/jobs/kubernetes/sig-sca_invalid

```
> Note: githubConfigDir is an invalid link



Logs

```
I0212 10:51:48.123168   31660 perfdash.go:73] Starting perfdash...
I0212 10:51:48.125962   31660 perfdash.go:136] Starting server...
I0212 10:51:48.126053   31660 perfdash.go:124] Fetching new data...
I0212 10:51:48.126111   31660 github-configs-fetcher.go:62] Downloading github spec from https://api.github.com/repos/kubernetes/test-infra/contents/config/jobs/kubernetes/sig-scalabilit
E0212 10:51:48.597656   31660 perfdash.go:127] Error fetching data: error unmarshall github response {"message":"Not Found","documentation_url":"https://docs.github.com/rest/reference/repos#get-repository-content"}: yaml: unmarshal errors:
  line 1: cannot unmarshal !!map into []main.githubDirContent

```

We can see with this change,  we do see real error message from github
```
{"message":"Not Found","documentation_url":"https://docs.github.com/rest/reference/repos#get-repository-content"}:
```


**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes/perf-tests/issues/1273

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```