### PR TITLE
Support prometheus scratching for control plane which disables anonymous-auth

### DIFF
--- a/clusterloader2/pkg/prometheus/manifests/master-ip/master-serviceMonitor.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/master-ip/master-serviceMonitor.yaml
@@ -35,17 +35,20 @@ spec:
     {{else}}
     interval: 5s
     {{end}}
+    bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
   - interval: 5s
     port: kubelet
     scheme: https
     tlsConfig:
       insecureSkipVerify: true
+    bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
   - interval: 5s
     port: kubelet
     path: /metrics/cadvisor
     scheme: https
     tlsConfig:
       insecureSkipVerify: true
+    bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
   - interval: 5s
     port: kube-scheduler
     scheme: https


### PR DESCRIPTION
`bearerTokenFile` will be used to authenticate apiserver and kubelet. Since prometheus-k8s already support to get nonResourceUrls `/metrics`, authorization will work as well.

Signed-off-by: Jiaxin Shan <seedjeffwan@gmail.com>


**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:
control plane which disables anonymous-auth will fail the prometheus scratching requests to secure port. Adding `bearerTokenFile` to the configuration helps prometheus send request with prometheus service account token. 


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1721 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```