### PR TITLE
Automated cherry pick of #1718: Fix keyFile assignment for AWS provider

### DIFF
--- a/clusterloader2/pkg/measurement/util/ssh.go
+++ b/clusterloader2/pkg/measurement/util/ssh.go
@@ -94,7 +94,7 @@ func getSigner(provider string) (ssh.Signer, error) {
 			keyfile = "google_compute_engine"
 		}
 	case "aws", "eks":
-		keyfile := os.Getenv("AWS_SSH_KEY")
+		keyfile = os.Getenv("AWS_SSH_KEY")
 		if keyfile == "" {
 			keyfile = "kube_aws_rsa"
 		}


### PR DESCRIPTION
Cherry pick of #1718 on release-1.18.

#1718: Fix keyFile assignment for AWS provider

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.