### PR TITLE
Automated cherry pick of #1725: Fix: only check label key in LegacyIsMasterNode

### DIFF
--- a/clusterloader2/pkg/util/cluster.go
+++ b/clusterloader2/pkg/util/cluster.go
@@ -168,9 +168,9 @@ func GetMasterIPs(c clientset.Interface, addressType corev1.NodeAddressType) ([]
 // node-roles may not be used for feature enablement.
 // DEPRECATED: this will be removed in Kubernetes 1.19
 func LegacyIsMasterNode(node *corev1.Node) bool {
-	for key, val := range node.GetLabels() {
+	for key := range node.GetLabels() {
 		if key == keyMasterNodeLabel {
-			return strings.ToLower(val) == "true"
+			return true
 		}
 	}
 

--- a/clusterloader2/pkg/util/cluster_test.go
+++ b/clusterloader2/pkg/util/cluster_test.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
+)
+
+func TestLegacyIsMasterNode(t *testing.T) {
+	testcases := map[string]struct {
+		Name   string
+		Labels map[string]string
+		expect bool
+	}{
+		"node with node label key": {
+			Labels: map[string]string{keyMasterNodeLabel: ""},
+			expect: true,
+		},
+		"node with node label key value": {
+			Labels: map[string]string{keyMasterNodeLabel: "true"},
+			expect: true,
+		},
+		"node without node label": {
+			Labels: map[string]string{},
+			expect: false,
+		},
+	}
+
+	for _, tc := range testcases {
+		node := &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{Labels: tc.Labels},
+		}
+		result := LegacyIsMasterNode(node)
+		assert.Equal(t, tc.expect, result)
+	}
+}


### PR DESCRIPTION
Cherry pick of #1725 on release-1.19.

#1725: Fix: only check label key in LegacyIsMasterNode

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.