### PR TITLE
Check for absolute path also while validating object files

### DIFF
--- a/clusterloader2/api/validation.go
+++ b/clusterloader2/api/validation.go
@@ -243,5 +243,9 @@ func (v *ConfigValidator) validateGlobalQPSLoad(gl *GlobalQPSLoad, fldPath *fiel
 func (v *ConfigValidator) fileExists(path string) bool {
 	cwd, _ := os.Getwd()
 	_, err := os.Stat(fmt.Sprintf("%s/%s/%s", cwd, v.configDir, path))
+	if os.IsNotExist(err) {
+		// If relative path didn't work, we also try absolute path.
+		_, err = os.Stat(fmt.Sprintf("%s/%s", v.configDir, path))
+	}
 	return !os.IsNotExist(err)
 }


### PR DESCRIPTION
When I was trying to run clusterloader from my laptop using a command like this:
```
./clusterloader \
    --alsologtostderr \
    --kubeconfig /home/ec2-user/.kube/config \
    --testconfig /home/ec2-user/perf-tests/clusterloader2/testing/load/config.yaml \
    --testoverrides /home/ec2-user/perf-tests/clusterloader2/build/overrides.yaml 
...
```

It failed with errors like these:
```
F0218 09:30:18.245345   64780 clusterloader.go:334] Test compliation failed: [steps[1].phases[0].objectBundle[0].objectTemplatePath: Invalid value: "service.yaml": file must exist
steps[1].phases[1].objectBundle[0].objectTemplatePath: Invalid value: "service.yaml": file must exist
steps[1].phases[2].objectBundle[0].objectTemplatePath: Invalid value: "service.yaml": file must exist
steps[2].phases[0].objectBundle[0].objectTemplatePath: Invalid value: "daemonset-priorityclass.yaml": file must exist
steps[4].phases[0].objectBundle[0].objectTemplatePath: Invalid value: "daemonset.yaml": file must exist
steps[4].phases[1].objectBundle[0].objectTemplatePath: Invalid value: "configmap.yaml": file must exist
...
```

Seems like this is happening after some recent validation added in https://github.com/kubernetes/perf-tests/pull/1694. Specifically, this piece of code is only checking for relative path (which will be broken if configDir is an absolute path):
```
func (v *ConfigValidator) fileExists(path string) bool {
        cwd, _ := os.Getwd()
        _, err := os.Stat(fmt.Sprintf("%s/%s/%s", cwd, v.configDir, path))
        return !os.IsNotExist(err)
}
```

Fixing it in this pr.

/kind bug