### PR TITLE
Adapt golang subdirectory to pod-utils migration

### DIFF
--- a/golang/Makefile
+++ b/golang/Makefile
@@ -17,9 +17,7 @@
 export GCS_BUCKET?=k8s-scale-golang-build
 export GO_COMPILER_PKG?=go1.14.2.linux-amd64.tar.gz
 export GO_COMPILER_URL?=https://dl.google.com/go/$(GO_COMPILER_PKG)
-# Additional mandatory env variables:
-# K8S_RELEASE_COMMIT
-# K8S_COMMIT
+export ROOT_DIR?=/home/prow/go/src
 
 all: push
 

--- a/golang/build-go.sh
+++ b/golang/build-go.sh
@@ -24,8 +24,7 @@ function install_go_compiler {
 }
 
 function build_go {
-  git clone https://go.googlesource.com/go
-  cd go/src
+  cd $ROOT_DIR/golang/src
   ./make.bash
 }
 

--- a/golang/push.sh
+++ b/golang/push.sh
@@ -17,5 +17,5 @@
 set -euxo pipefail
 
 # Push Kubernetes build to GCS.
-cd /go/src/k8s.io/kubernetes
+cd $ROOT_DIR/k8s.io/kubernetes
 ../release/push-build.sh --nomock --ci --bucket=$GCS_BUCKET --private-bucket


### PR DESCRIPTION
Perform a major revamp of the scripts inside `golang` directory so that the migration to pod-utils is feasible.