### PR TITLE
clusterloader2/../config.yaml: Enable kube-state-metrics measurement …

### DIFF
--- a/clusterloader2/testing/load/config.yaml
+++ b/clusterloader2/testing/load/config.yaml
@@ -20,6 +20,7 @@
 {{$ENABLE_CHAOSMONKEY := DefaultParam .ENABLE_CHAOSMONKEY false}}
 {{$CHECK_IF_PODS_ARE_UPDATED := DefaultParam .CL2_CHECK_IF_PODS_ARE_UPDATED true}}
 {{$PROMETHEUS_SCRAPE_KUBE_PROXY := DefaultParam .PROMETHEUS_SCRAPE_KUBE_PROXY true}}
+{{$PROMETHEUS_SCRAPE_KUBE_STATE_METRICS := DefaultParam .PROMETHEUS_SCRAPE_KUBE_STATE_METRICS false}}
 {{$ENABLE_PVS := DefaultParam .CL2_ENABLE_PVS true}}
 {{$DISABLE_DAEMONSETS := DefaultParam .CL2_DISABLE_DAEMONSETS false}}
 {{$ENABLE_NETWORKPOLICIES := DefaultParam .CL2_ENABLE_NETWORKPOLICIES false}}
@@ -166,6 +167,12 @@ steps:
   {{if $PROMETHEUS_SCRAPE_KUBE_PROXY}}
   - Identifier: NetworkProgrammingLatency
     Method: NetworkProgrammingLatency
+    Params:
+      action: start
+  {{end}}
+  {{if $PROMETHEUS_SCRAPE_KUBE_STATE_METRICS}}
+  - Identifier: KubeStateMetricsLatency
+    Method: KubeStateMetricsLatency
     Params:
       action: start
   {{end}}
@@ -881,6 +888,12 @@ steps:
   {{if $PROMETHEUS_SCRAPE_KUBE_PROXY}}
   - Identifier: NetworkProgrammingLatency
     Method: NetworkProgrammingLatency
+    Params:
+      action: gather
+  {{end}}
+  {{if $PROMETHEUS_SCRAPE_KUBE_STATE_METRICS}}
+  - Identifier: KubeStateMetricsLatency
+    Method: KubeStateMetricsLatency
     Params:
       action: gather
   {{end}}


### PR DESCRIPTION
As per suggestion #1684 kube-state-metrics 2.0 release perf tests were split into 3 parts this is the last PR. This PR enables kube-state-metrics measurement conditionally, it requires https://github.com/kubernetes/perf-tests/pull/1761 to be merged first.

/hold

cc @tariq1890 @mrueg @brancz 