### PR TITLE
clusterloader2/testing/load: Adjust kube-state-metrics latency tests

### DIFF
--- a/clusterloader2/pkg/measurement/common/kube_state_metrics_measurement.go
+++ b/clusterloader2/pkg/measurement/common/kube_state_metrics_measurement.go
@@ -78,6 +78,10 @@ func CreateKSMLatencyMeasurement() measurement.Measurement {
 // it also collects initial latency metrics.
 // - gather - gathers latency metrics and creates a latency summary.
 func (m *ksmLatencyMeasurement) Execute(config *measurement.Config) ([]measurement.Summary, error) {
+	if !config.CloudProvider.Features().SupportKubeStateMetrics {
+		klog.Infof("not executing KSMLatencyMeasurement: unsupported for provider, %s", config.ClusterFramework.GetClusterConfig().Provider.Name())
+		return nil, nil
+	}
 	action, err := util.GetString(config.Params, "action")
 	if err != nil {
 		return nil, err

--- a/clusterloader2/pkg/prometheus/manifests/exporters/kube-state-metrics/deployment.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/exporters/kube-state-metrics/deployment.yaml
@@ -31,12 +31,10 @@ spec:
             cpu: {{AddInt 200 (MultiplyInt 500 (DivideInt .Nodes 1000))}}m
             # Start with 2Gi and add 2Gi for each 1K nodes.
             memory: {{MultiplyInt 2 (AddInt 1 (DivideInt .Nodes 1000))}}Gi
-            {{end}}
           limits:
             cpu: {{AddInt 200 (MultiplyInt 500 (DivideInt .Nodes 1000))}}m
             # Start with 2Gi and add 2Gi for each 1K nodes.
             memory: {{MultiplyInt 2 (AddInt 1 (DivideInt .Nodes 1000))}}Gi
-            {{end}}
         ports:
         - containerPort: 8080
           name: http-metrics

--- a/clusterloader2/pkg/prometheus/prometheus.go
+++ b/clusterloader2/pkg/prometheus/prometheus.go
@@ -197,7 +197,7 @@ func (pc *Controller) SetUpPrometheusStack() error {
 		}
 	}
 
-	if pc.clusterLoaderConfig.PrometheusConfig.ScrapeKubeStateMetrics {
+	if pc.clusterLoaderConfig.PrometheusConfig.ScrapeKubeStateMetrics && pc.clusterLoaderConfig.ClusterConfig.Provider.Features().SupportKubeStateMetrics {
 		klog.V(2).Infof("Applying kube-state-metrics in the cluster.")
 		if err := pc.applyManifests(pc.clusterLoaderConfig.PrometheusConfig.KubeStateMetricsManifests); err != nil {
 			return err

--- a/clusterloader2/pkg/provider/gce.go
+++ b/clusterloader2/pkg/provider/gce.go
@@ -44,6 +44,7 @@ func NewGCEProvider(_ map[string]string) Provider {
 			SupportEnablePrometheusServer:       true,
 			SupportGrabMetricsFromKubelets:      true,
 			SupportAccessAPIServerPprofEndpoint: true,
+			SupportKubeStateMetrics:             true,
 		},
 	}
 }

--- a/clusterloader2/pkg/provider/provider.go
+++ b/clusterloader2/pkg/provider/provider.go
@@ -52,6 +52,8 @@ type Features struct {
 	SupportNodeKiller bool
 	// SupportGrabMetricsFromKubelets determines whether getting metrics from kubelet is supported.
 	SupportGrabMetricsFromKubelets bool
+	// SupportKubeStateMetrics determines if running kube-state-metrics is supported.
+	SupportKubeStateMetrics bool
 
 	// ShouldPrometheusScrapeApiserverOnly determines if we should set PROMETHEUS_SCRAPE_APISERVER_ONLY by default.
 	ShouldPrometheusScrapeApiserverOnly bool


### PR DESCRIPTION
Enable kube-state-metrics to be run in the presubmit load tests.
/hold