### PR TITLE
Add SLO parameter to API availability measurement

### DIFF
--- a/clusterloader2/pkg/measurement/common/api_availability_metrics.go
+++ b/clusterloader2/pkg/measurement/common/api_availability_metrics.go
@@ -29,7 +29,7 @@ type apiAvailabilityMetrics struct {
 
 type apiAvailabilitySummary struct {
 	IP                       string  `json:"IP,omitempty"`
-	AvailabilityPercentage   float32 `json:"availabilityPercentage"`
+	AvailabilityPercentage   float64 `json:"availabilityPercentage"`
 	LongestUnavailablePeriod string  `json:"longestUnavailablePeriod"`
 }
 
@@ -51,9 +51,9 @@ func (a *apiAvailabilityMetrics) update(availability bool) {
 }
 
 func (a *apiAvailabilityMetrics) buildSummary(pollFrequency time.Duration, hostIP string) apiAvailabilitySummary {
-	availabilityPercentage := float32(100)
+	availabilityPercentage := float64(100)
 	if a.numSuccesses > 0 || a.numFailures > 0 {
-		availabilityPercentage = (float32(a.numSuccesses) / float32(a.numSuccesses+a.numFailures)) * 100
+		availabilityPercentage = (float64(a.numSuccesses) / float64(a.numSuccesses+a.numFailures)) * 100
 	}
 	longestUnavailablePeriod := time.Duration(a.maxConsecutiveFailedProbes) * pollFrequency
 	return apiAvailabilitySummary{

--- a/clusterloader2/testing/load/config.yaml
+++ b/clusterloader2/testing/load/config.yaml
@@ -38,6 +38,7 @@
 {{$ENABLE_VIOLATIONS_FOR_API_CALL_PROMETHEUS := DefaultParam .CL2_ENABLE_VIOLATIONS_FOR_API_CALL_PROMETHEUS false}}
 {{$ENABLE_VIOLATIONS_FOR_API_CALL_PROMETHEUS_SIMPLE := DefaultParam .CL2_ENABLE_VIOLATIONS_FOR_API_CALL_PROMETHEUS_SIMPLE true}}
 {{$ENABLE_API_AVAILABILITY_MEASUREMENT := DefaultParam .CL2_ENABLE_API_AVAILABILITY_MEASUREMENT false}}
+{{$API_AVAILABILITY_PERCENTAGE_THRESHOLD := DefaultParam .CL2_API_AVAILABILITY_PERCENTAGE_THRESHOLD 0.0}}
 #Variables
 {{$namespaces := DivideInt .Nodes $NODES_PER_NAMESPACE}}
 {{$totalPods := MultiplyInt $namespaces $NODES_PER_NAMESPACE $PODS_PER_NODE}}
@@ -183,6 +184,7 @@ steps:
       action: start
       pollFrequency: "5s"
       hostPollTimeoutSeconds: 5
+      threshold: {{$API_AVAILABILITY_PERCENTAGE_THRESHOLD}}
   {{end}}
   - Identifier: TestMetrics
     Method: TestMetrics


### PR DESCRIPTION
Add a configurable threshold parameter that would serve as an SLO for the measurement.

/sig scalability
/assign @jkaniuk 