### PR TITLE
Make prometheus-operator watch only limited set of secrets

### DIFF
--- a/clusterloader2/pkg/prometheus/manifests/0prometheus-operator-deployment.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/0prometheus-operator-deployment.yaml
@@ -31,6 +31,7 @@ spec:
         - --kubelet-service=kube-system/kubelet
         {{end}}
         - --prometheus-config-reloader=gcr.io/k8s-testimages/quay.io/prometheus-operator/prometheus-config-reloader:v0.46.0
+        - --secret-field-selector=type=prometheus-alert
         image: gcr.io/k8s-testimages/quay.io/prometheus-operator/prometheus-operator:v0.46.0
         name: prometheus-operator
         ports:


### PR DESCRIPTION
Prometheus-operator watches all secrets in the system as part of alertmanager. It also uses json for serialization/deserialization which is CPU/memory consuming.

It happens that when secrets watch is being interrupted, the secrets LIST result is not able to fit in the memory (in large clusters), causing OOMs.

Our tests usually create quite a few secrets, but we don't use any prometheus alert.

Let's use --secret-field-selector option to reduce set of secrets to only the ones that matches field selector type=prometheus-alert (none currently).