### PR TITLE
Upgrade perfdash to 2.33

### DIFF
--- a/perfdash/deployment.yaml
+++ b/perfdash/deployment.yaml
@@ -15,8 +15,7 @@ spec:
     spec:
       containers:
       - name: perfdash
-        # TODO: Bump to 2.33 and increase the memory limit once https://github.com/kubernetes/k8s.io/pull/1604 gets merged
-        image: gcr.io/k8s-testimages/perfdash:2.32
+        image: gcr.io/k8s-testimages/perfdash:2.33
         command:
           - /perfdash
           -   --www=true
@@ -37,9 +36,9 @@ spec:
           timeoutSeconds: 1
         resources:
           requests:
-            cpu: "3"
-            memory: 10Gi
+            cpu: "5"
+            memory: 20Gi
           limits:
-            cpu: "3"
-            memory: 10Gi
+            cpu: "5"
+            memory: 20Gi
       restartPolicy: Always


### PR DESCRIPTION
NAP is already enabled in 'aaa' cluster, we have larger node pools.

Fixes https://github.com/kubernetes/perf-tests/issues/1792