### PR TITLE
Support preinstall Prometheus server

### DIFF
--- a/clusterloader2/README.md
+++ b/clusterloader2/README.md
@@ -162,6 +162,20 @@ Allows to scrape metrics from all pods in service. Here you can find example [Se
 - **PodMonitor** \
 Allows to scrape metrics from all pods with specific label. Here you can find example [Pod monitor]
 
+### Use preinstall Prometheus server
+
+If you already have a prometheus server to use in the cluster, you can ask CL2 to scrape metrics from that target server
+instead of setting up new prometheus and deleting it after the test.
+
+Following options are used to enable preinstall prometheus server and specify service details
+
+```
+--preinstall-prometheus-server
+--preinstall-prometheus-service-namespace
+--preinstall-prometheus-service-name
+--preinstall-prometheus-service-port
+```
+
 ## Vendor
 
 Vendor is created using [Go modules].

--- a/clusterloader2/pkg/config/cluster.go
+++ b/clusterloader2/pkg/config/cluster.go
@@ -66,6 +66,13 @@ type ModifierConfig struct {
 type PrometheusConfig struct {
 	EnableServer              bool
 	TearDownServer            bool
+	PreInstallServer          bool
+	PreInstallNamespace       string
+	PreInstallServiceName     string
+	PreInstallServicePort     int
+	Namespace                 string
+	ServiceName               string
+	ServicePort               int
 	ScrapeEtcd                bool
 	ScrapeNodeExporter        bool
 	ScrapeKubelets            bool

--- a/clusterloader2/pkg/measurement/common/prometheus_measurement.go
+++ b/clusterloader2/pkg/measurement/common/prometheus_measurement.go
@@ -18,6 +18,7 @@ package common
 
 import (
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/prometheus/common/model"
@@ -34,7 +35,7 @@ func CreatePrometheusMeasurement(gatherer Gatherer) measurement.Measurement {
 	}
 }
 
-// QueryExecutor is an interface for queryning Prometheus server.
+// QueryExecutor is an interface for querying Prometheus server.
 type QueryExecutor interface {
 	Query(query string, queryTime time.Time) ([]*model.Sample, error)
 }
@@ -83,7 +84,8 @@ func (m *prometheusMeasurement) Execute(config *measurement.Config) ([]measureme
 		}
 
 		c := config.PrometheusFramework.GetClientSets().GetClient()
-		executor := measurementutil.NewQueryExecutor(c)
+		prometheusSvcConfig := config.ClusterLoaderConfig.PrometheusConfig
+		executor := measurementutil.NewQueryExecutor(c, prometheusSvcConfig.Namespace, prometheusSvcConfig.ServiceName, strconv.Itoa(prometheusSvcConfig.ServicePort))
 
 		summary, err := m.gatherer.Gather(executor, m.startTime, config)
 		if err != nil {


### PR DESCRIPTION
**What type of PR is this?**
/kind feature


**What this PR does / why we need it**:
Address https://github.com/kubernetes/perf-tests/issues/1713

`--enable-prometheus-server` will help us provision prometheus stack in the cluster. However,  It's hard for it to bring up prometheus server due to environment variance.  This PR allows CL2 to scratch metrics from self-deployed Prometheus server and it also shift prometheus setup responsibility to user. 

Default behavior remains same and this will be enabled by explicitly setting corresponding arguments.  `--preinstall-prometheus-server`.  Following arguments are used to construct prometheus config so that query executor know which services to talk with. 

```
--preinstall-prometheus-service-namespace
--preinstall-prometheus-service-name
--preinstall-prometheus-service-port
```


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Support preinstall Prometheus server in CL2 tests
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

Usage example:

```
PROMETHEUS_STORAGE_CLASS_PROVISIONER=kubernetes.io/aws-ebs PROMETHEUS_STORAGE_CLASS_VOLUME_TYPE=gp2
ETCD_CERTIFICATE=/etc/kubernetes/pki/kube-apiserver/etcd-client.crt ETCD_KEY=/etc/kubernetes/pki/kube-apiserver/etcd-client.key KUBE_SSH_USER=ubuntu AWS_SSH_KEY=/Users/jiaxin/.ssh/id_rsa 
go run cmd/clusterloader.go --kubeconfig=/Users/jiaxin/.kube/config --testconfig=/Users/jiaxin/go/src/k8s.io/perf-tests/clusterloader2/testing/density/config.yaml --provider=aws  --alsologtostderr --v=2 --report-dir=/tmp/pt/ --nodes=2 
--preinstall-prometheus-server 
--preinstall-prometheus-service-namespace=prometheus 
--preinstall-prometheus-service-name=prometheus --preinstall-prometheus-service-port=9095

```