### PR TITLE
Add custom thresholds override for 5k Kubemark job

### DIFF
--- a/clusterloader2/testing/overrides/kubemark_5000_nodes.yaml
+++ b/clusterloader2/testing/overrides/kubemark_5000_nodes.yaml
@@ -1,0 +1,6 @@
+CUSTOM_API_CALL_THRESHOLDS: |
+  - verb: PATCH
+    resource: nodes
+    subresource: status
+    scope: resource
+    threshold: 3s


### PR DESCRIPTION
This is to turn off alerting on slow patches of node statuses for Kubemark 5k CI job.

/sig scalability
/assign @marseel 