### PR TITLE
Change load test job to be more resilient

### DIFF
--- a/clusterloader2/testing/load/config.yaml
+++ b/clusterloader2/testing/load/config.yaml
@@ -20,6 +20,7 @@
 {{$ENABLE_CHAOSMONKEY := DefaultParam .ENABLE_CHAOSMONKEY false}}
 {{$ENABLE_API_AVAILABILITY_MEASUREMENT := DefaultParam .CL2_ENABLE_API_AVAILABILITY_MEASUREMENT false}}
 {{$ENABLE_HUGE_SERVICES := DefaultParam .CL2_ENABLE_HUGE_SERVICES false}}
+{{$RANDOM_SCALE_FACTOR := 0.5}}
 #Variables
 {{$namespaces := DivideInt .Nodes $NODES_PER_NAMESPACE}}
 {{$totalPods := MultiplyInt $namespaces $NODES_PER_NAMESPACE $PODS_PER_NODE}}
@@ -135,6 +136,7 @@ steps:
       actionName: "create"
       namespaces: {{$namespaces}}
       tuningSet: RandomizedSaturationTimeLimited
+      testMaxReplicaFactor: {{$RANDOM_SCALE_FACTOR}}
       daemonSetImage: k8s.gcr.io/pause:3.0
       daemonSetReplicas: 1
       bigDeploymentSize: {{$BIG_GROUP_SIZE}}
@@ -255,7 +257,8 @@ steps:
       actionName: "scale and update"
       namespaces: {{$namespaces}}
       tuningSet: RandomizedScalingTimeLimited
-      randomScaleFactor: 0.5
+      randomScaleFactor: {{$RANDOM_SCALE_FACTOR}}
+      testMaxReplicaFactor: {{$RANDOM_SCALE_FACTOR}}
       daemonSetImage: k8s.gcr.io/pause:3.1
       daemonSetReplicas: 1
       bigDeploymentSize: {{$BIG_GROUP_SIZE}}
@@ -281,6 +284,7 @@ steps:
       actionName: "delete"
       namespaces: {{$namespaces}}
       tuningSet: RandomizedDeletionTimeLimited
+      testMaxReplicaFactor: {{$RANDOM_SCALE_FACTOR}}
       daemonSetImage: k8s.gcr.io/pause:3.1
       daemonSetReplicas: 0
       bigDeploymentSize: {{$BIG_GROUP_SIZE}}

--- a/clusterloader2/testing/load/job.yaml
+++ b/clusterloader2/testing/load/job.yaml
@@ -9,6 +9,7 @@ metadata:
 spec:
   manualSelector: true
   parallelism: {{RandIntRange .ReplicasMin .ReplicasMax}}
+  completions: {{.Completions}}
   selector:
     matchLabels:
       name: {{.Name}}
@@ -27,7 +28,7 @@ spec:
           requests:
             cpu: 10m
             memory: "10M"
-      restartPolicy: Never
+      restartPolicy: OnFailure
       terminationGracePeriodSeconds: 1
       # Add not-ready/unreachable tolerations for 15 minutes so that node
       # failure doesn't trigger pod deletion.

--- a/clusterloader2/testing/load/modules/reconcile-objects.yaml
+++ b/clusterloader2/testing/load/modules/reconcile-objects.yaml
@@ -9,6 +9,7 @@
 {{$randomScaleFactor := DefaultParam .randomScaleFactor 0}}
 {{$minReplicaFactor := SubtractFloat 1 $randomScaleFactor}}
 {{$maxReplicaFactor := AddFloat 1 $randomScaleFactor}}
+{{$testMaxReplicaFactor := AddFloat 1 .testMaxReplicaFactor}}
 
 # DaemonSets
 {{$daemonSetImage := DefaultParam .daemonSetImage "k8s.gcr.io/pause:3.0"}}
@@ -35,6 +36,7 @@
 {{$mediumJobsPerNamespace := .mediumJobsPerNamespace}}
 {{$smallJobSize := .smallJobSize}}
 {{$smallJobsPerNamespace := .smallJobsPerNamespace}}
+{{$completionsFactor := MultiplyFloat 2 $testMaxReplicaFactor}}
 
 # PV
 {{$pvSmallStatefulSetSize := DefaultParam .pvSmallStatefulSetSize 0}}
@@ -191,6 +193,7 @@ steps:
     - basename: small-job
       objectTemplatePath: job.yaml
       templateFillMap:
+        Completions: {{MultiplyInt $smallJobSize $completionsFactor}}
         ReplicasMin: {{MultiplyInt $smallJobSize $minReplicaFactor}}
         ReplicasMax: {{MultiplyInt $smallJobSize $maxReplicaFactor}}
   - namespaceRange:
@@ -202,6 +205,7 @@ steps:
     - basename: medium-job
       objectTemplatePath: job.yaml
       templateFillMap:
+        Completions: {{MultiplyInt $mediumJobSize $completionsFactor}}
         ReplicasMin: {{MultiplyInt $mediumJobSize $minReplicaFactor}}
         ReplicasMax: {{MultiplyInt $mediumJobSize $maxReplicaFactor}}
   - namespaceRange:
@@ -213,6 +217,7 @@ steps:
     - basename: big-job
       objectTemplatePath: job.yaml
       templateFillMap:
+        Completions: {{MultiplyInt $bigJobSize $completionsFactor}}
         ReplicasMin: {{MultiplyInt $bigJobSize $minReplicaFactor}}
         ReplicasMax: {{MultiplyInt $bigJobSize $maxReplicaFactor}}
 {{if and $is_deleting $ENABLE_PVS}}


### PR DESCRIPTION
Change to 'Parallel Jobs with a work queue' to 'Parallel Jobs with a fixed completion count'
Setting `.spec.completions` to double of possible replicas to make test more resilient for node restart.

https://kubernetes.io/docs/concepts/workloads/controllers/job/#parallel-jobs