### PR TITLE
Add mborsz to util-images/probes/OWNERS

### DIFF
--- a/util-images/probes/OWNERS
+++ b/util-images/probes/OWNERS
@@ -1,8 +1,10 @@
 approvers:
+- mborsz
 - mm4tt
 - oxddr
 - wojtek-t
 reviewers:
+- mborsz
 - mm4tt
 - oxddr
 - wojtek-t


### PR DESCRIPTION
The current set of OWNERS in that directory doesn't provide a good overage (technically only wojtek-t is able to do reviews).

Add me to avoid sending all PRs there to wojtek-t.