### PR TITLE
Add mborsz to OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,5 +1,6 @@
 approvers:
 - gmarek
+- mborsz
 - mm4tt
 - shyamjvs
 - timothysc


### PR DESCRIPTION
Adds mborsz to top-level OWNERS as suggested by @wojtek-t in https://github.com/kubernetes/perf-tests/pull/1819#pullrequestreview-672742974.

/cc @gmarek @mm4tt @shyamjvs @timothysc @wojtek-t 