### PR TITLE
cleanup automanaged ns

### DIFF
--- a/clusterloader2/api/validation.go
+++ b/clusterloader2/api/validation.go
@@ -44,11 +44,6 @@ func (v *ConfigValidator) Validate() *errors.ErrorList {
 	allErrs := field.ErrorList{}
 	c := v.config
 
-	// TODO(#1696): Clean up after removing automanagedNamespaces
-	if c.AutomanagedNamespaces < 0 {
-		allErrs = append(allErrs, field.Invalid(field.NewPath("automanagedNamespaces"), c.AutomanagedNamespaces, "must be non-negative"))
-	}
-
 	allErrs = append(allErrs, v.validateNamespace(&c.Namespace, field.NewPath("namespace"))...)
 
 	for i := range c.TuningSets {

--- a/clusterloader2/api/validation_test.go
+++ b/clusterloader2/api/validation_test.go
@@ -301,7 +301,6 @@ func TestVerifyStep(t *testing.T) {
 	}
 }
 
-// TODO(#1696): Remove deprecated automanagedNamespaces
 func TestFileExists(t *testing.T) {
 	for _, test := range []struct {
 		name     string
@@ -338,7 +337,6 @@ func TestValidate(t *testing.T) {
 		{
 			name: "valid config",
 			input: Config{
-				AutomanagedNamespaces: 10,
 				Namespace: NamespaceConfig{
 					Number: 1,
 				},
@@ -346,19 +344,8 @@ func TestValidate(t *testing.T) {
 			expected: nil,
 		},
 		{
-			name: "negative automanaged namespaces",
-			input: Config{
-				AutomanagedNamespaces: -10,
-				Namespace: NamespaceConfig{
-					Number: 1,
-				},
-			},
-			expected: errors.NewErrorList(fmt.Errorf("automanagedNamespaces: Invalid value: -10: must be non-negative")),
-		},
-		{
 			name: "non-positive number of namespaces",
 			input: Config{
-				AutomanagedNamespaces: 10,
 				Namespace: NamespaceConfig{
 					Number: 0,
 				},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug
/kind failing-test
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
This PR removes the usage of deprecated automanaged namespaces , in continuation of #1806 
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1696 

**Special notes for your reviewer**:
[WIP]

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```