### PR TITLE
Actually delete configmaps and secrets

### DIFF
--- a/clusterloader2/testing/load/config.yaml
+++ b/clusterloader2/testing/load/config.yaml
@@ -332,9 +332,9 @@ steps:
       actionName: delete
       tuningSet: Global100qps
       namespaces: {{$namespaces}}
-      bigDeploymentsPerNamespace: {{$bigDeploymentsPerNamespace}}
-      mediumDeploymentsPerNamespace: {{$mediumDeploymentsPerNamespace}}
-      smallDeploymentsPerNamespace: {{$smallDeploymentsPerNamespace}}
+      bigDeploymentsPerNamespace: 0
+      mediumDeploymentsPerNamespace: 0
+      smallDeploymentsPerNamespace: 0
 
 - name: Deleting PriorityClass for DaemonSets
   phases:


### PR DESCRIPTION
Bug in https://github.com/kubernetes/perf-tests/pull/1822, the step that is supposed to delete configmaps and secrets in fact no-op patches them.

/assign @marseel 