### PR TITLE
Ignore few restarts on konnectivity-agent

### DIFF
--- a/clusterloader2/testing/experiments/ignore_known_gce_container_restarts.yaml
+++ b/clusterloader2/testing/experiments/ignore_known_gce_container_restarts.yaml
@@ -9,6 +9,7 @@ RESTART_COUNT_THRESHOLD_OVERRIDES: |
   metadata-proxy: 2
   prometheus-to-sd-exporter: 2
   coredns: 2
+  konnectivity-agent: 2
 
   # Allow for a single restart of master components.
   # As long as tests are passing, a single restart shouldn't be a problem


### PR DESCRIPTION
We are already ignoring node components. Add 'konnectivity-agent' to the list

/assign @wojtek-t 