### PR TITLE
Parallelize scheduler-throughput pod creation

### DIFF
--- a/clusterloader2/testing/load/config.yaml
+++ b/clusterloader2/testing/load/config.yaml
@@ -20,6 +20,7 @@
 {{$ENABLE_CHAOSMONKEY := DefaultParam .ENABLE_CHAOSMONKEY false}}
 {{$ENABLE_API_AVAILABILITY_MEASUREMENT := DefaultParam .CL2_ENABLE_API_AVAILABILITY_MEASUREMENT false}}
 {{$ENABLE_HUGE_SERVICES := DefaultParam .CL2_ENABLE_HUGE_SERVICES false}}
+{{$ENABLE_HUGE_SERVICES_MULTIPLE_DEPLOYMENTS := DefaultParam .CL2_ENABLE_HUGE_SERVICES_MULTIPLE_REPLICAS false}}
 # Determines number of pods per deployment. Should be a divider of .Nodes.
 {{$HUGE_SERVICES_SIZE := DefaultParam .CL2_HUGE_SERVICES_SIZE 1000}}
 {{$RANDOM_SCALE_FACTOR := 0.5}}
@@ -64,7 +65,7 @@
 {{$schedulerThroughputPodsPerDeployment := .Nodes}}
 {{$schedulerThroughputNamespaces := DivideInt $totalSchedulerThroughputPods $schedulerThroughputPodsPerDeployment}}
 
-{{if and $ENABLE_HUGE_SERVICES (ge .Nodes $HUGE_SERVICES_SIZE)}}
+{{if and $ENABLE_HUGE_SERVICES $ENABLE_HUGE_SERVICES_MULTIPLE_DEPLOYMENTS (ge .Nodes $HUGE_SERVICES_SIZE)}}
   {{$schedulerThroughputReplicasPerNamespace = DivideInt .Nodes $HUGE_SERVICES_SIZE}}
   {{$schedulerThroughputPodsPerDeployment = DivideInt .Nodes $schedulerThroughputReplicasPerNamespace}}
   {{$schedulerThroughputNamespaces = 1}}
@@ -195,6 +196,7 @@ steps:
     path: modules/huge-services.yaml
     params:
       action: create
+      enableMultipleDeployments: {{$ENABLE_HUGE_SERVICES_MULTIPLE_DEPLOYMENTS}}
       namespaces: {{$namespaces}}
       replicasPerNamespace: 1
       schedulerThroughputNamespaces: {{$schedulerThroughputNamespaces}}
@@ -203,6 +205,7 @@ steps:
     path: modules/scheduler-throughput.yaml
     params:
       action: create
+      enableMultipleDeployments: {{$ENABLE_HUGE_SERVICES_MULTIPLE_DEPLOYMENTS}}
       namespaces: {{$namespaces}}
       replicasPerNamespace: {{$schedulerThroughputReplicasPerNamespace}}
       schedulerThroughputNamespaces: {{$schedulerThroughputNamespaces}}
@@ -257,6 +260,7 @@ steps:
     path: modules/scheduler-throughput.yaml
     params:
       action: delete
+      enableMultipleDeployments: {{$ENABLE_HUGE_SERVICES_MULTIPLE_DEPLOYMENTS}}
       namespaces: {{$namespaces}}
       replicasPerNamespace: 0
       schedulerThroughputNamespaces: {{$schedulerThroughputNamespaces}}
@@ -267,6 +271,7 @@ steps:
     path: modules/huge-services.yaml
     params:
       action: delete
+      enableMultipleDeployments: {{$ENABLE_HUGE_SERVICES_MULTIPLE_DEPLOYMENTS}}
       namespaces: {{$namespaces}}
       replicasPerNamespace: 0
       schedulerThroughputNamespaces: {{$schedulerThroughputNamespaces}}

--- a/clusterloader2/testing/load/config.yaml
+++ b/clusterloader2/testing/load/config.yaml
@@ -20,6 +20,8 @@
 {{$ENABLE_CHAOSMONKEY := DefaultParam .ENABLE_CHAOSMONKEY false}}
 {{$ENABLE_API_AVAILABILITY_MEASUREMENT := DefaultParam .CL2_ENABLE_API_AVAILABILITY_MEASUREMENT false}}
 {{$ENABLE_HUGE_SERVICES := DefaultParam .CL2_ENABLE_HUGE_SERVICES false}}
+# Determines number of pods per deployment. Should be a divider of .Nodes.
+{{$HUGE_SERVICES_SIZE := DefaultParam .CL2_HUGE_SERVICES_SIZE 1000}}
 {{$RANDOM_SCALE_FACTOR := 0.5}}
 #Variables
 {{$namespaces := DivideInt .Nodes $NODES_PER_NAMESPACE}}
@@ -58,13 +60,20 @@
 # BEGIN scheduler-throughput section
 # TODO( https://github.com/kubernetes/perf-tests/issues/1027): Lower the number of "min-pods" once we fix the scheduler throughput measurement.
 {{$totalSchedulerThroughputPods := MaxInt (MultiplyInt 2 $MIN_PODS_IN_SMALL_CLUSTERS) .Nodes}}
+{{$schedulerThroughputReplicasPerNamespace := 1}}
 {{$schedulerThroughputPodsPerDeployment := .Nodes}}
 {{$schedulerThroughputNamespaces := DivideInt $totalSchedulerThroughputPods $schedulerThroughputPodsPerDeployment}}
-# END scheduler-throughput section
+
+{{if and $ENABLE_HUGE_SERVICES (ge .Nodes $HUGE_SERVICES_SIZE)}}
+  {{$schedulerThroughputReplicasPerNamespace = DivideInt .Nodes $HUGE_SERVICES_SIZE}}
+  {{$schedulerThroughputPodsPerDeployment = DivideInt .Nodes $schedulerThroughputReplicasPerNamespace}}
+  {{$schedulerThroughputNamespaces = 1}}
+{{end}}
 
 # Set schedulerThroughputNamespaces to 1 on small clusters otherwise it will result
 # in an unnecessary number of namespaces.
 {{$schedulerThroughputNamespaces := IfThenElse $IS_SMALL_CLUSTER 1 $schedulerThroughputNamespaces}}
+# END scheduler-throughput section
 
 # Command to be executed
 {{$EXEC_COMMAND := DefaultParam .CL2_EXEC_COMMAND nil}}
@@ -82,7 +91,7 @@ tuningSets:
 # parallel creation of deployments.
 - name: SchedulerThroughputParallel
   parallelismLimitedLoad:
-    parallelismLimit: {{$schedulerThroughputNamespaces}}
+    parallelismLimit: {{MultiplyInt $schedulerThroughputNamespaces $schedulerThroughputReplicasPerNamespace}}
 # TODO(https://github.com/kubernetes/perf-tests/issues/1024): This TuningSet is used only for pod-startup-latency, get rid of it
 # Uniform5qps: for each running phase, use 5 qps.
 - name: Uniform5qps
@@ -104,6 +113,9 @@ tuningSets:
     # as each RS changes its size from X to a uniform random value in [X/2, 3X/2].
     # To match 10 [pods/s] requirement, we need to divide saturationTime by 4.
     timeLimit: {{DivideInt $saturationTime 4}}s
+- name: DeletionTimeLimited
+  TimeLimitedLoad:
+    timeLimit: 5m
 - name: RandomizedDeletionTimeLimited
   RandomizedTimeLimitedLoad:
     timeLimit: {{$deletionTime}}s
@@ -192,7 +204,7 @@ steps:
     params:
       action: create
       namespaces: {{$namespaces}}
-      replicasPerNamespace: 1
+      replicasPerNamespace: {{$schedulerThroughputReplicasPerNamespace}}
       schedulerThroughputNamespaces: {{$schedulerThroughputNamespaces}}
       schedulerThroughputPodsPerDeployment: {{$schedulerThroughputPodsPerDeployment}}
   {{if $ENABLE_HUGE_SERVICES}}

--- a/clusterloader2/testing/load/modules/huge-services.yaml
+++ b/clusterloader2/testing/load/modules/huge-services.yaml
@@ -4,9 +4,6 @@
 {{$replicasPerNamespace := .replicasPerNamespace}}
 {{$schedulerThroughputNamespaces := .schedulerThroughputNamespaces}}
 
-## Derivative variables
-{{$is_deleting := (eq .action "delete")}}
-
 steps:
 - name: {{$action}} huge services
   phases:
@@ -18,11 +15,3 @@ steps:
     objectBundle:
     - basename: huge-service
       objectTemplatePath: service.yaml
-{{if $is_deleting}}
-- name: Sleeping after deleting huge services
-  measurements:
-  - Identifier: WaitAfterHugeServicesDeletion
-    Method: Sleep
-    Params:
-      duration: "3m"
-{{end}}

--- a/clusterloader2/testing/load/modules/huge-services.yaml
+++ b/clusterloader2/testing/load/modules/huge-services.yaml
@@ -1,5 +1,6 @@
 # Valid actions: "create", "delete"
 {{$action := .action}}
+{{$enableMultipleDeployments := .enableMultipleDeployments}}
 {{$namespaces := .namespaces}}
 {{$replicasPerNamespace := .replicasPerNamespace}}
 {{$schedulerThroughputNamespaces := .schedulerThroughputNamespaces}}
@@ -15,3 +16,11 @@ steps:
     objectBundle:
     - basename: huge-service
       objectTemplatePath: service.yaml
+{{if and (eq .action "delete") $enableMultipleDeployments}}
+- name: Sleeping after deleting huge services
+  measurements:
+  - Identifier: WaitAfterHugeServicesDeletion
+    Method: Sleep
+    Params:
+      duration: "3m"
+{{end}}

--- a/clusterloader2/testing/load/modules/scheduler-throughput.yaml
+++ b/clusterloader2/testing/load/modules/scheduler-throughput.yaml
@@ -47,7 +47,7 @@ steps:
       min: {{AddInt $namespaces 1}}
       max: {{AddInt $namespaces $schedulerThroughputNamespaces}}
     replicasPerNamespace: {{$replicasPerNamespace}}
-    tuningSet: SchedulerThroughputParallel
+    tuningSet: {{IfThenElse $is_creating "SchedulerThroughputParallel" "DeletionTimeLimited"}}
     objectBundle:
     - basename: scheduler-throughput-deployment
       objectTemplatePath: simple-deployment.yaml

--- a/clusterloader2/testing/load/modules/scheduler-throughput.yaml
+++ b/clusterloader2/testing/load/modules/scheduler-throughput.yaml
@@ -10,6 +10,7 @@
 
 ## Derivative variables
 {{$is_creating := (eq .action "create")}}
+{{$tuningSet := IfThenElse (and (eq .action "delete") .enableMultipleDeployments) "DeletionTimeLimited" "SchedulerThroughputParallel"}}
 
 ## CL2 params
 {{$SCHEDULER_THROUGHPUT_THRESHOLD := DefaultParam .CL2_SCHEDULER_THROUGHPUT_THRESHOLD 100}}
@@ -47,7 +48,7 @@ steps:
       min: {{AddInt $namespaces 1}}
       max: {{AddInt $namespaces $schedulerThroughputNamespaces}}
     replicasPerNamespace: {{$replicasPerNamespace}}
-    tuningSet: {{IfThenElse $is_creating "SchedulerThroughputParallel" "DeletionTimeLimited"}}
+    tuningSet: {{$tuningSet}}
     objectBundle:
     - basename: scheduler-throughput-deployment
       objectTemplatePath: simple-deployment.yaml


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
Currently, in load test we have 5k pods in huge service. Unfortunately this is too big and causes flakiness of our tests. We would like to find appropriate size of huge service so we can include it in our scalability documentation. The idea is to split huge service to several smaller deployments, and document max service size equal to the size of single deployment.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
N/A

**Special notes for your reviewer**:
N/A

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
N/A
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
N/A
```