### PR TITLE
Make API call latency panels title more meaningful

### DIFF
--- a/clusterloader2/pkg/prometheus/manifests/dashboards/master-dashboard.dashboard.py
+++ b/clusterloader2/pkg/prometheus/manifests/dashboards/master-dashboard.dashboard.py
@@ -37,19 +37,19 @@ def api_call_latency_panel(expression):
 
     return [
         api_call_latency(
-            title="Read-only API call latency (percentaile=99, scope=resource, threshold=1s)",
+            title="GET resource latency (percentaile=99, scope=resource, threshold=1s)",
             verb="GET",
             scope="resource",
             threshold=1,
         ),
         api_call_latency(
-            title="Read-only API call latency (percentaile=99, scope=namespace, threshold=5s)",
+            title="LIST namespace latency (percentaile=99, scope=namespace, threshold=5s)",
             verb="LIST",
             scope="namespace",
             threshold=5,
         ),
         api_call_latency(
-            title="Read-only API call latency (percentaile=99, scope=cluster, threshold=30s)",
+            title="LIST cluster latency (percentaile=99, scope=cluster, threshold=30s)",
             verb="LIST",
             scope="cluster",
             threshold=30,

--- a/clusterloader2/pkg/prometheus/manifests/dashboards/master-dashboard.json
+++ b/clusterloader2/pkg/prometheus/manifests/dashboards/master-dashboard.json
@@ -95,7 +95,7 @@
                     ],
                     "timeFrom": null,
                     "timeShift": null,
-                    "title": "Read-only API call latency (percentaile=99, scope=resource, threshold=1s)",
+                    "title": "GET resource latency (percentaile=99, scope=resource, threshold=1s)",
                     "tooltip": {
                         "msResolution": true,
                         "shared": true,
@@ -207,7 +207,7 @@
                     ],
                     "timeFrom": null,
                     "timeShift": null,
-                    "title": "Read-only API call latency (percentaile=99, scope=namespace, threshold=5s)",
+                    "title": "LIST namespace latency (percentaile=99, scope=namespace, threshold=5s)",
                     "tooltip": {
                         "msResolution": true,
                         "shared": true,
@@ -319,7 +319,7 @@
                     ],
                     "timeFrom": null,
                     "timeShift": null,
-                    "title": "Read-only API call latency (percentaile=99, scope=cluster, threshold=30s)",
+                    "title": "LIST cluster latency (percentaile=99, scope=cluster, threshold=30s)",
                     "tooltip": {
                         "msResolution": true,
                         "shared": true,
@@ -553,7 +553,7 @@
                     ],
                     "timeFrom": null,
                     "timeShift": null,
-                    "title": "Read-only API call latency (percentaile=99, scope=resource, threshold=1s)",
+                    "title": "GET resource latency (percentaile=99, scope=resource, threshold=1s)",
                     "tooltip": {
                         "msResolution": true,
                         "shared": true,
@@ -665,7 +665,7 @@
                     ],
                     "timeFrom": null,
                     "timeShift": null,
-                    "title": "Read-only API call latency (percentaile=99, scope=namespace, threshold=5s)",
+                    "title": "LIST namespace latency (percentaile=99, scope=namespace, threshold=5s)",
                     "tooltip": {
                         "msResolution": true,
                         "shared": true,
@@ -777,7 +777,7 @@
                     ],
                     "timeFrom": null,
                     "timeShift": null,
-                    "title": "Read-only API call latency (percentaile=99, scope=cluster, threshold=30s)",
+                    "title": "LIST cluster latency (percentaile=99, scope=cluster, threshold=30s)",
                     "tooltip": {
                         "msResolution": true,
                         "shared": true,


### PR DESCRIPTION
What type of PR is this?
/kind cleanup

What this PR does / why we need it:
Currently most of "API call latency" panels has the same title: "Read-only API call latency".
This PR make titles more descriptive.