### PR TITLE
Remove exec and proxy subresources from graphs

### DIFF
--- a/clusterloader2/pkg/prometheus/manifests/dashboards/master-dashboard.dashboard.py
+++ b/clusterloader2/pkg/prometheus/manifests/dashboards/master-dashboard.dashboard.py
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from collections import namedtuple
 from grafanalib import core as g
 import defaults as d
 
@@ -68,6 +67,7 @@ apiserver:apiserver_request_latency_1m:histogram_quantile{
   verb=~"%(verb)s",
   scope=~"%(scope)s",
   resource=~"${resource:regex}s*",
+  subresource!~"exec|proxy",
 }""")
 
 QUANTILE_API_CALL_LATENCY_PANELS = api_call_latency_panel("""
@@ -77,6 +77,7 @@ apiserver:apiserver_request_latency_1m:histogram_quantile{
   verb=~"%(verb)s",
   scope=~"%(scope)s",
   resource=~"${resource:regex}s*",
+  subresource!~"exec|proxy",
 }[5d])""")
 
 PAF_PANELS = [

--- a/clusterloader2/pkg/prometheus/manifests/dashboards/master-dashboard.json
+++ b/clusterloader2/pkg/prometheus/manifests/dashboards/master-dashboard.json
@@ -81,7 +81,7 @@
                         },
                         {
                             "datasource": "",
-                            "expr": "apiserver:apiserver_request_latency_1m:histogram_quantile{quantile=\"0.99\", verb=~\"GET\", scope=~\"resource\", resource=~\"${resource:regex}s*\", }",
+                            "expr": "apiserver:apiserver_request_latency_1m:histogram_quantile{quantile=\"0.99\", verb=~\"GET\", scope=~\"resource\", resource=~\"${resource:regex}s*\", subresource!~\"exec|proxy\", }",
                             "format": "time_series",
                             "instant": false,
                             "interval": "",
@@ -193,7 +193,7 @@
                         },
                         {
                             "datasource": "",
-                            "expr": "apiserver:apiserver_request_latency_1m:histogram_quantile{quantile=\"0.99\", verb=~\"LIST\", scope=~\"namespace\", resource=~\"${resource:regex}s*\", }",
+                            "expr": "apiserver:apiserver_request_latency_1m:histogram_quantile{quantile=\"0.99\", verb=~\"LIST\", scope=~\"namespace\", resource=~\"${resource:regex}s*\", subresource!~\"exec|proxy\", }",
                             "format": "time_series",
                             "instant": false,
                             "interval": "",
@@ -305,7 +305,7 @@
                         },
                         {
                             "datasource": "",
-                            "expr": "apiserver:apiserver_request_latency_1m:histogram_quantile{quantile=\"0.99\", verb=~\"LIST\", scope=~\"cluster\", resource=~\"${resource:regex}s*\", }",
+                            "expr": "apiserver:apiserver_request_latency_1m:histogram_quantile{quantile=\"0.99\", verb=~\"LIST\", scope=~\"cluster\", resource=~\"${resource:regex}s*\", subresource!~\"exec|proxy\", }",
                             "format": "time_series",
                             "instant": false,
                             "interval": "",
@@ -417,7 +417,7 @@
                         },
                         {
                             "datasource": "",
-                            "expr": "apiserver:apiserver_request_latency_1m:histogram_quantile{quantile=\"0.99\", verb=~\"CREATE|DELETE|PATCH|POST|PUT\", scope=~\"namespace|cluster|resource\", resource=~\"${resource:regex}s*\", }",
+                            "expr": "apiserver:apiserver_request_latency_1m:histogram_quantile{quantile=\"0.99\", verb=~\"CREATE|DELETE|PATCH|POST|PUT\", scope=~\"namespace|cluster|resource\", resource=~\"${resource:regex}s*\", subresource!~\"exec|proxy\", }",
                             "format": "time_series",
                             "instant": false,
                             "interval": "",
@@ -539,7 +539,7 @@
                         },
                         {
                             "datasource": "",
-                            "expr": "quantile_over_time(0.99, apiserver:apiserver_request_latency_1m:histogram_quantile{quantile=\"0.99\", verb=~\"GET\", scope=~\"resource\", resource=~\"${resource:regex}s*\", }[5d])",
+                            "expr": "quantile_over_time(0.99, apiserver:apiserver_request_latency_1m:histogram_quantile{quantile=\"0.99\", verb=~\"GET\", scope=~\"resource\", resource=~\"${resource:regex}s*\", subresource!~\"exec|proxy\", }[5d])",
                             "format": "time_series",
                             "instant": false,
                             "interval": "",
@@ -651,7 +651,7 @@
                         },
                         {
                             "datasource": "",
-                            "expr": "quantile_over_time(0.99, apiserver:apiserver_request_latency_1m:histogram_quantile{quantile=\"0.99\", verb=~\"LIST\", scope=~\"namespace\", resource=~\"${resource:regex}s*\", }[5d])",
+                            "expr": "quantile_over_time(0.99, apiserver:apiserver_request_latency_1m:histogram_quantile{quantile=\"0.99\", verb=~\"LIST\", scope=~\"namespace\", resource=~\"${resource:regex}s*\", subresource!~\"exec|proxy\", }[5d])",
                             "format": "time_series",
                             "instant": false,
                             "interval": "",
@@ -763,7 +763,7 @@
                         },
                         {
                             "datasource": "",
-                            "expr": "quantile_over_time(0.99, apiserver:apiserver_request_latency_1m:histogram_quantile{quantile=\"0.99\", verb=~\"LIST\", scope=~\"cluster\", resource=~\"${resource:regex}s*\", }[5d])",
+                            "expr": "quantile_over_time(0.99, apiserver:apiserver_request_latency_1m:histogram_quantile{quantile=\"0.99\", verb=~\"LIST\", scope=~\"cluster\", resource=~\"${resource:regex}s*\", subresource!~\"exec|proxy\", }[5d])",
                             "format": "time_series",
                             "instant": false,
                             "interval": "",
@@ -875,7 +875,7 @@
                         },
                         {
                             "datasource": "",
-                            "expr": "quantile_over_time(0.99, apiserver:apiserver_request_latency_1m:histogram_quantile{quantile=\"0.99\", verb=~\"CREATE|DELETE|PATCH|POST|PUT\", scope=~\"namespace|cluster|resource\", resource=~\"${resource:regex}s*\", }[5d])",
+                            "expr": "quantile_over_time(0.99, apiserver:apiserver_request_latency_1m:histogram_quantile{quantile=\"0.99\", verb=~\"CREATE|DELETE|PATCH|POST|PUT\", scope=~\"namespace|cluster|resource\", resource=~\"${resource:regex}s*\", subresource!~\"exec|proxy\", }[5d])",
                             "format": "time_series",
                             "instant": false,
                             "interval": "",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup
**What this PR does / why we need it**:
In APIResponsivenessPrometheus, we are not taking into account long running requests like exec or proxy: https://github.com/kubernetes/perf-tests/blob/7a618c70f992f9718a156106f42e56ab78eecbe6/clusterloader2/pkg/measurement/common/slos/api_responsiveness_prometheus.go#L48
This PR removes these two calls from grafana latency panels as well. 
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```