### PR TITLE
Refactor logging in WaitForPods

### DIFF
--- a/clusterloader2/pkg/measurement/util/wait_for_pods.go
+++ b/clusterloader2/pkg/measurement/util/wait_for_pods.go
@@ -64,7 +64,9 @@ func WaitForPods(clientSet clientset.Interface, stopCh <-chan struct{}, options 
 		select {
 		case <-stopCh:
 			desiredPodCount := options.DesiredPodCount()
-			klog.V(2).Infof("%s: %s: pods status: %v", options.CallerName, options.Selector.String(), ComputePodsStatus(oldPods, desiredPodCount))
+			pods := ComputePodsStatus(oldPods)
+			klog.V(2).Infof("%s: %s: expected %d pods, got %d pods (not RunningAndReady pods: %v)", options.CallerName, options.Selector.String(), desiredPodCount, len(oldPods), pods.NotRunningAndReady())
+			klog.V(2).Infof("%s: %s: all pods: %v", options.CallerName, options.Selector.String(), pods)
 			return fmt.Errorf("timeout while waiting for %d pods to be running in namespace '%v' with labels '%v' and fields '%v' - summary of pods : %s",
 				desiredPodCount, options.Selector.Namespace, options.Selector.LabelSelector, options.Selector.FieldSelector, podsStatus.String())
 		case <-time.After(options.WaitForPodsInterval):


### PR DESCRIPTION
This is a first PR of WaitForPods refactor.

The goal is to make the logging in case of timeout more readable:
* not printing all "good state" pods
* making sure that all states in the logs matches actual statuses used in conditions

This PR addresses mostly first part.

I'm afraid to change the WaitForPods logic on Friday afternoon, so will do that in the next PR.

/assign @marseel 