### PR TITLE
Automate testing scalability of Metrics Server

### DIFF
--- a/clusterloader2/pkg/prometheus/README.md
+++ b/clusterloader2/pkg/prometheus/README.md
@@ -13,3 +13,11 @@ Prometheus stack in ClusterLoader2 framework.
 1. ``kubectl --namespace monitoring port-forward svc/grafana 3000 --address=0.0.0.0``
 2. Visit http://localhost:3000
 3. Login/password: admin/admin
+
+## How to measure the Latency of metrics-server
+
+Make sure to configure the following flags
+
+- `--provider=gce`
+- `--enable-prometheus-server=true`
+- `--prometheus-scrape-metrics-server=true`

--- a/clusterloader2/pkg/prometheus/manifests/exporters/metrics-server/resourceConsumer.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/exporters/metrics-server/resourceConsumer.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: resource-consumer
+  namespace: default
+spec:
+  replicas: 10
+  selector:
+    matchLabels:
+      app: resource-consumer
+  template:
+    metadata:
+      labels:
+        app: resource-consumer
+    spec:
+      containers:
+      - name: resource-consumer
+        image: gcr.io/kubernetes-e2e-test-images/resource-consumer:1.5
+        command:
+          - ./consume-cpu/consume-cpu
+        args:
+          - --duration-sec=3600
+          - --millicores=10
+        resources:
+          requests:
+            cpu: 10m
+          limits:  
+            cpu: 10m

--- a/clusterloader2/pkg/prometheus/manifests/exporters/metrics-server/resourceConsumerHpa.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/exporters/metrics-server/resourceConsumerHpa.yaml
@@ -1,0 +1,13 @@
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: resource-consumer-hpa
+  namespace: default
+spec:
+  maxReplicas: 80
+  minReplicas: 10
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: resource-consumer
+  targetCPUUtilizationPercentage: 50


### PR DESCRIPTION
Signed-off-by: JunYang <yang.jun22@zte.com.cn>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
implement of issue:  [#710](https://github.com/kubernetes-sigs/metrics-server/issues/710)
Deploy some dummy HPAs to put load on MS and use resource-consumer image maintained as part of test-infra, and will not affect other tests.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
part of issue:  [#710](https://github.com/kubernetes-sigs/metrics-server/issues/710)
**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```