### PR TITLE
Add SIGINT handler to handle Prometheus snapshot

### DIFF
--- a/clusterloader2/cmd/clusterloader.go
+++ b/clusterloader2/cmd/clusterloader.go
@@ -292,6 +292,9 @@ func main() {
 		if err := prometheusController.SetUpPrometheusStack(); err != nil {
 			klog.Exitf("Error while setting up prometheus stack: %v", err)
 		}
+		if clusterLoaderConfig.PrometheusConfig.TearDownServer {
+			prometheusController.EnableTearDownPrometheusStackOnInterrupt()
+		}
 	}
 	if clusterLoaderConfig.EnableExecService {
 		if err := execservice.SetUpExecService(f); err != nil {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Currently, [kubetest sends SIGINT](https://github.com/kubernetes/test-infra/blob/master/kubetest/process/process.go#L202) in case of test timeout. This is handled by ClusterLoader2 by exiting immediately.

After this changes, SIGINT will be cached and ClusterLoader2 will try to snapshot disk image.

Test timeouts can indicate problems with unresponsive kube-apiserver, so there is no communication attempt to kube-apiserver. Potentially partial data will be lost, but it's a better situation that missing a whole snapshot.

/assign @mborsz 