### PR TITLE
Fast delete events

### DIFF
--- a/clusterloader2/cmd/clusterloader.go
+++ b/clusterloader2/cmd/clusterloader.go
@@ -85,6 +85,7 @@ func initClusterFlags() {
 	flags.StringSliceEnvVar(&clusterLoaderConfig.ClusterConfig.MasterIPs, "masterip", "MASTER_IP", nil /*defaultValue*/, "Hostname/IP of the master node, supports multiple values when separated by commas")
 	flags.StringSliceEnvVar(&clusterLoaderConfig.ClusterConfig.MasterInternalIPs, "master-internal-ip", "MASTER_INTERNAL_IP", nil /*defaultValue*/, "Cluster internal/private IP of the master vm, supports multiple values when separated by commas")
 	flags.BoolEnvVar(&clusterLoaderConfig.ClusterConfig.APIServerPprofByClientEnabled, "apiserver-pprof-by-client-enabled", "APISERVER_PPROF_BY_CLIENT_ENABLED", true, "Whether apiserver pprof endpoint can be accessed by Kubernetes client.")
+	flags.IntEnvVar(&clusterLoaderConfig.ClusterConfig.ParallelEventDeletions, framework.ParallelEventDeletionsName, "PARALLEL_EVENT_DELETIONS", 0, "Number of events to delete in parallel before deleting namespace. For faster test cleanup. Zero means just let namespace deletion implicitly clean up events - which is slower for large event counts")
 
 	flags.StringEnvVar(&providerInitOptions.ProviderName, "provider", "PROVIDER", "", "Cluster provider name")
 	flags.StringSliceEnvVar(&providerInitOptions.ProviderConfigs, "provider-configs", "PROVIDER_CONFIGS", nil, "Cluster provider configurations")

--- a/clusterloader2/pkg/config/cluster.go
+++ b/clusterloader2/pkg/config/cluster.go
@@ -48,6 +48,9 @@ type ClusterConfig struct {
 	DeleteStaleNamespaces bool
 	// TODO(#1696): Clean up after removing automanagedNamespaces
 	DeleteAutomanagedNamespaces bool
+	// ParallelEventDeletions says how many goroutines to run for fast deletion of events, before deleting a namespace
+	// Zero means do not delete events (just let namespace deletion implicitly delete the events)
+	ParallelEventDeletions int
 	// APIServerPprofByClientEnabled determines whether kube-apiserver pprof endpoint can be accessed
 	// using kubernetes client. If false, clusterloader will avoid collecting kube-apiserver profiles.
 	APIServerPprofByClientEnabled bool


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

CL2 tests may cause a lot of events to be created in K8s. Then, at the end of the test, when CL2 cleans up the namespace, it can take quite a few minutes to delete the namespace due to the large number of events.

This PR adds optional fast deletion of events, by deleting events in parallel just prior to namespace deletion.  This considerably reduces the cleanup time at the end of tests (e.g. from 5mins to 30 seconds in one test).

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes/perf-tests/issues/1872

**Does this PR introduce a user-facing change?**:

```release-note
ClusterLoader2 can now clean up namespaces faster if you specify the command line parameter `--parallel-event-deletions`.  Try setting to it to 100 for smaller clusters and 200 for larger.
```

