### PR TITLE
pod startup: pre-define generic ephemeral volume type

### DIFF
--- a/clusterloader2/testing/experimental/storage/pod-startup/config.yaml
+++ b/clusterloader2/testing/experimental/storage/pod-startup/config.yaml
@@ -146,6 +146,9 @@ steps:
       templateFillMap:
         Group: volume-test
         VolumesPerPod: {{$VOLUMES_PER_POD}}
+        VolSize: {{$VOL_SIZE}}
+        StorageClass: {{$STORAGE_CLASS}}
+        Provisioner: {{$PROVISIONER}}
 - name: Waiting for deployments to be running
   measurements:
   - Identifier: WaitForRunningDeployments

--- a/clusterloader2/testing/experimental/storage/pod-startup/volume-types/genericephemeralinline/deployment_with_inline.yaml
+++ b/clusterloader2/testing/experimental/storage/pod-startup/volume-types/genericephemeralinline/deployment_with_inline.yaml
@@ -1,0 +1,67 @@
+{{$index := .Index}}
+{{$volumesPerPod := .VolumesPerPod}}
+{{$name := .Name}}
+{{$group := .Group}}
+{{$provisioner := .Provisioner}}
+{{$storageclass := .StorageClass}}
+{{$volsize := .VolSize}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{.Name}}
+  labels:
+    group: {{.Group}}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: {{.Name}}
+  template:
+    metadata:
+      labels:
+        group: {{.Group}}
+        name: {{.Name}}
+    spec:
+      containers:
+      - name: {{.Name}}
+        image: k8s.gcr.io/pause:3.1
+        imagePullPolicy: IfNotPresent
+        volumeMounts:
+        {{ range $volumeIndex := Loop .VolumesPerPod }}
+        - name: vol-{{$volumeIndex}}
+          mountPath: /usr/share/{{$volumeIndex}}
+        {{ end }}
+      volumes:
+      {{ range $volumeIndex := Loop .VolumesPerPod }}
+      - name: vol-{{$volumeIndex}}
+        ephemeral:
+          volumeClaimTemplate:
+            metadata:
+              labels:
+                app: {{$name}}
+                group: {{$group}}
+              {{ if $provisioner }}
+              annotations:
+                volume.beta.kubernetes.io/storage-provisioner: {{$provisioner}}
+              {{ end }}
+            spec:
+              accessModes:
+                - ReadWriteOnce
+              {{ if $storageclass }}
+              storageClassName: {{$storageclass}}
+              {{ end }}
+              resources:
+                requests:
+                  storage: {{$volsize}}
+      {{ end }}
+      # Add not-ready/unreachable tolerations for 15 minutes so that node
+      # failure doesn't trigger pod deletion.
+      tolerations:
+      - key: "node.kubernetes.io/not-ready"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 900
+      - key: "node.kubernetes.io/unreachable"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 900

--- a/clusterloader2/testing/experimental/storage/pod-startup/volume-types/genericephemeralinline/override.yaml
+++ b/clusterloader2/testing/experimental/storage/pod-startup/volume-types/genericephemeralinline/override.yaml
@@ -1,0 +1,4 @@
+PROVISION_VOLUME: false
+WAIT_FOR_PVS_BOUND: false
+WAIT_FOR_PVS_DELETED: false
+DEPLOYMENT_TEMPLATE_PATH: "volume-types/genericephemeralinline/deployment_with_inline.yaml"


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

This can be used to create pods with a varying number of generic ephemeral
inline volumes.

Example for usage with the "distributed" deployment of csi-driver-host-path:

```
  $ cat test.yaml
  PODS_PER_NODE: 5
  VOLUMES_PER_POD: 3
  VOL_SIZE: 1Gi
  STORAGE_CLASS: csi-hostpath-fast

  $ go run cmd/clusterloader.go -v=3 --kubeconfig=$KUBECONFIG --provider=local --nodes=1 \
       --testconfig=testing/experimental/storage/pod-startup/config.yaml \
       --testoverrides=testing/experimental/storage/pod-startup/volume-types/genericephemeralinline/override.yaml \
       --testoverrides=test.yaml
```

**Which issue(s) this PR fixes**:

Related-to: https://github.com/kubernetes/enhancements/issues/1698

**Does this PR introduce a user-facing change?**:
```release-note
the experimental pod startup test now also has a pre-defined volume type for generic ephemeral volumes
```
