### PR TITLE
add timed_qps_load and RuntimeInjection.RandomInt

### DIFF
--- a/clusterloader2/api/types.go
+++ b/clusterloader2/api/types.go
@@ -167,6 +167,8 @@ type TuningSet struct {
 	InitialDelay Duration `json:"initialDelay"`
 	// QPSLoad is a definition for QPSLoad tuning set.
 	QPSLoad *QPSLoad `json:"qpsLoad"`
+	// TimedQPSLoad is a definition for the TimedQPSLoad tuning set.
+	TimedQPSLoad *TimedQPSLoad `json:"timedQPSLoad"`
 	// RandomizedLoad is a definition for RandomizedLoad tuning set.
 	RandomizedLoad *RandomizedLoad `json:"randomizedLoad"`
 	// SteppedLoad is a definition for SteppedLoad tuning set.
@@ -212,6 +214,18 @@ type Measurement struct {
 type QPSLoad struct {
 	// QPS specifies requested qps.
 	QPS float64 `json:"qps"`
+}
+
+type TimedQPSLoad struct {
+	// QPS specifies requested qps.
+	QPS float64 `json:"qps"`
+
+	// How long to exert QPS load for
+	Duration Duration `json:"duration"`
+
+	// TODO:
+	// * some sort of kill signal that monitors a configmap
+	// killSignal string
 }
 
 // RandomizedLoad defines a load that is spread randomly

--- a/clusterloader2/api/validation.go
+++ b/clusterloader2/api/validation.go
@@ -181,6 +181,10 @@ func (v *ConfigValidator) validateTuningSet(ts *TuningSet, fldPath *field.Path) 
 		tuningSetsNumber++
 		allErrs = append(allErrs, v.validateQPSLoad(ts.QPSLoad, fldPath.Child("qpsLoad"))...)
 	}
+	if ts.TimedQPSLoad != nil {
+		tuningSetsNumber++
+		allErrs = append(allErrs, v.validateTimedQPSLoad(ts.TimedQPSLoad, fldPath.Child("timedQPSLoad"))...)
+	}
 	if ts.RandomizedLoad != nil {
 		tuningSetsNumber++
 		allErrs = append(allErrs, v.validateRandomizedLoad(ts.RandomizedLoad, fldPath.Child("randomizedLoad"))...)
@@ -220,6 +224,17 @@ func (v *ConfigValidator) validateQPSLoad(ql *QPSLoad, fldPath *field.Path) fiel
 	allErrs := field.ErrorList{}
 	if ql.QPS <= 0 {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("qps"), ql.QPS, "must have positive value"))
+	}
+	return allErrs
+}
+
+func (v *ConfigValidator) validateTimedQPSLoad(ql *TimedQPSLoad, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	if ql.QPS <= 0 {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("qps"), ql.QPS, "must have positive value"))
+	}
+	if ql.Duration < 0 {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("duration"), ql.Duration, "must have positive value"))
 	}
 	return allErrs
 }

--- a/clusterloader2/pkg/runtimeinjection/runtime_substitution.go
+++ b/clusterloader2/pkg/runtimeinjection/runtime_substitution.go
@@ -1,0 +1,56 @@
+package runtimeinjection
+
+import (
+	"fmt"
+	"math/rand"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// This function substitutes all runtime injections:
+// * marshalls into a string
+// * searches for runtime injections
+// * for each runtime injection, calls the function and replaces the string with the result
+// * unmarshals back into an object
+func SubstituteRuntimeInjections(obj *unstructured.Unstructured) error {
+	objBytes, err := obj.MarshalJSON()
+	if err != nil {
+		return fmt.Errorf("Error marshalling in runtimeinjection: %v", err)
+	}
+	objString := string(objBytes)
+	// First group is the injection type, second group will be the args
+	re := regexp.MustCompile("\"RuntimeInjection.([a-zA-Z]+)\\((.+)\\)\"")
+	// results: [[<full-match>, <first-string>, <second-string>]]
+	results := re.FindAllStringSubmatch(objString, -1)
+	// results = [][]string{}
+	for _, result := range results {
+		if len(result) != 3 {
+			return fmt.Errorf("Invalid RuntimeInjection")
+		}
+
+		fullMatch := result[0]
+		injectionType := result[1]
+		injectionArgs := result[2]
+		switch injectionType {
+		case "RandomInt":
+			max, err := strconv.Atoi(injectionArgs)
+			if err != nil {
+				return fmt.Errorf("Unsupported RuntimeInjection arg: %v", injectionArgs)
+			}
+			randomInteger := rand.Intn(max)
+			objString = strings.Replace(objString, fullMatch, fmt.Sprint(randomInteger), 1)
+		default:
+			return fmt.Errorf("Unsupported RuntimeInjection: %v", injectionType)
+		}
+	}
+
+	fmt.Println(objString)
+	err = obj.UnmarshalJSON([]byte(objString))
+	if err != nil {
+		return fmt.Errorf("Error unmarshalling in runtimeinjection: %v", err)
+	}
+	return nil
+}

--- a/clusterloader2/pkg/test/simple_test_executor.go
+++ b/clusterloader2/pkg/test/simple_test_executor.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/perf-tests/clusterloader2/pkg/config"
 	"k8s.io/perf-tests/clusterloader2/pkg/errors"
 	"k8s.io/perf-tests/clusterloader2/pkg/measurement/util/runtimeobjects"
+	"k8s.io/perf-tests/clusterloader2/pkg/runtimeinjection"
 	"k8s.io/perf-tests/clusterloader2/pkg/state"
 	"k8s.io/perf-tests/clusterloader2/pkg/util"
 )
@@ -299,6 +300,10 @@ func (ste *simpleExecutor) ExecuteObject(ctx Context, object *api.Object, namesp
 		obj, err = ctx.GetTemplateProvider().TemplateToObject(object.ObjectTemplatePath, mapping)
 		if err != nil && err != config.ErrorEmptyFile {
 			return errors.NewErrorList(fmt.Errorf("reading template (%v) error: %v", object.ObjectTemplatePath, err))
+		}
+		err := runtimeinjection.SubstituteRuntimeInjections(obj)
+		if err != nil {
+			return errors.NewErrorList(fmt.Errorf("runtime injection error: %v", err))
 		}
 	case deleteObject:
 		obj, err = ctx.GetTemplateProvider().RawToObject(object.ObjectTemplatePath)

--- a/clusterloader2/pkg/tuningset/simple_tuning_set_factory.go
+++ b/clusterloader2/pkg/tuningset/simple_tuning_set_factory.go
@@ -50,6 +50,8 @@ func (tf *simpleFactory) CreateTuningSet(name string) (TuningSet, error) {
 		return nil, fmt.Errorf("tuningset %s not found", name)
 	}
 	switch {
+	case tuningSet.TimedQPSLoad != nil:
+		return newTimedQPSLoad(tuningSet.TimedQPSLoad), nil
 	case tuningSet.QPSLoad != nil:
 		return newQPSLoad(tuningSet.QPSLoad), nil
 	case tuningSet.RandomizedLoad != nil:

--- a/clusterloader2/pkg/tuningset/timed_qps_load.go
+++ b/clusterloader2/pkg/tuningset/timed_qps_load.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tuningset
+
+import (
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/perf-tests/clusterloader2/api"
+)
+
+type timedQPSLoad struct {
+	params *api.TimedQPSLoad
+}
+
+func newTimedQPSLoad(params *api.TimedQPSLoad) TuningSet {
+	return &timedQPSLoad{
+		params: params,
+	}
+}
+
+func (ql *timedQPSLoad) Execute(actions []func()) {
+	stopTime := time.Now().Add(time.Duration(ql.params.Duration))
+
+	var wg wait.Group
+	for time.Now().Before(stopTime) {
+		// TODO:
+		// * log time left in tuningset
+		sleepDuration := time.Duration(int(float64(time.Second) / ql.params.QPS))
+		for i := range actions {
+			wg.Start(actions[i])
+			time.Sleep(sleepDuration)
+		}
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature


**What this PR does / why we need it**:
* Adds the `timed_qps_load` tuning set to allow running tests indefinitely. 
* Introduces `RuntimeInjections` to allow for creating unique objects in tuning set loops. These are necessary because cl2 precompiles the objects to create before passing them to the tuning set, so even if a tuning set were to loop forever, it would just loop over the same objects and after the first loop not add any additional load to the cluster. With RuntimeInjections which are evaluated when the tuningset is running, you can create unique objects.
* More context here: https://github.com/kubernetes/perf-tests/issues/1880

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1880

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
No changes to existing APIs.

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

Example config:
```
{{ $NAMESPACES := "3"}}
{{ $POD_GROUP_LABEL := DefaultParam .POD_GROUP_LABEL "cluster-loader" }}

name: simple-bring-up
namespace:
  number: {{ $NAMESPACES }}
tuningSets:
- name: uniform-qps
  qpsLoad:
    qps: 1
- name: timed-qps
  timedQPSLoad:
    qps: 1
    duration: 300d

steps:
# create deployments. NOTE this has to be in a separate step than scaling the deployments due to how cl2 works.
# It will predetermine whether to send a POST or a PATCH at the beginning of the test, not at the tuning-set execution
- name: create-pods
  phases:
    - namespaceRange:
        min: 1
        max: {{ $NAMESPACES }}
      replicasPerNamespace: {{ 3 }}
      tuningSet: uniform-qps
      objectBundle:
        - basename: deployment
          objectTemplatePath: deployment.yaml
          templateFillMap:
            Replicas: 1
            Group: {{ $POD_GROUP_LABEL }}
            CpuRequest: 10m
            MemoryRequest: 5Mi

# scales deployments to random replica counts between 0-10 in a loop for timed-qps duration
- name: scale-pods
  phases:
    - namespaceRange:
        min: 1
        max: {{ $NAMESPACES }}
      replicasPerNamespace: {{ 3 }}
      tuningSet: timed-qps
      objectBundle:
        - basename: deployment
          objectTemplatePath: deployment.yaml
          templateFillMap:
            Replicas: RuntimeInjection.RandomInt(10)
            Group: {{ $POD_GROUP_LABEL }}
            CpuRequest: 10m
            MemoryRequest: 5Mi
```