### PR TITLE
Add lock when calling pingCheckers's functions to guarantee data consistency

### DIFF
--- a/clusterloader2/pkg/measurement/common/service_creation_latency.go
+++ b/clusterloader2/pkg/measurement/common/service_creation_latency.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"time"
+	"sync"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -78,6 +79,7 @@ type serviceCreationLatencyMeasurement struct {
 	client        clientset.Interface
 	creationTimes *measurementutil.ObjectTransitionTimes
 	pingCheckers  checker.Map
+	lock          sync.Mutex
 }
 
 // Execute executes service startup latency measurement actions.
@@ -123,6 +125,8 @@ func (s *serviceCreationLatencyMeasurement) Dispose() {
 		close(s.stopCh)
 	}
 	s.queue.Stop()
+	s.lock.Lock()
+	defer s.lock.Unlock()
 	s.pingCheckers.Dispose()
 }
 
@@ -257,6 +261,8 @@ func (s *serviceCreationLatencyMeasurement) deleteObject(svc *corev1.Service) er
 	if err != nil {
 		return fmt.Errorf("meta key created error: %v", err)
 	}
+	s.lock.Lock()
+	defer s.lock.Unlock()
 	s.pingCheckers.DeleteAndStop(key)
 	return nil
 }
@@ -290,6 +296,8 @@ func (s *serviceCreationLatencyMeasurement) updateObject(svc *corev1.Service) er
 		stopCh:        make(chan struct{}),
 	}
 	pc.run()
+	s.lock.Lock()
+	defer s.lock.Unlock()
 	s.pingCheckers.Add(key, pc)
 
 	return nil


### PR DESCRIPTION
Missing lock when manipulating pingCheckers in service_creation_latency.go

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
Add lock when manipulating pingCheckers. Without the fix, there is high possibility to hit  fatal error as below
```
fatal error: concurrent map writes

goroutine 18304 [running]:
runtime.throw(0x199dc53, 0x15)
        /usr/local/go/src/runtime/panic.go:1117 +0x72 fp=0xc00172ed48 sp=0xc00172ed18 pc=0x438bb2
runtime.mapdelete_faststr(0x18102c0, 0xc004bdc3f0, 0xc002320260, 0x1d)
        /usr/local/go/src/runtime/map_faststr.go:306 +0x3de fp=0xc00172edb0 sp=0xc00172ed48 pc=0x41667e
k8s.io/perf-tests/clusterloader2/pkg/measurement/util/checker.Map.DeleteAndStop(...)
        /src/k8s.io/perf-tests-1c-100w/clusterloader2/pkg/measurement/util/checker/checker_map.go:52
k8s.io/perf-tests/clusterloader2/pkg/measurement/common.(*serviceCreationLatencyMeasurement).deleteObject(0xc005390460, 0xc0053a8240, 0x416c1b, 0xc00172
ee80)
        /src/k8s.io/perf-tests-1c-100w/clusterloader2/pkg/measurement/common/service_creation_latency.go:277 +0x159 fp=0xc00172ee20 sp=0xc00172edb0 pc=0
x16108d9
k8s.io/perf-tests/clusterloader2/pkg/measurement/common.(*serviceCreationLatencyMeasurement).handleObject(0xc005390460, 0x1971cc0, 0xc0053a8240, 0x0, 0x
0)
        /src/k8s.io/perf-tests-1c-100w/clusterloader2/pkg/measurement/common/service_creation_latency.go:260 +0x1a5 fp=0xc00172ef10 sp=0xc00172ee20 pc=0
x16103c5
k8s.io/perf-tests/clusterloader2/pkg/measurement/common.(*serviceCreationLatencyMeasurement).start.func1.1()
        /src/k8s.io/perf-tests-1c-100w/clusterloader2/pkg/measurement/common/service_creation_latency.go:156 +0x4e fp=0xc00172ef48 sp=0xc00172ef10 pc=0x
161c56e
k8s.io/perf-tests/clusterloader2/pkg/measurement/util/workerqueue.(*WorkerQueue).worker(0xc00f996420)
        /src/k8s.io/perf-tests-1c-100w/clusterloader2/pkg/measurement/util/workerqueue/workerqueue.go:65 +0x35 fp=0xc00172ef88 sp=0xc00172ef48 pc=0x15fe
b55
k8s.io/perf-tests/clusterloader2/pkg/measurement/util/workerqueue.(*WorkerQueue).worker-fm()
        /src/k8s.io/perf-tests-1c-100w/clusterloader2/pkg/measurement/util/workerqueue/workerqueue.go:59 +0x33 fp=0xc00172efa0 sp=0xc00172ef88 pc=0x15fe
c33
k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1(0xc00f996430, 0xc004ce2fa0)
        /root/go/pkg/mod/k8s.io/apimachinery@v0.18.0/pkg/util/wait/wait.go:73 +0x51 fp=0xc00172efd0 sp=0xc00172efa0 pc=0x10b8cb1
runtime.goexit()
        /usr/local/go/src/runtime/asm_amd64.s:1371 +0x1 fp=0xc00172efd8 sp=0xc00172efd0 pc=0x46e8c1
created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start
        /root/go/pkg/mod/k8s.io/apimachinery@v0.18.0/pkg/util/wait/wait.go:71 +0x65
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```