### PR TITLE
perf-dash: Also cap scale on Command on mac.

### DIFF
--- a/perfdash/Makefile
+++ b/perfdash/Makefile
@@ -1,7 +1,7 @@
 all: push
 
 # See deployment.yaml for the version currently running-- bump this ahead before rebuilding!
-TAG = 2.35
+TAG = 2.36
 
 REPO = gcr.io/k8s-testimages
 
@@ -28,4 +28,3 @@ push: container
 
 clean:
 	rm -f perfdash
-

--- a/perfdash/deployment.yaml
+++ b/perfdash/deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: perfdash
-        image: gcr.io/k8s-testimages/perfdash:2.35
+        image: gcr.io/k8s-testimages/perfdash:2.36
         command:
           - /perfdash
           -   --www=true

--- a/perfdash/www/script.js
+++ b/perfdash/www/script.js
@@ -34,7 +34,7 @@ var PerfDashApp = function(http, scope, route) {
 
 PerfDashApp.prototype.onClickInternal_ = function(data, evt, chart) {
     console.log(this, data, evt, chart);
-    if (evt.ctrlKey) {
+    if (evt.ctrlKey || evt.metaKey) {
       this.cap = (chart.scale.min + chart.scale.max) / 2;
       this.labelChanged();
       return;


### PR DESCRIPTION
On OSX, Command key is reported as evt.metaKey and not evt.ctrKey: https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/metaKey

It makes it hard to use the scale trimming feature. This PR makes perf-dash trim scale on "Cmd + click"

/assign @jprzychodzen 