### PR TITLE
[backport 1.20] Use containerd in image preloader

### DIFF
--- a/clusterloader2/pkg/imagepreload/manifests/daemonset.yaml
+++ b/clusterloader2/pkg/imagepreload/manifests/daemonset.yaml
@@ -15,16 +15,21 @@ spec:
       initContainers:
       {{range $idx, $image := .Images}}
       - name: preload-{{$idx}}
-        image: docker
-        command: ["docker", "pull", "{{$image}}"]
+        image: gcr.io/k8s-testimages/perf-tests-util/containerd:v0.0.1
+        command: ["sh", "-c", "ctr -n=k8s.io image pull {{$image}} 2>&1 | tee /var/log/cl2-image-preload-{{$idx}}.log"]
         volumeMounts:
-        - name: docker
-          mountPath: /var/run
+        - name: containerd
+          mountPath: /run/containerd
+        - name: logs-volume
+          mountPath: /var/log
       {{end}}
       volumes:
-      - name: docker
+      - name: containerd
         hostPath:
-          path: /var/run
+          path: /run/containerd
+      - name: logs-volume
+        hostPath:
+          path: /var/log
       containers:
       - name: pause
         image: gcr.io/google_containers/pause


### PR DESCRIPTION
Our 1.20 tests are using containerd [1], but the clusterloader tries to use docker pull to fetch images. It fails.

This backports https://github.com/kubernetes/perf-tests/pull/1654 to make it work

[1] https://github.com/kubernetes/test-infra/blob/7562f6f1ca5e73357264ad194accf5373404c2b0/config/jobs/kubernetes/sig-release/release-branch-jobs/1.20.yaml#L330-L335

/assign @wojtek-t 
