### PR TITLE
Set www/ permissions in perfdash.

### DIFF
--- a/perfdash/Dockerfile
+++ b/perfdash/Dockerfile
@@ -27,7 +27,7 @@ RUN GO111MODULE=on go build -a -installsuffix cgo -ldflags '-w' -o $PWD/perfdash
 
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/base:nonroot
-COPY www/ /www/
+COPY --chmod=0644 www/ /www/
 COPY --from=builder /workspace/perfdash /
 
 EXPOSE 8080

--- a/perfdash/Makefile
+++ b/perfdash/Makefile
@@ -1,7 +1,7 @@
 all: push
 
 # See deployment.yaml for the version currently running-- bump this ahead before rebuilding!
-TAG = 2.36
+TAG = 2.37
 
 REPO = gcr.io/k8s-testimages
 
@@ -20,8 +20,9 @@ run: perfdash
 		--githubConfigDir=https://api.github.com/repos/kubernetes/test-infra/contents/config/jobs/kubernetes/sig-scalability \
 		--githubConfigDir=https://api.github.com/repos/kubernetes/test-infra/contents/config/jobs/kubernetes/sig-release/release-branch-jobs
 
+# Use buildkit to have "COPY --chmod=" support (availability of it in "regular" docker build depends on docker version).
 container:
-	docker build --pull -t $(REPO)/perfdash:$(TAG) .
+	DOCKER_BUILDKIT=1 docker build --pull -t $(REPO)/perfdash:$(TAG) .
 
 push: container
 	gcloud docker -s $(REPO) -- push $(REPO)/perfdash:$(TAG)

--- a/perfdash/deployment.yaml
+++ b/perfdash/deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: perfdash
-        image: gcr.io/k8s-testimages/perfdash:2.36
+        image: gcr.io/k8s-testimages/perfdash:2.37
         command:
           - /perfdash
           -   --www=true


### PR DESCRIPTION
Without explicitly setting permissions for www/ static dir, `docker build` output depends on the chmod on the build workstation. This can lead to setting incorrect file permissions and rendering static file index instead of perfdash.

Let's explicitly request 0644 permissions.

/assign @mm4tt 