### PR TITLE
Allow customisation of number of endpoints for huge service

### DIFF
--- a/clusterloader2/testing/load/config.yaml
+++ b/clusterloader2/testing/load/config.yaml
@@ -20,7 +20,8 @@
 {{$ENABLE_CHAOSMONKEY := DefaultParam .ENABLE_CHAOSMONKEY false}}
 {{$ENABLE_API_AVAILABILITY_MEASUREMENT := DefaultParam .CL2_ENABLE_API_AVAILABILITY_MEASUREMENT false}}
 {{$ENABLE_HUGE_SERVICES := DefaultParam .CL2_ENABLE_HUGE_SERVICES false}}
-# Determines number of pods per deployment. Should be a divider of .Nodes.
+{{$HUGE_SERVICES_SIZE := DefaultParam .CL2_HUGE_SERVICES_SIZE .Nodes}}
+# Determines number of pods per deployment. Should be a divider of $HUGE_SERVICES_SIZE.
 {{$HUGE_SERVICES_PODS_PER_DEPLOYMENT := DefaultParam .CL2_HUGE_SERVICES_PODS_PER_DEPLOYMENT 1000}}
 {{$RANDOM_SCALE_FACTOR := 0.5}}
 #Variables
@@ -64,8 +65,8 @@
 {{$schedulerThroughputPodsPerDeployment := .Nodes}}
 {{$schedulerThroughputNamespaces := DivideInt $totalSchedulerThroughputPods $schedulerThroughputPodsPerDeployment}}
 
-{{if and $ENABLE_HUGE_SERVICES (ge .Nodes $HUGE_SERVICES_PODS_PER_DEPLOYMENT)}}
-  {{$schedulerThroughputReplicasPerNamespace = DivideInt .Nodes $HUGE_SERVICES_PODS_PER_DEPLOYMENT}}
+{{if and $ENABLE_HUGE_SERVICES (ge $HUGE_SERVICES_SIZE $HUGE_SERVICES_PODS_PER_DEPLOYMENT)}}
+  {{$schedulerThroughputReplicasPerNamespace = DivideInt $HUGE_SERVICES_SIZE $HUGE_SERVICES_PODS_PER_DEPLOYMENT}}
   {{$schedulerThroughputPodsPerDeployment = $HUGE_SERVICES_PODS_PER_DEPLOYMENT}}
   {{$schedulerThroughputNamespaces = 1}}
 {{end}}

--- a/clusterloader2/testing/load/config.yaml
+++ b/clusterloader2/testing/load/config.yaml
@@ -21,7 +21,7 @@
 {{$ENABLE_API_AVAILABILITY_MEASUREMENT := DefaultParam .CL2_ENABLE_API_AVAILABILITY_MEASUREMENT false}}
 {{$ENABLE_HUGE_SERVICES := DefaultParam .CL2_ENABLE_HUGE_SERVICES false}}
 # Determines number of pods per deployment. Should be a divider of .Nodes.
-{{$HUGE_SERVICES_SIZE := DefaultParam .CL2_HUGE_SERVICES_SIZE 1000}}
+{{$HUGE_SERVICES_PODS_PER_DEPLOYMENT := DefaultParam .CL2_HUGE_SERVICES_PODS_PER_DEPLOYMENT 1000}}
 {{$RANDOM_SCALE_FACTOR := 0.5}}
 #Variables
 {{$namespaces := DivideInt .Nodes $NODES_PER_NAMESPACE}}
@@ -64,9 +64,9 @@
 {{$schedulerThroughputPodsPerDeployment := .Nodes}}
 {{$schedulerThroughputNamespaces := DivideInt $totalSchedulerThroughputPods $schedulerThroughputPodsPerDeployment}}
 
-{{if and $ENABLE_HUGE_SERVICES (ge .Nodes $HUGE_SERVICES_SIZE)}}
-  {{$schedulerThroughputReplicasPerNamespace = DivideInt .Nodes $HUGE_SERVICES_SIZE}}
-  {{$schedulerThroughputPodsPerDeployment = DivideInt .Nodes $schedulerThroughputReplicasPerNamespace}}
+{{if and $ENABLE_HUGE_SERVICES (ge .Nodes $HUGE_SERVICES_PODS_PER_DEPLOYMENT)}}
+  {{$schedulerThroughputReplicasPerNamespace = DivideInt .Nodes $HUGE_SERVICES_PODS_PER_DEPLOYMENT}}
+  {{$schedulerThroughputPodsPerDeployment = $HUGE_SERVICES_PODS_PER_DEPLOYMENT}}
   {{$schedulerThroughputNamespaces = 1}}
 {{end}}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
Rename the existing `HUGE_SERVICES_SIZE` flag to `HUGE_SERVICES_PODS_PER_DEPLOYMENT` which better reflects on it's functionality and reintroduce flag of the same name (`HUGE_SERVICES_SIZE`) that specifies the number of pods that the huge service should consist of.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
N/A

**Special notes for your reviewer**:
This PR is split into two commits. It should make it a bit easier to track the changes as the end result might be a bit confusing.
/assign @marseel

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
N/A
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
N/A
```