### PR TITLE
Increase image preload timeout to 15m

### DIFF
--- a/clusterloader2/pkg/imagepreload/imagepreload.go
+++ b/clusterloader2/pkg/imagepreload/imagepreload.go
@@ -43,8 +43,7 @@ const (
 	namespace       = "preload"
 	daemonsetName   = "preload"
 	pollingInterval = 5 * time.Second
-	// TODO(oxddr): verify whether 5 minutes is a sufficient timeout
-	pollingTimeout = 5 * time.Minute
+	pollingTimeout  = 15 * time.Minute
 )
 
 var images []string


### PR DESCRIPTION
5m isn't sufficient in very large clusters.

/assign @wojtek-t 