### PR TITLE
Remove old hacky cherry-picks from golang

### DIFF
--- a/golang/build-kubernetes.sh
+++ b/golang/build-kubernetes.sh
@@ -60,21 +60,6 @@ WORKDIR $GOPATH#' Dockerfile
 function build_kubernetes {
   cd $ROOT_DIR/k8s.io/kubernetes/build/build-image
 
-  # Cherry-pick of https://github.com/kubernetes/kubernetes/pull/90806 which
-  # artifically increases Kubemark cluster nodes objects.
-  # TODO: Get rid of this cherry-pick once we start testing against k8s v1.19+.
-  git cherry-pick -m 1 fc2c410a5a37aba7ab0a3635c6b1195245b77e2b
-  # Cherry-pick of https://github.com/kubernetes/kubernetes/pull/95494 which
-  # prevents from rate limiting by Docker Hub when pulling busybox image per
-  # hollow node pod.
-  # TODO: Get rid of this cherry-pick once we start testing against k8s v1.20+.
-  git cherry-pick -m 1 1698af78be83db748415d224ec1ea217755ea932
-
-  # Cherry-pick of https://github.com/kubernetes/kubernetes/pull/97843 and https://github.com/kubernetes/kubernetes/pull/98141 rebased to 1.18.
-  # Used for debugging failing golang tests.
-  # TODO: Get rid of this cherry-pick once we fix the regression.
-  git fetch https://github.com/mborsz/kubernetes.git cacher-1.18 && git cherry-pick FETCH_HEAD
-
   # Change the base image of kube-build to our own kube-cross image.
   sed -i 's#FROM .*#FROM gcr.io/k8s-testimages/kube-cross-amd64:'"$TAG"'#' Dockerfile
 


### PR DESCRIPTION
We are going to bump the version of K8s for the Golang job, so these cherry picks are no longer needed.

/sig scalability