### PR TITLE
perfdash: use NEG for kubernetes service

### DIFF
--- a/perfdash/perfdash-service.yaml
+++ b/perfdash/perfdash-service.yaml
@@ -4,6 +4,8 @@ metadata:
   name: perfdash-status
   labels:
     app: perfdash
+  annotations:
+    cloud.google.com/neg: '{"ingress": true}'
 spec:
   selector:
     app: perfdash
@@ -11,4 +13,4 @@ spec:
   - name: status
     port: 80
     targetPort: status
-  type: NodePort
+  type: ClusterIP


### PR DESCRIPTION
Ref: https://github.com/kubernetes/k8s.io/issues/2488.

Switch to ClusterIP for the service.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>

/kind cleanup
/sig k8s-infra
/sig scalability