### PR TITLE
Print type when there is a merge value conflict.

### DIFF
--- a/clusterloader2/pkg/config/template_provider.go
+++ b/clusterloader2/pkg/config/template_provider.go
@@ -288,7 +288,7 @@ func MergeMappings(a, b map[string]interface{}) error {
 			continue
 		}
 		if !reflect.DeepEqual(av, bv) {
-			return goerrors.Errorf("merge conflict for key '%v': old value=%v, new value=%v", k, av, bv)
+			return goerrors.Errorf("merge conflict for key '%v': old value=%v (%T), new value=%v (%T)", k, av, av, bv, bv)
 		}
 	}
 	return nil


### PR DESCRIPTION
E.g.

```
F0929 10:57:13.881474 4136660 clusterloader.go:305] Error while preloading images: [mapping merging error: merge conflict for key 'CL2_DELETE_TEST_THROUGHPUT': old value=14 (float64), new value=14 (int64)]
```

Without this, it's quite hard to tell why the validation fails in some cases.

/assign @tosi3k 