### PR TITLE
Split CL2 env variables by = into two parts

### DIFF
--- a/clusterloader2/pkg/config/template_provider.go
+++ b/clusterloader2/pkg/config/template_provider.go
@@ -255,7 +255,7 @@ func LoadCL2Envs() (map[string]interface{}, error) {
 		if !strings.HasPrefix(keyValue, "CL2_") {
 			continue
 		}
-		split := strings.Split(keyValue, "=")
+		split := strings.SplitN(keyValue, "=", 2)
 		if len(split) != 2 {
 			return nil, goerrors.Errorf("unparsable string in os.Eviron(): %v", keyValue)
 		}

--- a/clusterloader2/pkg/config/template_provider_test.go
+++ b/clusterloader2/pkg/config/template_provider_test.go
@@ -91,6 +91,7 @@ func TestLoadCL2Envs(t *testing.T) {
 				"CL2_MY_PARAM3": "99.99",
 				"CL2_MY_PARAM4": "XXX",
 				"CL2_MY_PARAM5": "1",
+				"CL2_MY_PARAM6": "a=b",
 			},
 			wantedMapping: map[string]interface{}{
 				"CL2_MY_PARAM1": int64(100),
@@ -98,6 +99,7 @@ func TestLoadCL2Envs(t *testing.T) {
 				"CL2_MY_PARAM3": 99.99,
 				"CL2_MY_PARAM4": "XXX",
 				"CL2_MY_PARAM5": int64(1),
+				"CL2_MY_PARAM6": "a=b",
 			},
 		},
 		{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
Currently, if a variable is set with multiple equality signs (`=`), the clusterloader2 will yield an error. This change will make it resolve such variables by splitting only at the first occurence of such sign.
It should allow simplification of configuration where a `CL2` environment variable needs to be set to something like `a=b`.
For motivation see: https://github.com/kubernetes/perf-tests/pull/1876/commits/3b14d82a7b33c8547084138abb77c44afffbdba6

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
N/A

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
N/A
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
N/A
```