### PR TITLE
Add --k8s-clients-number to CL2

### DIFF
--- a/clusterloader2/pkg/config/cluster.go
+++ b/clusterloader2/pkg/config/cluster.go
@@ -52,6 +52,7 @@ type ClusterConfig struct {
 	// using kubernetes client. If false, clusterloader will avoid collecting kube-apiserver profiles.
 	APIServerPprofByClientEnabled bool
 	KubeletPort                   int
+	K8SClientsNumber              int
 }
 
 // ModifierConfig represent all flags used by test modification

--- a/clusterloader2/pkg/framework/framework.go
+++ b/clusterloader2/pkg/framework/framework.go
@@ -65,6 +65,7 @@ func NewRootFramework(clusterConfig *config.ClusterConfig, clientsNumber int) (*
 }
 
 func newFramework(clusterConfig *config.ClusterConfig, clientsNumber int, kubeConfigPath string) (*Framework, error) {
+	klog.Infof("Creating framework with %d clients and %q kubeconfig.", clientsNumber, kubeConfigPath)
 	var err error
 	f := Framework{
 		automanagedNamespaces: map[string]bool{},


### PR DESCRIPTION
Make the number of k8s clients used by CL2 customizable for two reasons:
* We think that maybe it is sufficient to use single client as it creates multiple http underlying connections anyway
* Maybe we need to actually do otherwise and increase this number to mitigate timeout issues we have seen recently.

/assign @wojtek-t 