### PR TITLE
Fix TestHistogramQuantile test

### DIFF
--- a/clusterloader2/pkg/measurement/util/histogram.go
+++ b/clusterloader2/pkg/measurement/util/histogram.go
@@ -30,8 +30,11 @@ import (
 
 // Histogram is a structure that represents distribution of data.
 type Histogram struct {
-	Labels  map[string]string `json:"labels"`
-	Buckets map[string]int    `json:"buckets"`
+	Labels map[string]string `json:"labels"`
+	// Buckets maps value to cumulative sample count:
+	// * key: float64 converted to string
+	// * value: cumulative count of all samples less or equal to the key.
+	Buckets map[string]int `json:"buckets"`
 }
 
 // Quantile calculates the quantile 'q' based on the given buckets of Histogram.

--- a/clusterloader2/pkg/measurement/util/histogram_test.go
+++ b/clusterloader2/pkg/measurement/util/histogram_test.go
@@ -104,29 +104,29 @@ func TestHistogramQuantile(t *testing.T) {
 		{
 			histogram: Histogram{
 				Buckets: map[string]int{
-					"4": 10,
-					"8": 20,
+					"4": 40,
+					"8": 60,
 					"1": 20,
-					"2": 10,
+					"2": 30,
 				},
 			},
-			q50: 0.5,
-			q90: 7.2,
-			q99: 7.92,
+			q50: 2.0,
+			q90: 6.8,
+			q99: 7.88,
 		},
-		// unsorted sequence
+		// sorted sequence
 		{
 			histogram: Histogram{
 				Buckets: map[string]int{
 					"1": 20,
-					"2": 10,
-					"4": 10,
-					"8": 20,
+					"2": 30,
+					"4": 40,
+					"8": 60,
 				},
 			},
-			q50: 0.5,
-			q90: 7.2,
-			q99: 7.92,
+			q50: 2.0,
+			q90: 6.8,
+			q99: 7.88,
 		},
 	}
 


### PR DESCRIPTION
It incorrectly sets count as a value instead of cumulative count.

In "prod", the histogram is generated using https://github.com/kubernetes/perf-tests/blob/d4c896470c6246838edde817dd41af04a181bd73/clusterloader2/pkg/measurement/util/histogram.go#L100-L110 which is using `model.BucketLabel` (value: "le") to populate, which is cumulative already.

/assign @marseel 