### PR TITLE
Fix the port number to collect the profiling data for the apiserver

### DIFF
--- a/clusterloader2/cmd/clusterloader.go
+++ b/clusterloader2/cmd/clusterloader.go
@@ -71,6 +71,7 @@ func initClusterFlags() {
 	flags.StringEnvVar(&clusterLoaderConfig.ClusterConfig.EtcdKeyPath, "etcd-key", "ETCD_KEY", "/etc/srv/kubernetes/pki/etcd-apiserver-server.key", "Path to the etcd key on the master machine")
 	flags.IntEnvVar(&clusterLoaderConfig.ClusterConfig.EtcdInsecurePort, "etcd-insecure-port", "ETCD_INSECURE_PORT", 2382, "Inscure http port")
 	flags.BoolEnvVar(&clusterLoaderConfig.ClusterConfig.DeleteStaleNamespaces, "delete-stale-namespaces", "DELETE_STALE_NAMESPACES", false, "DEPRECATED: Whether to delete all stale namespaces before the test execution.")
+	flags.IntEnvVar(&clusterLoaderConfig.ClusterConfig.KubeApiserverPort, "kube-apiserver-port", "KUBE_APISERVER_PORT", 443, "port of apiserver used to collect profiling data")
 	err := flags.MarkDeprecated("delete-stale-namespaces", "specify deleteStaleNamespaces in testconfig file instead.")
 	if err != nil {
 		klog.Fatalf("unable to mark flag delete-stale-namespaces deprecated %v", err)

--- a/clusterloader2/pkg/config/cluster.go
+++ b/clusterloader2/pkg/config/cluster.go
@@ -53,6 +53,7 @@ type ClusterConfig struct {
 	APIServerPprofByClientEnabled bool
 	KubeletPort                   int
 	K8SClientsNumber              int
+	KubeApiserverPort             int
 }
 
 // ModifierConfig represent all flags used by test modification

--- a/clusterloader2/pkg/measurement/common/profile.go
+++ b/clusterloader2/pkg/measurement/common/profile.go
@@ -232,6 +232,9 @@ func (p *profileMeasurement) getProfileCommand(config *measurement.Config) (stri
 	}
 
 	var command string
+	if p.config.componentName == "kube-apiserver" && profilePort != config.ClusterFramework.GetClusterConfig().KubeApiserverPort {
+		profilePort = config.ClusterFramework.GetClusterConfig().KubeApiserverPort
+	}
 	if p.config.componentName == "etcd" {
 		etcdCert := config.ClusterFramework.GetClusterConfig().EtcdCertificatePath
 		etcdKey := config.ClusterFramework.GetClusterConfig().EtcdKeyPath

--- a/clusterloader2/pkg/provider/util.go
+++ b/clusterloader2/pkg/provider/util.go
@@ -27,7 +27,7 @@ func getComponentProtocolAndPort(componentName string) (string, int, error) {
 	case "etcd":
 		return "https://", 2379, nil
 	case "kube-apiserver":
-		return "https://", 6443, nil
+		return "https://", 443, nil
 	case "kube-controller-manager":
 		return "https://", 10257, nil
 	case "kube-scheduler":

--- a/clusterloader2/pkg/provider/util.go
+++ b/clusterloader2/pkg/provider/util.go
@@ -27,7 +27,7 @@ func getComponentProtocolAndPort(componentName string) (string, int, error) {
 	case "etcd":
 		return "https://", 2379, nil
 	case "kube-apiserver":
-		return "https://", 443, nil
+		return "https://", 6443, nil
 	case "kube-controller-manager":
 		return "https://", 10257, nil
 	case "kube-scheduler":


### PR DESCRIPTION
`443` is the tcp port for the cluster ip `10.96.0.1`, which is used by
service `kubernetes`.

Connect the port with the localhost and fetch the profiling data is not allowed,

> curl -k https://localhost:443/debug/pprof/profile?seconds=30 -o cpu2.pprof

>  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (7) Failed to connect to localhost port 443: Connection refused

Because of this, profiling file for apiserver is always empty,

> file 10.253.2.51_kube-apiserver_CPUProfile_load_2021-08-26T11:10:26Z.pprof
10.253.2.51_kube-apiserver_CPUProfile_load_2021-08-26T11:10:26Z.pprof: empty

We should either update the url to use clusterip:443 or just update the port
to use the port exposed by the pod directly.

Signed-off-by: Dave Chen <dave.chen@arm.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
Actually,  I am not pretty sure is this a bug or just something I missed, the original code has been last for one year, why no one report the issue?

 
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```