### PR TITLE
Add configurable timeout for Prometheus stack

### DIFF
--- a/clusterloader2/pkg/config/cluster.go
+++ b/clusterloader2/pkg/config/cluster.go
@@ -17,6 +17,8 @@ limitations under the License.
 package config
 
 import (
+	"time"
+
 	"k8s.io/perf-tests/clusterloader2/pkg/provider"
 )
 
@@ -86,6 +88,7 @@ type PrometheusConfig struct {
 	NodeExporterPod            string
 	StorageClassProvisioner    string
 	StorageClassVolumeType     string
+	ReadyTimeout               time.Duration
 }
 
 // GetMasterIP returns the first master ip, added for backward compatibility.

--- a/clusterloader2/pkg/flags/types.go
+++ b/clusterloader2/pkg/flags/types.go
@@ -19,6 +19,7 @@ package flags
 import (
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/spf13/pflag"
 )
@@ -146,4 +147,34 @@ func (b *boolFlagFunc) Set(val string) error {
 // Type returns flag type.
 func (*boolFlagFunc) Type() string {
 	return "bool"
+}
+
+type durationFlagFunc struct {
+	valPtr         *time.Duration
+	initializeFunc func() error
+}
+
+// initialize runs additional parsing function.
+func (d *durationFlagFunc) initialize() error {
+	return d.initializeFunc()
+}
+
+// String returns default string.
+func (*durationFlagFunc) String() string {
+	return "0s"
+}
+
+// Set handles flag value setting.
+func (d *durationFlagFunc) Set(val string) error {
+	dVal, err := time.ParseDuration(val)
+	if err != nil {
+		return err
+	}
+	*d.valPtr = dVal
+	return nil
+}
+
+// Type returns flag type.
+func (*durationFlagFunc) Type() string {
+	return "time.Duration"
 }


### PR DESCRIPTION
Adds a possibility to configure how long ClusterLoader2 should wait for healthy Prometheus stack.

/kind feature

**What this PR does / why we need it**:

It's useful in case of:
1. Setting lower timeout for a well defined scenarios that should work.
2. Increasing timeout for exporters that need much time to start.

/assign @marseel 