### PR TITLE
Add endTime to Gatherer interface

### DIFF
--- a/clusterloader2/pkg/measurement/common/metrics_server_prometheus.go
+++ b/clusterloader2/pkg/measurement/common/metrics_server_prometheus.go
@@ -46,8 +46,8 @@ func init() {
 
 type metricsServerGatherer struct{}
 
-func (g *metricsServerGatherer) Gather(executor QueryExecutor, startTime time.Time, config *measurement.Config) ([]measurement.Summary, error) {
-	latencyMetrics, err := g.gatherLatencyMetrics(executor, startTime)
+func (g *metricsServerGatherer) Gather(executor QueryExecutor, startTime, endTime time.Time, config *measurement.Config) ([]measurement.Summary, error) {
+	latencyMetrics, err := g.gatherLatencyMetrics(executor, startTime, endTime)
 	if err != nil {
 		return nil, err
 	}
@@ -67,8 +67,7 @@ func (g *metricsServerGatherer) String() string {
 	return metricsServerPrometheusMeasurementName
 }
 
-func (g *metricsServerGatherer) gatherLatencyMetrics(executor QueryExecutor, startTime time.Time) (*measurementutil.LatencyMetric, error) {
-	endTime := time.Now()
+func (g *metricsServerGatherer) gatherLatencyMetrics(executor QueryExecutor, startTime, endTime time.Time) (*measurementutil.LatencyMetric, error) {
 	measurementDuration := endTime.Sub(startTime)
 	promDuration := measurementutil.ToPrometheusTime(measurementDuration)
 

--- a/clusterloader2/pkg/measurement/common/nodelocaldns_latency_prometheus.go
+++ b/clusterloader2/pkg/measurement/common/nodelocaldns_latency_prometheus.go
@@ -48,8 +48,8 @@ func init() {
 
 type nodelocaldnsLatencyGatherer struct{}
 
-func (n *nodelocaldnsLatencyGatherer) Gather(executor QueryExecutor, startTime time.Time, config *measurement.Config) ([]measurement.Summary, error) {
-	result, err := n.getPercentileLatencies(executor, startTime)
+func (n *nodelocaldnsLatencyGatherer) Gather(executor QueryExecutor, startTime, endTime time.Time, config *measurement.Config) ([]measurement.Summary, error) {
+	result, err := n.getPercentileLatencies(executor, startTime, endTime)
 	if err != nil {
 		return nil, err
 	}
@@ -82,8 +82,7 @@ func (n *nodelocaldnsLatencyGatherer) validateResult(config *measurement.Config,
 	return nil
 }
 
-func (n *nodelocaldnsLatencyGatherer) getPercentileLatencies(executor QueryExecutor, startTime time.Time) (*measurementutil.LatencyMetric, error) {
-	endTime := time.Now()
+func (n *nodelocaldnsLatencyGatherer) getPercentileLatencies(executor QueryExecutor, startTime, endTime time.Time) (*measurementutil.LatencyMetric, error) {
 	measurementDuration := endTime.Sub(startTime)
 	promDuration := measurementutil.ToPrometheusTime(measurementDuration)
 	errList := errors.NewErrorList()

--- a/clusterloader2/pkg/measurement/common/prometheus_measurement.go
+++ b/clusterloader2/pkg/measurement/common/prometheus_measurement.go
@@ -43,7 +43,7 @@ type QueryExecutor interface {
 // It's assumed Prometheus is up, running and instructed to scrape required metrics in the test cluster
 // (please see clusterloader2/pkg/prometheus/manifests).
 type Gatherer interface {
-	Gather(executor QueryExecutor, startTime time.Time, config *measurement.Config) ([]measurement.Summary, error)
+	Gather(executor QueryExecutor, startTime, endTime time.Time, config *measurement.Config) ([]measurement.Summary, error)
 	IsEnabled(config *measurement.Config) bool
 	String() string
 }
@@ -85,7 +85,7 @@ func (m *prometheusMeasurement) Execute(config *measurement.Config) ([]measureme
 		c := config.PrometheusFramework.GetClientSets().GetClient()
 		executor := measurementutil.NewQueryExecutor(c)
 
-		summary, err := m.gatherer.Gather(executor, m.startTime, config)
+		summary, err := m.gatherer.Gather(executor, m.startTime, time.Now(), config)
 		if err != nil {
 			if !errors.IsMetricViolationError(err) {
 				klog.Errorf("%s gathering error: %v", config.Identifier, err)

--- a/clusterloader2/pkg/measurement/common/scheduling_throughput_prometheus.go
+++ b/clusterloader2/pkg/measurement/common/scheduling_throughput_prometheus.go
@@ -42,8 +42,8 @@ func init() {
 
 type schedulingThroughputGatherer struct{}
 
-func (a *schedulingThroughputGatherer) Gather(executor QueryExecutor, startTime time.Time, config *measurement.Config) ([]measurement.Summary, error) {
-	throughputSummary, err := a.getThroughputSummary(executor, startTime, config)
+func (a *schedulingThroughputGatherer) Gather(executor QueryExecutor, startTime, endTime time.Time, config *measurement.Config) ([]measurement.Summary, error) {
+	throughputSummary, err := a.getThroughputSummary(executor, startTime, endTime, config)
 	if err != nil {
 		return nil, err
 	}
@@ -67,13 +67,12 @@ func (a *schedulingThroughputGatherer) Gather(executor QueryExecutor, startTime 
 	return summaries, err
 }
 
-func (a *schedulingThroughputGatherer) getThroughputSummary(executor QueryExecutor, startTime time.Time, config *measurement.Config) (*schedulingThroughputPrometheus, error) {
-	measurementEnd := time.Now()
-	measurementDuration := measurementEnd.Sub(startTime)
+func (a *schedulingThroughputGatherer) getThroughputSummary(executor QueryExecutor, startTime, endTime time.Time, config *measurement.Config) (*schedulingThroughputPrometheus, error) {
+	measurementDuration := endTime.Sub(startTime)
 	promDuration := measurementutil.ToPrometheusTime(measurementDuration)
 	query := fmt.Sprintf(maxSchedulingThroughputQuery, promDuration)
 
-	samples, err := executor.Query(query, measurementEnd)
+	samples, err := executor.Query(query, endTime)
 	if err != nil {
 		return nil, err
 	}

--- a/clusterloader2/pkg/measurement/common/slos/api_responsiveness_prometheus_test.go
+++ b/clusterloader2/pkg/measurement/common/slos/api_responsiveness_prometheus_test.go
@@ -333,7 +333,7 @@ func TestAPIResponsivenessSLOFailures(t *testing.T) {
 				},
 			}
 
-			_, err := gatherer.Gather(executor, time.Now(), config)
+			_, err := gatherer.Gather(executor, time.Now(), time.Now(), config)
 			if tc.hasError {
 				assert.NotNil(t, err, "wanted error, but got none")
 			} else {
@@ -410,7 +410,7 @@ func TestAPIResponsivenessSummary(t *testing.T) {
 				},
 			}
 
-			summaries, err := gatherer.Gather(executor, time.Now(), config)
+			summaries, err := gatherer.Gather(executor, time.Now(), time.Now(), config)
 			if !errors.IsMetricViolationError(err) {
 				t.Fatal("unexpected error: ", err)
 			}
@@ -573,7 +573,7 @@ func TestLogging(t *testing.T) {
 			gatherer := &apiResponsivenessGatherer{}
 			config := &measurement.Config{}
 
-			_, err := gatherer.Gather(executor, time.Now(), config)
+			_, err := gatherer.Gather(executor, time.Now(), time.Now(), config)
 			if err != nil && !errors.IsMetricViolationError(err) {
 				t.Errorf("error while gathering results: %v", err)
 			}
@@ -738,7 +738,7 @@ func TestAPIResponsivenessCustomThresholds(t *testing.T) {
 			executor := &fakeQueryExecutor{samples: tc.samples}
 			gatherer := &apiResponsivenessGatherer{}
 
-			_, err := gatherer.Gather(executor, time.Now(), tc.config)
+			_, err := gatherer.Gather(executor, time.Now(), time.Now(), tc.config)
 			klog.Flush()
 			if tc.hasError {
 				assert.NotNil(t, err, "expected an error, but got none")

--- a/clusterloader2/pkg/measurement/common/slos/network_programming.go
+++ b/clusterloader2/pkg/measurement/common/slos/network_programming.go
@@ -57,8 +57,8 @@ func (n *netProgGatherer) IsEnabled(config *measurement.Config) bool {
 	return config.CloudProvider.Name() != "kubemark"
 }
 
-func (n *netProgGatherer) Gather(executor common.QueryExecutor, startTime time.Time, config *measurement.Config) ([]measurement.Summary, error) {
-	latency, err := n.query(executor, startTime)
+func (n *netProgGatherer) Gather(executor common.QueryExecutor, startTime, endTime time.Time, config *measurement.Config) ([]measurement.Summary, error) {
+	latency, err := n.query(executor, startTime, endTime)
 	if err != nil {
 		return nil, err
 	}
@@ -72,13 +72,12 @@ func (n *netProgGatherer) String() string {
 	return netProg
 }
 
-func (n *netProgGatherer) query(executor common.QueryExecutor, startTime time.Time) (*measurementutil.LatencyMetric, error) {
-	end := time.Now()
-	duration := end.Sub(startTime)
+func (n *netProgGatherer) query(executor common.QueryExecutor, startTime, endTime time.Time) (*measurementutil.LatencyMetric, error) {
+	duration := endTime.Sub(startTime)
 
 	boundedQuery := fmt.Sprintf(query, measurementutil.ToPrometheusTime(duration))
 
-	samples, err := executor.Query(boundedQuery, end)
+	samples, err := executor.Query(boundedQuery, endTime)
 	if err != nil {
 		return nil, err
 	}

--- a/clusterloader2/pkg/measurement/common/slos/network_programming_test.go
+++ b/clusterloader2/pkg/measurement/common/slos/network_programming_test.go
@@ -53,7 +53,7 @@ func TestGather(t *testing.T) {
 
 func testGatherer(t *testing.T, executor common.QueryExecutor, wantData *measurementutil.PerfData, wantError error) {
 	g := &netProgGatherer{}
-	summaries, err := g.Gather(executor, time.Now(), nil)
+	summaries, err := g.Gather(executor, time.Now(), time.Now(), nil)
 	if err != nil {
 		if wantError != nil {
 			assert.Equal(t, wantError, err)

--- a/clusterloader2/pkg/measurement/common/slos/windows_node_resource_usage.go
+++ b/clusterloader2/pkg/measurement/common/slos/windows_node_resource_usage.go
@@ -95,8 +95,8 @@ func convertToMemoryPerfData(samples []*model.Sample) *measurementutil.PerfData 
 	return perfData
 }
 
-func getSummary(query string, converter convertFunc, metricsName string, executor common.QueryExecutor, config *measurement.Config) (measurement.Summary, error) {
-	samples, err := executor.Query(query, time.Now())
+func getSummary(query string, converter convertFunc, metricsName string, measurementTime time.Time, executor common.QueryExecutor, config *measurement.Config) (measurement.Summary, error) {
+	samples, err := executor.Query(query, measurementTime)
 	if err != nil {
 		return nil, err
 	}
@@ -112,12 +112,12 @@ func getSummary(query string, converter convertFunc, metricsName string, executo
 }
 
 // Gather gathers the metrics and convert to json summary
-func (w *windowsResourceUsageGatherer) Gather(executor common.QueryExecutor, startTime time.Time, config *measurement.Config) ([]measurement.Summary, error) {
-	cpuSummary, err := getSummary(cpuUsageQueryTop10, convertToCPUPerfData, cpuUsageMetricsName, executor, config)
+func (w *windowsResourceUsageGatherer) Gather(executor common.QueryExecutor, startTime, endTime time.Time, config *measurement.Config) ([]measurement.Summary, error) {
+	cpuSummary, err := getSummary(cpuUsageQueryTop10, convertToCPUPerfData, cpuUsageMetricsName, endTime, executor, config)
 	if err != nil {
 		return nil, err
 	}
-	memorySummary, err := getSummary(memoryUsageQueryTop10, convertToMemoryPerfData, memoryUsageMetricsName, executor, config)
+	memorySummary, err := getSummary(memoryUsageQueryTop10, convertToMemoryPerfData, memoryUsageMetricsName, endTime, executor, config)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
This PR adds endTime to Gatherer interface. It is necessary for me to introduce new executor to be used in unit tests in next pull request. This new executor will use prometheus query engine with lazy loader backend, allowing users to load time series from file. Thanks to that we will be able to write unit tests for measurements which will run queries against executor that can parse and execute queries in the same manner as prometheus does. Therefore, we will be able to detect issues with our queries in measurement. Currently in unit tests, we use fakeExecutors which always return the same results for test case even after the query in measurement is changed.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
no
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```