### PR TITLE
Revert "Customize enabling of immutable secrets and configmaps in CL2"

### DIFF
--- a/clusterloader2/testing/load/configmap.yaml
+++ b/clusterloader2/testing/load/configmap.yaml
@@ -1,11 +1,8 @@
-# TODO(#1706): Remove CL2_ENABLE_IMMUTABLE_SECRETS_AND_CONFIGMAPS usage when support for 1.17 is dropped.
-{{$EnableImmutableSecretsAndConfigmaps := DefaultParam .CL2_ENABLE_IMMUTABLE_SECRETS_AND_CONFIGMAPS true}}
-
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{.Name}}
-{{if and $EnableImmutableSecretsAndConfigmaps (not (eq (Mod .Index 20) 0 19)) }}
+{{if not (eq (Mod .Index 20) 0 19) }} # .Index % 20 in {0,19} - only 10% deployments will have non-immutable ConfigMap.
 immutable: true
 {{end}}
 # Every pod that needs its own configmap entry should be unconditionally

--- a/clusterloader2/testing/load/deployment.yaml
+++ b/clusterloader2/testing/load/deployment.yaml
@@ -1,8 +1,6 @@
 {{$HostNetworkMode := DefaultParam .CL2_USE_HOST_NETWORK_PODS false}}
 {{$CpuRequest := DefaultParam .CpuRequest "10m"}}
 {{$MemoryRequest := DefaultParam .MemoryRequest "10M"}}
-# TODO(#1706): Remove CL2_ENABLE_IMMUTABLE_SECRETS_AND_CONFIGMAPS usage when support for 1.17 is dropped.
-{{$EnableImmutableSecretsAndConfigmaps := DefaultParam .CL2_ENABLE_IMMUTABLE_SECRETS_AND_CONFIGMAPS true}}
 
 apiVersion: apps/v1
 kind: Deployment
@@ -48,14 +46,10 @@ spec:
             cpu: {{$CpuRequest}}
             memory: {{$MemoryRequest}}
         volumeMounts:
-        {{if or $EnableImmutableSecretsAndConfigmaps (eq (Mod .Index 20) 0 19) }}
           - name: configmap
             mountPath: /var/configmap
-        {{end}}
-        {{if or $EnableImmutableSecretsAndConfigmaps (eq (Mod .Index 20) 10 19) }}
           - name: secret
             mountPath: /var/secret
-        {{end}}
       terminationGracePeriodSeconds: 1
       # Add not-ready/unreachable tolerations for 15 minutes so that node
       # failure doesn't trigger pod deletion.
@@ -69,14 +63,10 @@ spec:
         effect: "NoExecute"
         tolerationSeconds: 900
       volumes:
-      {{if or $EnableImmutableSecretsAndConfigmaps (eq (Mod .Index 20) 0 19) }}
         - name: configmap
           configMap:
             name: {{.BaseName}}-{{.Index}}
-      {{end}}
-      {{if or $EnableImmutableSecretsAndConfigmaps (eq (Mod .Index 20) 10 19) }}
         - name: secret
           secret:
             secretName: {{.BaseName}}-{{.Index}}
-      {{end}}
 

--- a/clusterloader2/testing/load/secret.yaml
+++ b/clusterloader2/testing/load/secret.yaml
@@ -1,11 +1,8 @@
-# TODO(#1706): Remove CL2_ENABLE_IMMUTABLE_SECRETS_AND_CONFIGMAPS usage when support for 1.17 is dropped.
-{{$EnableImmutableSecretsAndConfigmaps := DefaultParam .CL2_ENABLE_IMMUTABLE_SECRETS_AND_CONFIGMAPS true}}
-
 apiVersion: v1
 kind: Secret
 metadata:
   name: {{.Name}}
-{{if and $EnableImmutableSecretsAndConfigmaps (not (eq (Mod .Index 20) 10 19)) }}
+{{if not (eq (Mod .Index 20) 10 19) }} # .Index % 20 in {10,19} - only 10% deployments will have non-immutable Secret.
 immutable: true
 {{end}}
 type: Opaque


### PR DESCRIPTION
Reverts kubernetes/perf-tests#1692, since immutable ephemeral volumes are GA since 1.19+ and we do not test older minors anymore.

Fixes https://github.com/kubernetes/perf-tests/issues/1706.

/kind cleanup
/sig scalability
/assign @wojtek-t @mborsz