### PR TITLE
Add separate huge service test config

### DIFF
--- a/clusterloader2/testing/huge-service/config.yaml
+++ b/clusterloader2/testing/huge-service/config.yaml
@@ -1,0 +1,26 @@
+# Huge service test config
+{{$HUGE_SERVICE_HEADLESS := DefaultParam .CL2_HUGE_SERVICE_HEADLESS false}}
+{{$HUGE_SERVICE_ENDPOINTS := DefaultParam .CL2_HUGE_SERVICE_ENDPOINTS 1000}}
+
+name: huge-service
+namespace:
+  number: 1
+tuningSets:
+- name: Sequence
+  parallelismLimitedLoad:
+    parallelismLimit: 1
+steps:
+- module:
+    path: modules/measurements.yaml
+    params:
+      action: start
+- module:
+    path: modules/service.yaml
+    params:
+      endpoints: {{$HUGE_SERVICE_ENDPOINTS}}
+      isHeadless: {{$HUGE_SERVICE_HEADLESS}}
+      serviceName: huge-service
+- module:
+    path: modules/measurements.yaml
+    params:
+      action: gather

--- a/clusterloader2/testing/huge-service/modules/measurements.yaml
+++ b/clusterloader2/testing/huge-service/modules/measurements.yaml
@@ -1,0 +1,48 @@
+# Valid actions: "start", "gather"
+{{$action := .action}}
+
+{{$ALLOWED_SLOW_API_CALLS := DefaultParam .CL2_ALLOWED_SLOW_API_CALLS 0}}
+{{$PROBE_MEASUREMENTS_CHECK_PROBES_READY_TIMEOUT := DefaultParam .CL2_PROBE_MEASUREMENTS_CHECK_PROBES_READY_TIMEOUT "15m"}}
+{{$ENABLE_VIOLATIONS_FOR_API_CALL_PROMETHEUS := DefaultParam .CL2_ENABLE_VIOLATIONS_FOR_API_CALL_PROMETHEUS false}}
+{{$ENABLE_VIOLATIONS_FOR_API_CALL_PROMETHEUS_SIMPLE := DefaultParam .CL2_ENABLE_VIOLATIONS_FOR_API_CALL_PROMETHEUS_SIMPLE true}}
+
+{{$CUSTOM_API_CALL_THRESHOLDS := DefaultParam .CUSTOM_API_CALL_THRESHOLDS ""}}
+{{$ENABLE_RESTART_COUNT_CHECK := DefaultParam .ENABLE_RESTART_COUNT_CHECK true}}
+{{$ENABLE_SYSTEM_POD_METRICS := DefaultParam .ENABLE_SYSTEM_POD_METRICS true}}
+{{$RESTART_COUNT_THRESHOLD_OVERRIDES := DefaultParam .RESTART_COUNT_THRESHOLD_OVERRIDES ""}}
+{{$USE_SIMPLE_LATENCY_QUERY := DefaultParam .USE_SIMPLE_LATENCY_QUERY false}}
+
+steps:
+- name: {{$action}}ing measurements
+  measurements:
+  - Identifier: APIResponsivenessPrometheus
+    Method: APIResponsivenessPrometheus
+    Params:
+      action: {{$action}}
+{{if not $USE_SIMPLE_LATENCY_QUERY}}
+      enableViolations: {{$ENABLE_VIOLATIONS_FOR_API_CALL_PROMETHEUS}}
+      allowedSlowCalls: {{$ALLOWED_SLOW_API_CALLS}}
+      customThresholds: {{YamlQuote $CUSTOM_API_CALL_THRESHOLDS 4}}
+{{end}}
+  - Identifier: APIResponsivenessPrometheusSimple
+    Method: APIResponsivenessPrometheus
+    Params:
+      action: {{$action}}
+      enableViolations: {{$ENABLE_VIOLATIONS_FOR_API_CALL_PROMETHEUS_SIMPLE}}
+      useSimpleLatencyQuery: true
+      summaryName: APIResponsivenessPrometheus_simple
+      allowedSlowCalls: {{$ALLOWED_SLOW_API_CALLS}}
+      customThresholds: {{YamlQuote $CUSTOM_API_CALL_THRESHOLDS 4}}
+  - Identifier: TestMetrics
+    Method: TestMetrics
+    Params:
+      action: {{$action}}
+      systemPodMetricsEnabled: {{$ENABLE_SYSTEM_POD_METRICS}}
+      restartCountThresholdOverrides: {{YamlQuote $RESTART_COUNT_THRESHOLD_OVERRIDES 4}}
+      enableRestartCountCheck: {{$ENABLE_RESTART_COUNT_CHECK}}
+  - Identifier: InClusterNetworkLatency
+    Method: InClusterNetworkLatency
+    Params:
+      action: {{$action}}
+      checkProbesReadyTimeout: {{$PROBE_MEASUREMENTS_CHECK_PROBES_READY_TIMEOUT}}
+      replicasPerProbe: {{AddInt 2 (DivideInt .Nodes 100)}}

--- a/clusterloader2/testing/huge-service/modules/service.yaml
+++ b/clusterloader2/testing/huge-service/modules/service.yaml
@@ -1,0 +1,83 @@
+{{$endpoints := .endpoints}}
+{{$isHeadless := .isHeadless}}
+{{$serviceName := .serviceName}}
+
+steps:
+- name: Create {{$serviceName}}
+  phases:
+  - namespaceRange:
+      min: 1
+      max: 1
+    replicasPerNamespace: 1
+    tuningSet: Sequence
+    objectBundle:
+    - basename: {{$serviceName}}
+      objectTemplatePath: service.yaml
+      templateFillMap:
+        HeadlessService: {{$isHeadless}}
+- name: Creating {{$serviceName}} measurements
+  measurements:
+  - Identifier: WaitForHugeServiceDeployments
+    Method: WaitForControlledPodsRunning
+    Params:
+      action: start
+      apiVersion: apps/v1
+      kind: Deployment
+      labelSelector: group = {{$serviceName}}
+      operationTimeout: 20m
+- name: Creating {{$serviceName}} pods
+  phases:
+  - namespaceRange:
+      min: 1
+      max: 1
+    replicasPerNamespace: 1
+    tuningSet: Sequence
+    objectBundle:
+    - basename: huge-service-deployment
+      objectTemplatePath: simple-deployment.yaml
+      templateFillMap:
+        Replicas: {{$endpoints}}
+        Group: huge-service
+        CpuRequest: 1m
+        MemoryRequest: 10M
+        SvcName: {{$serviceName}}
+- name: Waiting for {{$serviceName}} pods to be created
+  measurements:
+  - Identifier: WaitForHugeServiceDeployments
+    Method: WaitForControlledPodsRunning
+    Params:
+      action: gather
+- name: Deleting {{$serviceName}} pods
+  phases:
+  - namespaceRange:
+      min: 1
+      max: 1
+    replicasPerNamespace: 1
+    tuningSet: Sequence
+    objectBundle:
+    - basename: huge-service-deployment
+      objectTemplatePath: simple-deployment.yaml
+      templateFillMap:
+        Replicas: {{$endpoints}}
+        Group: {{$serviceName}}
+        CpuRequest: 1m
+        MemoryRequest: 10M
+        SvcName: {{$serviceName}}
+- name: Waiting for {{$serviceName}} pods to be deleted
+  measurements:
+  - Identifier: WaitForHugeServiceDeployments
+    Method: WaitForControlledPodsRunning
+    Params:
+      action: gather
+- name: Delete {{$serviceName}}
+  phases:
+  - namespaceRange:
+      min: 1
+      max: 1
+    replicasPerNamespace: 0
+    tuningSet: Sequence
+    objectBundle:
+    - basename: {{$serviceName}}
+      objectTemplatePath: service.yaml
+      templateFillMap:
+        HeadlessService: {{$isHeadless}}

--- a/clusterloader2/testing/huge-service/service.yaml
+++ b/clusterloader2/testing/huge-service/service.yaml
@@ -1,0 +1,1 @@
+../load/service.yaml

--- a/clusterloader2/testing/huge-service/simple-deployment.yaml
+++ b/clusterloader2/testing/huge-service/simple-deployment.yaml
@@ -1,0 +1,1 @@
+../load/simple-deployment.yaml


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
We want to decouple scheduler throughput from huge service test. In order to do so, a separate test needs to be implemented. Since we do not test for huge services everywhere, it is done in a separate file.

The default number of endpoints for the new huge service test is 1000 instead of the number of nodes.

There are two modules extracted from the existing `testing/load` configuration:
- `testing/load/modules/measurements.yaml` -> `testing/huge-service/modules/measurements.yaml`
- `testing/load/modules/huge-services.yaml` + `testing/load/modules/scheduler-throughput.yaml` -> `testing/huge-service/modules/service.yaml`

The config has been tested and passes our CI.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
N/A

**Special notes for your reviewer**:
/assign @mborsz
/cc @marseel 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
A new specialized config has been introduced for the purpose of testing a service with high amount of endpoints. 
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```