### PR TITLE
Add generic Prometheus query measurement

### DIFF
--- a/clusterloader2/examples/generic_query_example.yaml
+++ b/clusterloader2/examples/generic_query_example.yaml
@@ -1,0 +1,34 @@
+# Simple example of the use of generic query measurement.
+#
+# Notes on parameters:
+#       metricName will be logged in place of "GenericPrometheusQuery"
+#       rawQuery must be parametrized by duration
+
+{{$duration := "240s"}}
+{{$namespaces := 1}}
+
+name: generic-query
+namespace:
+  number: {{$namespaces}}
+steps:
+- name: Start measurements
+  measurements:
+  - Identifier: gq
+    Method: GenericPrometheusQuery
+    Params:
+      action: start
+      metricName: API request latency
+      metricVersion: v1
+      rawQuery:  quantile_over_time(0.99, apiserver:apiserver_request_latency_1m:histogram_quantile{verb!="WATCH", subresource!~"log|exec|portforward|attach|proxy"}[%v])
+- name: Sleep
+  measurements:
+  - Identifier: sleep
+    Method: Sleep
+    Params:
+      duration: {{$duration}}
+- name: Gather measurements
+  measurements:
+  - Identifier: gq
+    Method: GenericPrometheusQuery
+    Params:
+      action: gather

--- a/clusterloader2/pkg/measurement/common/generic_query_measurement.go
+++ b/clusterloader2/pkg/measurement/common/generic_query_measurement.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"fmt"
+	"time"
+
+	"k8s.io/klog"
+	"k8s.io/perf-tests/clusterloader2/pkg/measurement"
+	measurementutil "k8s.io/perf-tests/clusterloader2/pkg/measurement/util"
+	"k8s.io/perf-tests/clusterloader2/pkg/util"
+)
+
+const (
+	name = "GenericPrometheusQuery"
+)
+
+func init() {
+	create := func() measurement.Measurement { return CreatePrometheusMeasurement(&genericQueryGatherer{}) }
+	if err := measurement.Register(name, create); err != nil {
+		klog.Fatalf("Cannot register %s: %v", name, err)
+	}
+}
+
+type genericQueryGatherer struct {
+	metricName    string
+	metricVersion string
+	rawQuery      string
+}
+
+func (g *genericQueryGatherer) Configure(config *measurement.Config) error {
+	query, err := util.GetString(config.Params, "rawQuery")
+	if err != nil {
+		return err
+	}
+	metricName, err := util.GetString(config.Params, "metricName")
+	if err != nil {
+		return err
+	}
+	metricVersion, err := util.GetString(config.Params, "metricVersion")
+	if err != nil {
+		return err
+	}
+
+	g.rawQuery = query
+	g.metricName = metricName
+	g.metricVersion = metricVersion
+	return nil
+}
+
+func (g *genericQueryGatherer) IsEnabled(config *measurement.Config) bool {
+	return true
+}
+
+func (g *genericQueryGatherer) Gather(executor QueryExecutor, startTime, endTime time.Time, config *measurement.Config) ([]measurement.Summary, error) {
+	metric, err := g.query(executor, startTime, endTime)
+	if err != nil {
+		return nil, err
+	}
+
+	klog.V(2).Infof("%s: got %v", g.metricName, metric)
+	summary, err := g.createSummary(metric)
+	return []measurement.Summary{summary}, err
+}
+
+func (g *genericQueryGatherer) String() string {
+	return name
+}
+
+func (g *genericQueryGatherer) query(executor QueryExecutor, startTime, endTime time.Time) (*measurementutil.LatencyMetric, error) {
+	duration := endTime.Sub(startTime)
+	boundedQuery := fmt.Sprintf(g.rawQuery, measurementutil.ToPrometheusTime(duration))
+	klog.V(2).Infof("bounded query: %s, duration: %v", boundedQuery, duration)
+	samples, err := executor.Query(boundedQuery, endTime)
+	if err != nil {
+		return nil, err
+	}
+	// For now, only latency is supported.
+	return measurementutil.NewLatencyMetricPrometheus(samples)
+}
+
+func (g *genericQueryGatherer) createSummary(latency *measurementutil.LatencyMetric) (measurement.Summary, error) {
+	content, err := util.PrettyPrintJSON(&measurementutil.PerfData{
+		Version:   g.metricVersion,
+		DataItems: []measurementutil.DataItem{latency.ToPerfData(name)},
+	})
+	if err != nil {
+		return nil, err
+	}
+	return measurement.CreateSummary(g.metricName, "json", content), nil
+}

--- a/clusterloader2/pkg/measurement/common/metrics_server_prometheus.go
+++ b/clusterloader2/pkg/measurement/common/metrics_server_prometheus.go
@@ -59,6 +59,10 @@ func (g *metricsServerGatherer) Gather(executor QueryExecutor, startTime, endTim
 	return summaries, nil
 }
 
+func (g *metricsServerGatherer) Configure(config *measurement.Config) error {
+	return nil
+}
+
 func (g *metricsServerGatherer) IsEnabled(config *measurement.Config) bool {
 	return config.CloudProvider.Features().SupportMetricsServerMetrics
 }

--- a/clusterloader2/pkg/measurement/common/nodelocaldns_latency_prometheus.go
+++ b/clusterloader2/pkg/measurement/common/nodelocaldns_latency_prometheus.go
@@ -65,6 +65,9 @@ func (n *nodelocaldnsLatencyGatherer) String() string {
 	return nodelocaldnsLatencyPrometheusMeasurementName
 }
 
+func (n *nodelocaldnsLatencyGatherer) Configure(config *measurement.Config) error {
+	return nil
+}
 func (n *nodelocaldnsLatencyGatherer) IsEnabled(config *measurement.Config) bool {
 	return true
 }

--- a/clusterloader2/pkg/measurement/common/prometheus_measurement.go
+++ b/clusterloader2/pkg/measurement/common/prometheus_measurement.go
@@ -43,6 +43,7 @@ type QueryExecutor interface {
 // It's assumed Prometheus is up, running and instructed to scrape required metrics in the test cluster
 // (please see clusterloader2/pkg/prometheus/manifests).
 type Gatherer interface {
+	Configure(config *measurement.Config) error
 	Gather(executor QueryExecutor, startTime, endTime time.Time, config *measurement.Config) ([]measurement.Summary, error)
 	IsEnabled(config *measurement.Config) bool
 	String() string
@@ -72,6 +73,9 @@ func (m *prometheusMeasurement) Execute(config *measurement.Config) ([]measureme
 
 	switch action {
 	case "start":
+		if err := m.gatherer.Configure(config); err != nil {
+			return nil, err
+		}
 		klog.V(2).Infof("%s has started", config.Identifier)
 		m.startTime = time.Now()
 		return nil, nil

--- a/clusterloader2/pkg/measurement/common/scheduling_throughput_prometheus.go
+++ b/clusterloader2/pkg/measurement/common/scheduling_throughput_prometheus.go
@@ -92,6 +92,10 @@ func (a *schedulingThroughputGatherer) String() string {
 	return schedulingThroughputPrometheusMeasurementName
 }
 
+func (a *schedulingThroughputGatherer) Configure(config *measurement.Config) error {
+	return nil
+}
+
 func (a *schedulingThroughputGatherer) IsEnabled(config *measurement.Config) bool {
 	return true
 }

--- a/clusterloader2/pkg/measurement/common/slos/api_responsiveness_prometheus.go
+++ b/clusterloader2/pkg/measurement/common/slos/api_responsiveness_prometheus.go
@@ -154,6 +154,10 @@ func (a *apiResponsivenessGatherer) String() string {
 	return apiResponsivenessPrometheusMeasurementName
 }
 
+func (a *apiResponsivenessGatherer) Configure(config *measurement.Config) error {
+	return nil
+}
+
 func (a *apiResponsivenessGatherer) IsEnabled(config *measurement.Config) bool {
 	return true
 }

--- a/clusterloader2/pkg/measurement/common/slos/network_programming.go
+++ b/clusterloader2/pkg/measurement/common/slos/network_programming.go
@@ -48,6 +48,10 @@ func init() {
 
 type netProgGatherer struct{}
 
+func (n *netProgGatherer) Configure(config *measurement.Config) error {
+	return nil
+}
+
 func (n *netProgGatherer) IsEnabled(config *measurement.Config) bool {
 	// Disable NetworkProgrammingLatency measurement if scraping kube-proxy is disabled.
 	if !config.ClusterLoaderConfig.PrometheusConfig.ScrapeKubeProxy {

--- a/clusterloader2/pkg/measurement/common/slos/windows_node_resource_usage.go
+++ b/clusterloader2/pkg/measurement/common/slos/windows_node_resource_usage.go
@@ -44,6 +44,10 @@ const (
 type convertFunc func([]*model.Sample) *measurementutil.PerfData
 type windowsResourceUsageGatherer struct{}
 
+func (w *windowsResourceUsageGatherer) Configure(config *measurement.Config) error {
+	return nil
+}
+
 func (w *windowsResourceUsageGatherer) IsEnabled(config *measurement.Config) bool {
 	return true
 }


### PR DESCRIPTION
Basic version of a measurement allowing user to pass a custom Prometheus query via config, with the following limitations:
- only latency metrics are supported,
- the query must be parametrized by test duration,
- no checks/assertions available at this point.

Unit tests and documentation update pending.