### PR TITLE
Use metric name in summary

### DIFF
--- a/clusterloader2/pkg/measurement/common/generic_query_measurement.go
+++ b/clusterloader2/pkg/measurement/common/generic_query_measurement.go
@@ -97,7 +97,7 @@ func (g *genericQueryGatherer) query(executor QueryExecutor, startTime, endTime 
 func (g *genericQueryGatherer) createSummary(latency *measurementutil.LatencyMetric) (measurement.Summary, error) {
 	content, err := util.PrettyPrintJSON(&measurementutil.PerfData{
 		Version:   g.metricVersion,
-		DataItems: []measurementutil.DataItem{latency.ToPerfData(name)},
+		DataItems: []measurementutil.DataItem{latency.ToPerfData(g.metricName)},
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Replace measurement name with metric name in summary.