### PR TITLE
Added checkIfPodsAreUpdated param to CL2 scheduler-throughput and pod…

### DIFF
--- a/clusterloader2/testing/load/modules/pod-startup-latency.yaml
+++ b/clusterloader2/testing/load/modules/pod-startup-latency.yaml
@@ -18,6 +18,7 @@
 ## Variables
 {{$latencyReplicas := DivideInt $LATENCY_POD_COUNT $namespaces}}
 {{$podStartupLatencyThreshold := DefaultParam .CL2_POD_STARTUP_LATENCY_THRESHOLD "5s"}}
+{{$CHECK_IF_PODS_ARE_UPDATED := DefaultParam .CL2_CHECK_IF_PODS_ARE_UPDATED true}}
 
 steps:
 - name: Starting latency pod measurements
@@ -32,6 +33,7 @@ steps:
       Method: WaitForControlledPodsRunning
       Params:
         action: start
+        checkIfPodsAreUpdated: {{$CHECK_IF_PODS_ARE_UPDATED}}
         apiVersion: apps/v1
         kind: Deployment
         labelSelector: group = latency

--- a/clusterloader2/testing/load/modules/scheduler-throughput.yaml
+++ b/clusterloader2/testing/load/modules/scheduler-throughput.yaml
@@ -14,6 +14,7 @@
 
 ## CL2 params
 {{$SCHEDULER_THROUGHPUT_THRESHOLD := DefaultParam .CL2_SCHEDULER_THROUGHPUT_THRESHOLD 100}}
+{{$CHECK_IF_PODS_ARE_UPDATED := DefaultParam .CL2_CHECK_IF_PODS_ARE_UPDATED true}}
 
 steps:
 {{if $is_creating}}
@@ -29,6 +30,7 @@ steps:
     Method: WaitForControlledPodsRunning
     Params:
       action: start
+      checkIfPodsAreUpdated: {{$CHECK_IF_PODS_ARE_UPDATED}}
       apiVersion: apps/v1
       kind: Deployment
       labelSelector: group = scheduler-throughput


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Adds checkIfPodsAreUpdated param to WaitForControlledPodsRunning step in cl2/load scheduler-throughput and pod-startup-latency modules. This param just adds more flexibility when running load tests, default behaviour remains the same.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs

```