### PR TITLE
Add sleep in huge-service test

### DIFF
--- a/clusterloader2/testing/huge-service/modules/service.yaml
+++ b/clusterloader2/testing/huge-service/modules/service.yaml
@@ -47,6 +47,12 @@ steps:
     Method: WaitForControlledPodsRunning
     Params:
       action: gather
+- name: Wait 5min
+  measurements:
+  - Identifier: Wait
+    Method: Sleep
+    Params:
+      duration: 5m
 - name: Deleting {{$serviceName}} pods
   phases:
   - namespaceRange:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
As the number of pods is adjusted, some API calls tend to be a bit slower than usual. We want to balance the latency measurement by allowing the cluster to stay at desired state for a while (5m).

If we do not include this change than during any test running huge-service config the API call measurements will collect a very small sample of data leading to easy threshold breaches.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
The same solution has been used here: https://github.com/kubernetes/perf-tests/blob/c812b12b8e0cd31330ab9138d78e4c8cc99bfc9e/clusterloader2/testing/access-tokens/config.yaml#L135

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
N/A
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
N/A
```