### PR TITLE
Add support for integers in Exec measurement

### DIFF
--- a/clusterloader2/pkg/measurement/common/exec.go
+++ b/clusterloader2/pkg/measurement/common/exec.go
@@ -57,7 +57,7 @@ func (e *execMeasurement) Execute(config *measurement.Config) ([]measurement.Sum
 	}
 	command, err := util.GetStringArray(config.Params, "command")
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error parsing command: %v", err)
 	}
 	if len(command) == 0 {
 		return nil, fmt.Errorf("command is a required argument. Got empty slice instead")

--- a/clusterloader2/pkg/util/util.go
+++ b/clusterloader2/pkg/util/util.go
@@ -71,7 +71,7 @@ func GetMap(dict map[string]interface{}, key string) (map[string]interface{}, er
 	return getMap(dict, key)
 }
 
-// GetStringArray tries to return value from map of type map. If value doesn't exist, error is returned.
+// GetStringArray tries to return value from map of type map with casting to a string using fmt.Sprintf. If value doesn't exist, error is returned.
 func GetStringArray(dict map[string]interface{}, key string) ([]string, error) {
 	return getStringArray(dict, key)
 }
@@ -142,15 +142,12 @@ func getStringArray(dict map[string]interface{}, key string) ([]string, error) {
 
 	sliceValue, ok := value.([]interface{})
 	if !ok {
-		return nil, fmt.Errorf("type assertion error: %v (%T) is not a []string", value, value)
+		return nil, fmt.Errorf("type assertion error: %v (%T) is not a slice", value, value)
 	}
 
 	var res []string
 	for _, val := range sliceValue {
-		valStr, ok := val.(string)
-		if !ok {
-			return nil, fmt.Errorf("type assertion error: %v is not a string", val)
-		}
+		valStr := fmt.Sprintf("%v", val)
 		res = append(res, valStr)
 	}
 	return res, nil


### PR DESCRIPTION
Using an integer as a value in Exec measurement command throws a type assertion error.

Let's parse values as strings, as expected.

GetStringArray is only used in Exec measurement, so I feel confident with changing behavior of this function.