### PR TITLE
Allow additional slow calls in huge-service test

### DIFF
--- a/clusterloader2/testing/huge-service/modules/measurements.yaml
+++ b/clusterloader2/testing/huge-service/modules/measurements.yaml
@@ -2,6 +2,7 @@
 {{$action := .action}}
 
 {{$ALLOWED_SLOW_API_CALLS := DefaultParam .CL2_ALLOWED_SLOW_API_CALLS 0}}
+{{$HUGE_SERVICE_ALLOWED_SLOW_API_CALLS := DefaultParam .CL2_HUGE_SERVICE_ALLOWED_SLOW_API_CALLS 2}}
 {{$PROBE_MEASUREMENTS_CHECK_PROBES_READY_TIMEOUT := DefaultParam .CL2_PROBE_MEASUREMENTS_CHECK_PROBES_READY_TIMEOUT "15m"}}
 {{$ENABLE_VIOLATIONS_FOR_API_CALL_PROMETHEUS := DefaultParam .CL2_ENABLE_VIOLATIONS_FOR_API_CALL_PROMETHEUS false}}
 {{$ENABLE_VIOLATIONS_FOR_API_CALL_PROMETHEUS_SIMPLE := DefaultParam .CL2_ENABLE_VIOLATIONS_FOR_API_CALL_PROMETHEUS_SIMPLE true}}
@@ -12,6 +13,8 @@
 {{$RESTART_COUNT_THRESHOLD_OVERRIDES := DefaultParam .RESTART_COUNT_THRESHOLD_OVERRIDES ""}}
 {{$USE_SIMPLE_LATENCY_QUERY := DefaultParam .USE_SIMPLE_LATENCY_QUERY false}}
 
+{{$allowedSlowCalls := AddInt $ALLOWED_SLOW_API_CALLS $HUGE_SERVICE_ALLOWED_SLOW_API_CALLS}}
+
 steps:
 - name: {{$action}}ing measurements
   measurements:
@@ -21,7 +24,7 @@ steps:
       action: {{$action}}
 {{if not $USE_SIMPLE_LATENCY_QUERY}}
       enableViolations: {{$ENABLE_VIOLATIONS_FOR_API_CALL_PROMETHEUS}}
-      allowedSlowCalls: {{$ALLOWED_SLOW_API_CALLS}}
+      allowedSlowCalls: {{$allowedSlowCalls}}
       customThresholds: {{YamlQuote $CUSTOM_API_CALL_THRESHOLDS 4}}
 {{end}}
   - Identifier: APIResponsivenessPrometheusSimple
@@ -31,7 +34,7 @@ steps:
       enableViolations: {{$ENABLE_VIOLATIONS_FOR_API_CALL_PROMETHEUS_SIMPLE}}
       useSimpleLatencyQuery: true
       summaryName: APIResponsivenessPrometheus_simple
-      allowedSlowCalls: {{$ALLOWED_SLOW_API_CALLS}}
+      allowedSlowCalls: {{$allowedSlowCalls}}
       customThresholds: {{YamlQuote $CUSTOM_API_CALL_THRESHOLDS 4}}
   - Identifier: TestMetrics
     Method: TestMetrics


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/kind regression
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
After enabling the new huge-service test configuration, there were multiple failures related to slow pod lists per namespace. Investigation showed that there are on average 1-2 slow requests each time the cluster is drastically scaled up or down.

In the load test this was not visible as the test for a larger number of nodes lasts long enough for the p99 to get below 5s threshold. The huge-service test lasts at most a few minutes which is not enough for the same thing to happen.

Therefore a new parameter is introduced for the huge-service test that allows to ignore those few regularly appearing slow calls.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
This change is currently being tested.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
N/A
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
N/A
```