### PR TITLE
Add multiple queries and checks to generic query measurement

### DIFF
--- a/clusterloader2/examples/generic_query_example.yaml
+++ b/clusterloader2/examples/generic_query_example.yaml
@@ -2,9 +2,10 @@
 #
 # Notes on parameters:
 #       metricName will be logged in place of "GenericPrometheusQuery"
-#       rawQuery must be parametrized by duration
+#       query must be parametrized by duration and return exactly 1 sample
+#       threshold is optional
 
-{{$duration := "240s"}}
+{{$duration := "60s"}}
 {{$namespaces := 1}}
 
 name: generic-query
@@ -19,7 +20,19 @@ steps:
       action: start
       metricName: API request latency
       metricVersion: v1
-      rawQuery:  quantile_over_time(0.99, apiserver:apiserver_request_latency_1m:histogram_quantile{verb!="WATCH", subresource!~"log|exec|portforward|attach|proxy"}[%v])
+      unit: ms
+      queries:
+        - name: Perc99
+          query: histogram_quantile(0.99, sum(rate(apiserver_request_duration_seconds_bucket[%v])) by (le))
+          threshold: 60
+        - name: Perc90
+          query: histogram_quantile(0.9, sum(rate(apiserver_request_duration_seconds_bucket[%v])) by (le))
+        - name: Perc50
+          query: histogram_quantile(0.5, sum(rate(apiserver_request_duration_seconds_bucket[%v])) by (le))
+          threshold: 5
+        - name: non-existent
+          query: histogram_quantile(0.5, sum(rate(fake_apiserver_request_duration_seconds_bucket[%v])) by (le))
+          threshold: 42
 - name: Sleep
   measurements:
   - Identifier: sleep
@@ -32,3 +45,4 @@ steps:
     Method: GenericPrometheusQuery
     Params:
       action: gather
+      enableViolations: true

--- a/clusterloader2/pkg/measurement/common/generic_query_measurement_test.go
+++ b/clusterloader2/pkg/measurement/common/generic_query_measurement_test.go
@@ -1,0 +1,152 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/assert"
+)
+
+type fakeQueryExecutor struct {
+	samples map[string][]float64
+}
+
+func (f fakeQueryExecutor) Query(query string, _ time.Time) ([]*model.Sample, error) {
+	samples, found := f.samples[query]
+	if !found {
+		return nil, nil
+	}
+	res := []*model.Sample{}
+	for _, s := range samples {
+		res = append(res, &model.Sample{Value: model.SampleValue(s)})
+	}
+	return res, nil
+}
+
+func TestGather(t *testing.T) {
+	testCases := []struct {
+		desc          string
+		name          string
+		queries       []genericQuery
+		samples       map[string][]float64
+		expectedData  map[string]float64
+		notWantedData []string
+		expectedErr   string
+	}{
+		{
+			desc: "happy path",
+			name: "happy-path",
+			queries: []genericQuery{
+				{
+					name:         "no-samples",
+					query:        "no-samples-query[%v]",
+					hasThreshold: true,
+					threshold:    42,
+				},
+				{
+					name:         "below-threshold",
+					query:        "below-threshold-query[%v]",
+					hasThreshold: true,
+					threshold:    30,
+				},
+				{
+					name:  "no-threshold",
+					query: "no-threshold-query[%v]",
+				},
+			},
+			samples: map[string][]float64{
+				"below-threshold-query[1m]": {7},
+				"no-threshold-query[1m]":    {120},
+			},
+			expectedData: map[string]float64{
+				"below-threshold": 7.0,
+				"no-threshold":    120.0,
+			},
+			notWantedData: []string{
+				"no-samples",
+			},
+		},
+		{
+			desc: "too many samples",
+			name: "many-samples",
+			queries: []genericQuery{
+				{
+					name:  "many-samples",
+					query: "many-samples-query[%v]",
+				},
+			},
+			samples: map[string][]float64{
+				"many-samples-query[1m]": {1, 2, 3, 4, 5},
+			},
+			expectedErr: "too many samples",
+		},
+		{
+			desc: "sample above threshold",
+			name: "above-threshold",
+			queries: []genericQuery{
+				{
+					name:         "above-threshold",
+					query:        "above-threshold-query[%v]",
+					hasThreshold: true,
+					threshold:    60,
+				},
+			},
+			samples: map[string][]float64{
+				"above-threshold-query[1m]": {113},
+			},
+			expectedErr: "sample above threshold",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			gatherer := &genericQueryGatherer{
+				metricName: tc.name,
+				queries:    tc.queries,
+			}
+			startTime := time.Now()
+			endTime := startTime.Add(1 * time.Minute)
+			executor := fakeQueryExecutor{tc.samples}
+
+			summaries, err := gatherer.Gather(executor, startTime, endTime, nil)
+			if err != nil {
+				if tc.expectedErr != "" {
+					assert.True(t, strings.Contains(err.Error(), tc.expectedErr), "unexpected err: got %v, want: %v", err, tc.expectedErr)
+				} else {
+					t.Fatalf("got: %v, want no error", err)
+				}
+			}
+
+			if len(summaries) != 1 {
+				t.Fatalf("wrong number of summaries, got: %v, want: 1", len(summaries))
+			}
+			content := summaries[0].SummaryContent()
+			for k, v := range tc.expectedData {
+				entry := fmt.Sprintf("\"%v\": %v", k, v)
+				assert.True(t, strings.Contains(content, entry), "summary missing data: got: %v, want: %v", content, entry)
+			}
+			for _, s := range tc.notWantedData {
+				assert.False(t, strings.Contains(content, s), "summary contains extra data: got: %v, want: no %v", content, s)
+			}
+		})
+	}
+}

--- a/clusterloader2/pkg/util/util.go
+++ b/clusterloader2/pkg/util/util.go
@@ -71,7 +71,12 @@ func GetMap(dict map[string]interface{}, key string) (map[string]interface{}, er
 	return getMap(dict, key)
 }
 
-// GetStringArray tries to return value from map of type map with casting to a string using fmt.Sprintf. If value doesn't exist, error is returned.
+// GetMapArray tries to return value from map of type []map. If value doesn't exist, error is returned.
+func GetMapArray(dict map[string]interface{}, key string) ([]map[string]interface{}, error) {
+	return getMapArray(dict, key)
+}
+
+// GetStringArray tries to return value from map cast to a []string, using fmt.Sprintf for elements. If value doesn't exist, error is returned.
 func GetStringArray(dict map[string]interface{}, key string) ([]string, error) {
 	return getStringArray(dict, key)
 }
@@ -129,9 +134,31 @@ func getMap(dict map[string]interface{}, key string) (map[string]interface{}, er
 
 	mapValue, ok := value.(map[string]interface{})
 	if !ok {
-		return nil, fmt.Errorf("type assertion error: %v is not a string", value)
+		return nil, fmt.Errorf("type assertion error: %v is not a map", value)
 	}
 	return mapValue, nil
+}
+
+func getMapArray(dict map[string]interface{}, key string) ([]map[string]interface{}, error) {
+	value, exists := dict[key]
+	if !exists || value == nil {
+		return nil, &ErrKeyNotFound{key}
+	}
+
+	sliceValue, ok := value.([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("type assertion error: %v (%T) is not a []map", value, value)
+	}
+
+	var res []map[string]interface{}
+	for _, val := range sliceValue {
+		mapValue, ok := val.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("type assertion error: %v is not a map", val)
+		}
+		res = append(res, mapValue)
+	}
+	return res, nil
 }
 
 func getStringArray(dict map[string]interface{}, key string) ([]string, error) {


### PR DESCRIPTION
Follow-up to #1957. Changes:
- metric is no longer treated as latency,
- multiple queries can be defined for the same measurement instance,
- user can set threshold - all samples are expected to be lesser or equal to it.

@jprzychodzen - can you PTAL and see if the basic metric summary (avg, min, max) is what you meant? I'm not entirely sure what is the use case here (it obviously doesn't do anything for queries with top-level histogram_quantile()). If we're mostly supporting queries returning a single sample, perhaps we could instead return DataItem with names of queries as keys and results as values?