### PR TITLE
Revert "Install bind-tools in dnsperfgo image."

### DIFF
--- a/dns/dnsperfgo/Dockerfile
+++ b/dns/dnsperfgo/Dockerfile
@@ -1,7 +1,6 @@
 # runtime image
 FROM alpine:3.10
-# install bind-tools to prevent nslookup from sending PTR queries for each response IP
-RUN apk add --no-cache ca-certificates bash tcpdump git bind-tools
+RUN apk add --no-cache ca-certificates bash tcpdump git
 # This is to make sure dnstest compiled on debian can run in alpine/musl
 RUN mkdir /lib64 && ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2
 COPY dnsperfgo /dnsperfgo


### PR DESCRIPTION
Reverts kubernetes/perf-tests#1968

Installing bind-tools somehow prevents nslookup from doing in-parallel A and AAAA lookups. We do want to test this scenario since it can trigger iptables race conditions - https://www.weave.works/blog/racy-conntrack-and-dns-lookup-timeouts.


