### PR TITLE
Add image for sleep command

### DIFF
--- a/util-images/sleep/Dockerfile
+++ b/util-images/sleep/Dockerfile
@@ -1,0 +1,12 @@
+FROM golang:1.17 AS build-env
+
+ARG gopkg=k8s.io/perf-tests/util-images/sleep
+
+ADD [".", "/go/src/$gopkg"]
+
+WORKDIR /go/src/$gopkg
+RUN CGO_ENABLED=0 go build -o /go/bin/sleep main.go
+
+FROM gcr.io/distroless/static
+COPY --from=build-env /go/bin/sleep /
+ENTRYPOINT ["/sleep"]

--- a/util-images/sleep/Makefile
+++ b/util-images/sleep/Makefile
@@ -1,0 +1,17 @@
+PROJECT = k8s-staging-perf-tests
+IMG = gcr.io/$(PROJECT)/sleep
+TAG = v0.0.1
+
+all: push
+
+.PHONY: build
+build:
+	docker build --pull -t $(IMG):$(TAG) .
+	docker tag $(IMG):$(TAG) $(IMG):latest
+	@echo Built $(IMG):$(TAG) and tagged with latest
+
+.PHONY: push
+push: build
+	docker push $(IMG):$(TAG)
+	docker push $(IMG):latest
+	@echo Pushed $(IMG) with :latest and :$(TAG) tags

--- a/util-images/sleep/README.md
+++ b/util-images/sleep/README.md
@@ -1,0 +1,10 @@
+# Sleep
+
+Simple program that sleeps for a provided duration.
+
+## Building and Releasing
+
+1. Increment the `TAG` in the Makefile.
+2. `make build`
+3. Test changes with `docker run gcr.io/k8s-staging-perf-tests/sleep:latest -- ...`
+4. Release with `make push`

--- a/util-images/sleep/main.go
+++ b/util-images/sleep/main.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"time"
+)
+
+func init() {
+	flag.Usage = func() {
+		prog := os.Args[0]
+		fmt.Printf("Usage: %s [DURATION]\n", prog)
+		fmt.Println("DURATION is a sequence of decimal numbers, each with optional fraction and a unit suffix.")
+		fmt.Println("Valid time units are ns, us (or µs), ms, s, m, h.")
+	}
+}
+
+func main() {
+	flag.Parse()
+	input := flag.Arg(0)
+	var duration time.Duration
+	if input != "" {
+		var err error
+		duration, err = time.ParseDuration(input)
+		if err != nil {
+			fmt.Println(err)
+			flag.Usage()
+			os.Exit(1)
+		}
+	}
+	time.Sleep(duration)
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Adds an image with a program that sleeps for a given duration. This will be useful to test Jobs, which run to completion, as opposed to run forever.

**Which issue(s) this PR fixes**:

Part of #799

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```