### PR TITLE
update sleep image to optionally handle SIGTERM

### DIFF
--- a/util-images/sleep/main.go
+++ b/util-images/sleep/main.go
@@ -20,7 +20,13 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"os/signal"
+	"syscall"
 	"time"
+)
+
+var (
+	terminationGracePeriod = flag.Duration("termination-grace-period", 0, "The duration of time to sleep after receiving SIGTERM")
 )
 
 func init() {
@@ -45,5 +51,17 @@ func main() {
 			os.Exit(1)
 		}
 	}
+	stopCh := make(chan os.Signal, 1)
+	signal.Notify(stopCh, syscall.SIGTERM)
+
+	go func() {
+		<-stopCh
+		if *terminationGracePeriod != 0 {
+			time.Sleep(*terminationGracePeriod)
+		}
+
+		os.Exit(0)
+	}()
+
 	time.Sleep(duration)
 }


### PR DESCRIPTION
Signed-off-by: Andrew Sy Kim <andrewsy@google.com>

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

In KEP-1672 we introduced the "terminating" condition for the EndpointSlice API. One of the criteria for graduating this feature to GA is that it has gone through some extensive performance testing to ensure we are not regressing endpointslice performance. This PR adds the option for the sleep image to optionally handle SIGTERM which will be useful for performance testing KEP-1672 later in the v1.24 release cycle.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
update sleep image to optionally handle SIGTERM with a --termination-grace-period flag
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```