### PR TITLE
Add sleep bin to PATH

### DIFF
--- a/util-images/sleep/Dockerfile
+++ b/util-images/sleep/Dockerfile
@@ -8,5 +8,5 @@ WORKDIR /go/src/$gopkg
 RUN CGO_ENABLED=0 go build -o /go/bin/sleep main.go
 
 FROM gcr.io/distroless/static
-COPY --from=build-env /go/bin/sleep /
-ENTRYPOINT ["/sleep"]
+COPY --from=build-env /go/bin/sleep /usr/bin/
+ENTRYPOINT ["sleep"]

--- a/util-images/sleep/Makefile
+++ b/util-images/sleep/Makefile
@@ -1,6 +1,6 @@
 PROJECT = k8s-staging-perf-tests
 IMG = gcr.io/$(PROJECT)/sleep
-TAG = v0.0.2
+TAG = v0.0.3
 
 all: push
 


### PR DESCRIPTION
Signed-off-by: Carlos Eduardo Arango Gutierrez <carangog@redhat.com>

This patch adds the `sleep` bin from sleep image to PATH to prevent unwanted confusion when calling the image with explicit command arguments 

```bash
  Warning  Failed     8s                 kubelet            Error: container create failed: time="2022-02-23T21:08:56Z" level=error msg="container_linux.go:380: starting container process ca
used: exec: \"sleep\": executable file not found in $PATH" 
```

This error is due the bin is under `/` , and this is not in `"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"` 