### PR TITLE
Revert "Use the new dnsperfgo client in dns load tests."

### DIFF
--- a/clusterloader2/testing/load/configmap.yaml
+++ b/clusterloader2/testing/load/configmap.yaml
@@ -8,9 +8,30 @@ immutable: true
 # Every pod that needs its own configmap entry should be unconditionally
 # added below. That allows us to avoid complicating it with ifs.
 data:
-  # all-queries is used by DNS tests. Since dnsperfgo counts NXDOMAINs as errors, this config contains only valid names.
+  # all-queries is used by DNS tests.
   all-queries: |
-      kubernetes.default
-      metrics-server.kube-system
-      kube-dns.kube-system
-      metadata.google.internal
+    kubernetes A
+    kubernetes AAAA
+    kubernetes.cluster.local A
+    kubernetes.cluster.local AAAA
+    kubernetes.svc.cluster.local A
+    kubernetes.svc.cluster.local AAAA
+    kubernetes.default.svc.cluster.local A
+    kubernetes.default.svc.cluster.local AAAA
+    google.com.svc.cluster.local A
+    google.com.svc.cluster.local AAAA
+    google.com.default.svc.cluster.local A
+    google.com.default.svc.cluster.local AAAA
+    google.com.cluster.local A
+    google.com.cluster.local AAAA
+    google.com A
+    google.com AAAA
+    1-2-3-4.default.pod.cluster.local A
+    metrics-server A
+    metrics-server AAAA
+    metrics-server.cluster.local A
+    metrics-server.cluster.local AAAA
+    metrics-server.svc.cluster.local A
+    metrics-server.svc.cluster.local AAAA
+    metrics-server.kube-system.svc.cluster.local A
+    metrics-server.kube-system.svc.cluster.local AAAA

--- a/clusterloader2/testing/load/deployment.yaml
+++ b/clusterloader2/testing/load/deployment.yaml
@@ -24,19 +24,19 @@ spec:
       hostNetwork: {{$HostNetworkMode}}
       containers:
 {{if .EnableDNSTests}}
-      - image: gcr.io/k8s-staging-perf-tests/dnsperfgo:v1.1.0
+      - image: k8s.gcr.io/kube-dns-perf-client-amd64:1.1
       # Fetches the dns server from /etc/resolv.conf and
-      # sends 1 query per second.
-      # With searchpath expansion, this amounts to roughly 12 queries per second.
-      # dnsperfgo has a default client timeout of 5s. It sends queries for 60s,
+      # runs as 5 clients and 2 threads sending 10 queries per second.
+      # dnsperf has a client timeout of 5s. It sends queries for 60s,
       # then sleeps for 10s, to mimic bursts of DNS queries.
         command:
         - sh
         - -c
         - server=$(cat /etc/resolv.conf | grep nameserver | cut -d ' ' -f 2); echo
-          "Using nameserver ${server}";
-          ./dnsperfgo -duration 60s -idle-duration 10s -inputfile /var/configmap/all-queries -qps 1;
+          "Using nameserver ${server}"; while true; do ./dnsperf -s $server -l 60
+          -d /var/configmap/all-queries -c 5 -T 2 -Q 10; sleep 10; done
         name: {{.Name}}-dnsperf
+        app: dns-perf-client
 {{else}}
       - image: k8s.gcr.io/pause:3.1
         name: {{.Name}}


### PR DESCRIPTION
Reverts kubernetes/perf-tests#1962

This will make the tests use the old dns client again.

The plan is to make some changes to the new client and then reactivate the new version for the scale tests.

The change on the new client is in: https://github.com/kubernetes/perf-tests/pull/1982 