### PR TITLE
GenericQueryMeasurement: tiny refactoring of config parsing

### DIFF
--- a/clusterloader2/pkg/util/util.go
+++ b/clusterloader2/pkg/util/util.go
@@ -41,6 +41,18 @@ func IsErrKeyNotFound(err error) bool {
 	return isErrKeyNotFound
 }
 
+// ToStruct converts map[string]interface{} to standard object (e.g. struct).
+func ToStruct(dict map[string]interface{}, out interface{}) error {
+	output := &bytes.Buffer{}
+	if err := json.NewEncoder(output).Encode(dict); err != nil {
+		return fmt.Errorf("error encoding data: %w", err)
+	}
+	if err := json.NewDecoder(output).Decode(out); err != nil {
+		return fmt.Errorf("error decoding data: %w", err)
+	}
+	return nil
+}
+
 // GetString tries to return value from map cast to string type. If value doesn't exist, error is returned.
 func GetString(dict map[string]interface{}, key string) (string, error) {
 	return getString(dict, key)


### PR DESCRIPTION
Small change to GenericQueryMeasurement: instead of doing util.GetString and manually parse the config into struct, let's use some automation do to so!

Also changes tests to actually validate this change.

The goal is to make extensions easier.
This is a pilot of the new approach. We may want to migrate all measurements in to this pattern.

/assign @jprzychodzen 
/cc @aleksandra-malinowska 