### PR TITLE
Bump dnsperfgo to 1.3.0 version

### DIFF
--- a/dns/dnsperfgo/Makefile
+++ b/dns/dnsperfgo/Makefile
@@ -1,6 +1,6 @@
 REGISTRY ?= gcr.io/k8s-staging-perf-tests
 IMAGE_NAME = dnsperfgo
-VERSION ?= v1.2.0
+VERSION ?= v1.3.0
 
 all: push
 


### PR DESCRIPTION
Bump dnsperfgo to 1.3.0 version to include https://github.com/kubernetes/perf-tests/pull/1981

This should be merged after https://github.com/kubernetes/perf-tests/pull/1981