### PR TITLE
Add dns test for k8s hostnames to load test

### DIFF
--- a/clusterloader2/testing/load/config.yaml
+++ b/clusterloader2/testing/load/config.yaml
@@ -221,6 +221,11 @@ steps:
   {{end}}
 {{end}}
 
+- module:
+    path: modules/dns-k8s-hostnames.yaml
+    params:
+      tuningSet: Global100qps
+
 {{if $EXEC_COMMAND}}
 
 {{if $ENABLE_API_AVAILABILITY_MEASUREMENT}}

--- a/clusterloader2/testing/load/dns-client.yaml
+++ b/clusterloader2/testing/load/dns-client.yaml
@@ -1,0 +1,79 @@
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: dnsperfgo
+  namespace: default
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: dnsperfgo
+rules:
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["create", "get", "list", "delete"]
+  - apiGroups: [""]
+    resources: ["endpoints"]
+    verbs: ["get", "list"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: dnsperfgo
+subjects:
+  - kind: ServiceAccount
+    name: dnsperfgo
+    namespace: default
+roleRef:
+  kind: ClusterRole
+  name: dnsperfgo
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dnsperfgo
+spec:
+  replicas: 5
+  selector:
+    matchLabels:
+      name: dnsperfgo
+  template:
+    metadata:
+      labels:
+        name: dnsperfgo
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-perf-tests/dnsperfgo:v1.3.0
+      # Fetches the dns server from /etc/resolv.conf and sends 10 queries per second.
+      # With searchpath expansion, this is 120 queries per second.
+      # External names like google.com are expanded to 12 queries.
+      # FQDN lookups like kubernetes.default.svc.cluster.local are also expanded to 12 queries since they have < 5 dots in the name.
+      # Names like kubernetes.default will get partial search path expansion, since the query will succeed once "svc.cluster.local" path is applied.
+      # -query-cluster-names flag will generate FQDNs, in order to exercise searchpath expansion.
+      # dnsperf has a client timeout of 5s. It sends queries for 60s,
+      # then sleeps for 10s, to mimic bursts of DNS queries.
+        command:
+        - sh
+        - -c
+        - server=$(cat /etc/resolv.conf | grep nameserver | cut -d ' ' -f 2); echo
+          "Using nameserver ${server}";
+          ./dnsperfgo -duration 60s -idle-duration 10s -query-cluster-names -qps 10;
+        name: dnsperfgo
+        resources:
+          requests:
+            cpu: 10m
+            memory: 10M
+      serviceAccountName: dnsperfgo
+      terminationGracePeriodSeconds: 1
+      # Add not-ready/unreachable tolerations for 15 minutes so that node
+      # failure doesn't trigger pod deletion.
+      tolerations:
+      - key: "node.kubernetes.io/not-ready"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 900
+      - key: "node.kubernetes.io/unreachable"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 900

--- a/clusterloader2/testing/load/modules/dns-k8s-hostnames.yaml
+++ b/clusterloader2/testing/load/modules/dns-k8s-hostnames.yaml
@@ -1,0 +1,41 @@
+# This module creates deployments of dns clients that run queries for all of the
+# reachable k8s hostnames (services and endpoints), and generate metrics.
+# The default test duration is 5 minutes.
+
+{{$tuningSet := .tuningSet}}
+
+# CL2 params
+{{$ENABLE_DNSTESTS := DefaultParam .CL2_ENABLE_DNSTESTS false}}
+{{$DNS_K8S_HOSTNAMES_TEST_DURATION := DefaultParam .CL2_DNS_K8S_HOSTNAMES_TEST_DURATION "5m"}}
+
+{{if .ENABLE_DNSTESTS}}
+steps:
+- name: Create dns-clients
+  phases:
+  - namespaceRange:
+      min: 1
+      max: 1
+    replicasPerNamespace: 1
+    tuningSet: {{$tuningSet}}
+    objectBundle:
+    - basename: dns-clients
+      objectTemplatePath: dns-client.yaml
+
+- name: Wait for test to complete
+  measurements:
+  - Identifier: sleep
+    Method: Sleep
+    Params:
+      duration: {{$DNS_K8S_HOSTNAMES_TEST_DURATION}}
+
+- name: Delete dns-clients
+  phases:
+  - namespaceRange:
+      min: 1
+      max: 1
+    replicasPerNamespace: 0
+    tuningSet: {{$tuningSet}}
+    objectBundle:
+    - basename: dns-clients
+      objectTemplatePath: dns-client.yaml
+{{end}}


### PR DESCRIPTION
Add dns test for k8s hostnames to load test.

This should be merged after https://github.com/kubernetes/perf-tests/pull/1981 and https://github.com/kubernetes/perf-tests/pull/2008, and when the image for dnsperfgo 1.3.0 is available.

/kind feature
/assign @marseel