### PR TITLE
provides mechanism to gather custom scheduler metrics 

### DIFF
--- a/clusterloader2/pkg/measurement/common/slos/pod_startup_latency.go
+++ b/clusterloader2/pkg/measurement/common/slos/pod_startup_latency.go
@@ -39,6 +39,7 @@ import (
 
 const (
 	defaultPodStartupLatencyThreshold = 5 * time.Second
+	defaultSchedulerName              = corev1.DefaultSchedulerName
 	podStartupLatencyMeasurementName  = "PodStartupLatency"
 	informerSyncTimeout               = time.Minute
 
@@ -102,7 +103,11 @@ func (p *podStartupLatencyMeasurement) Execute(config *measurement.Config) ([]me
 		}
 		return nil, p.start(config.ClusterFramework.GetClientSets().GetClient())
 	case "gather":
-		return p.gather(config.ClusterFramework.GetClientSets().GetClient(), config.Identifier)
+		schedulerName, err := util.GetStringOrDefault(config.Params, "schedulerName", defaultSchedulerName)
+		if err != nil {
+			return nil, err
+		}
+		return p.gather(config.ClusterFramework.GetClientSets().GetClient(), config.Identifier, schedulerName)
 	default:
 		return nil, fmt.Errorf("unknown action %v", action)
 	}
@@ -217,7 +222,7 @@ type podStartupLatencyCheck struct {
 	filter     measurementutil.KeyFilterFunc
 }
 
-func (p *podStartupLatencyMeasurement) gather(c clientset.Interface, identifier string) ([]measurement.Summary, error) {
+func (p *podStartupLatencyMeasurement) gather(c clientset.Interface, identifier string, schedulerName string) ([]measurement.Summary, error) {
 	klog.V(2).Infof("%s: gathering pod startup latency measurement...", p)
 	if !p.isRunning {
 		return nil, fmt.Errorf("metric %s has not been started", podStartupLatencyMeasurementName)
@@ -225,7 +230,7 @@ func (p *podStartupLatencyMeasurement) gather(c clientset.Interface, identifier 
 
 	p.stop()
 
-	if err := p.gatherScheduleTimes(c); err != nil {
+	if err := p.gatherScheduleTimes(c, schedulerName); err != nil {
 		return nil, err
 	}
 
@@ -270,10 +275,10 @@ func (p *podStartupLatencyMeasurement) gather(c clientset.Interface, identifier 
 //  it just returns incomplete results.
 //  Given that we don't 100% accuracy, we should switch to a mechanism that is similar
 //  to the one that slo-monitor is using (added in #1477).
-func (p *podStartupLatencyMeasurement) gatherScheduleTimes(c clientset.Interface) error {
+func (p *podStartupLatencyMeasurement) gatherScheduleTimes(c clientset.Interface, schedulerName string) error {
 	selector := fields.Set{
 		"involvedObject.kind": "Pod",
-		"source":              corev1.DefaultSchedulerName,
+		"source":              schedulerName,
 	}.AsSelector().String()
 	options := metav1.ListOptions{FieldSelector: selector}
 	schedEvents, err := c.CoreV1().Events(p.selector.Namespace).List(context.TODO(), options)

--- a/clusterloader2/testing/density/scheduler/custom-scheduler-metrics/config-custom-schd-sample.yaml
+++ b/clusterloader2/testing/density/scheduler/custom-scheduler-metrics/config-custom-schd-sample.yaml
@@ -1,0 +1,51 @@
+name: test
+
+namespace:
+  number: 1
+
+tuningSets:
+- name: Uniform1qps
+  qpsLoad:
+    qps: 1
+
+steps:
+- name: Start measurements
+  measurements:
+  - Identifier: PodStartupLatency
+    Method: PodStartupLatency
+    Params:
+      action: start
+      labelSelector: group = test-pod-default
+      threshold: 180s
+  - Identifier: WaitForControlledPodsRunning
+    Method: WaitForControlledPodsRunning
+    Params:
+      action: start
+      apiVersion: apps/v1
+      kind: Deployment
+      labelSelector: group = test-deployment
+      operationTimeout: 180s
+- name: Create deployment
+  phases:
+  - namespaceRange:
+      min: 1
+      max: 1
+    replicasPerNamespace: 1
+    tuningSet: Uniform1qps
+    objectBundle:
+    - basename: test-deployment
+      objectTemplatePath: "deployment-sample.yaml"
+      templateFillMap:
+        Replicas: 7
+- name: Wait for pods to be running
+  measurements:
+  - Identifier: WaitForControlledPodsRunning
+    Method: WaitForControlledPodsRunning
+    Params:
+      action: gather
+- name: Measure pod startup latency
+  measurements:
+  - Identifier: PodStartupLatency
+    Method: PodStartupLatency
+    Params:
+      action: gather

--- a/clusterloader2/testing/density/scheduler/custom-scheduler-metrics/deployment-custom-schd-sample.yaml
+++ b/clusterloader2/testing/density/scheduler/custom-scheduler-metrics/deployment-custom-schd-sample.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{.Name}}
+  labels:
+    group: test-deployment
+spec:
+  replicas: {{.Replicas}}
+  selector:
+    matchLabels:
+      group: test-pod-default
+  template:
+    metadata:
+      labels:
+        group: test-pod-default
+    spec:
+      schedulerName: default-scheduler
+      containers:
+      - image: k8s.gcr.io/pause:3.1
+        name: {{.Name}}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->
This PR adds a new parameter to the configuration called schedulerName. This new parameter will be used by gather action to get metrics for a target custom scheduler.
**What type of PR is this?**
This is a feature enhancement PR to gather scheduling metrics from custom schedulers.

/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes  https://github.com/kubernetes/perf-tests/issues/1944

**Special notes for your reviewer**:
- schedulerName param is now needed in the execute method to gather scheduling metrics. If the value to the param is not supplied then it defaults to the default-scheduler. Please refer to sample yamls present in folder clusterloader2/testing/custom-scheduler-metrics
- This PR was already reviewed here: https://github.com/kubernetes/perf-tests/pull/1945 , closed due to merge issues.
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```