### PR TITLE
pod startup logging

### DIFF
--- a/clusterloader2/README.md
+++ b/clusterloader2/README.md
@@ -148,6 +148,11 @@ This measurement works as a barrier that waits until specified controlling objec
 (ReplicationController, ReplicaSet, Deployment, DaemonSet and Job) have all pods running.
 Controlling objects can be specified by label selector, field selector and namespace.
 In case of timeout test continues to run, with error (causing marking test as failed) being logged.
+Supports "start", "gather" and "stop" as actions. "Starts" begins the measurement, "gather"
+waits pods to be running or (if called again) to be stopped, and "stop" ends the measurement
+and cleans up. Calling "stop" is optional and not needed when the test terminates anyway.
+Calling it is useful in long-running tests because otherwise the measurement keeps
+running in the background and may start emitting unexpected log output.
 - **WaitForRunningPods** \
 This is a barrier that waits until required number of pods are running.
 Pods can be specified by label selector, field selector and namespace.

--- a/clusterloader2/pkg/measurement/common/wait_for_controlled_pods.go
+++ b/clusterloader2/pkg/measurement/common/wait_for_controlled_pods.go
@@ -549,6 +549,7 @@ func (w *waitForControlledPodsRunningMeasurement) waitForRuntimeObject(obj runti
 			CallerName:          w.String(),
 			WaitForPodsInterval: defaultWaitForPodsInterval,
 			IsPodUpdated:        isPodUpdated,
+			SilentProgress:      true,
 		}
 		// This function sets the status (and error message) for the object checker.
 		// The handling of bad statuses and errors is done by gather() function of the measurement.

--- a/clusterloader2/pkg/measurement/common/wait_for_controlled_pods.go
+++ b/clusterloader2/pkg/measurement/common/wait_for_controlled_pods.go
@@ -147,6 +147,9 @@ func (w *waitForControlledPodsRunningMeasurement) Execute(config *measurement.Co
 			return nil, err
 		}
 		return nil, w.gather(syncTimeout)
+	case "stop":
+		w.Dispose()
+		return nil, nil
 	default:
 		return nil, fmt.Errorf("unknown action %v", action)
 	}
@@ -158,6 +161,9 @@ func (w *waitForControlledPodsRunningMeasurement) Dispose() {
 		return
 	}
 	w.isRunning = false
+	// This does not actually wait for the informer to stop!
+	// informer.StartAndSync would have to be extended to support
+	// a WaitGroup that we then can wait on here.
 	close(w.stopCh)
 	w.queue.Stop()
 	w.lock.Lock()
@@ -210,6 +216,7 @@ func (w *waitForControlledPodsRunningMeasurement) gather(syncTimeout time.Durati
 	if !w.isRunning {
 		return fmt.Errorf("metric %s has not been started", w)
 	}
+
 	objectKeys, maxResourceVersion, err := w.getObjectKeysAndMaxVersion()
 	if err != nil {
 		return err

--- a/clusterloader2/testing/experimental/storage/pod-startup/config.yaml
+++ b/clusterloader2/testing/experimental/storage/pod-startup/config.yaml
@@ -166,6 +166,14 @@ steps:
     objectBundle:
     - basename: deployment
       objectTemplatePath: {{$DEPLOYMENT_TEMPLATE_PATH}}
+- name: Waiting for pods to be deleted
+  measurements:
+    - Identifier: WaitForDeletedPods
+      Method: WaitForRunningPods
+      Params:
+        desiredPodCount: 0
+        labelSelector: group = volume-test
+        timeout: {{$POD_STARTUP_TIMEOUT}}
 {{ end }}
 {{ if $PROVISION_VOLUME }}
 # Delete volumes

--- a/clusterloader2/testing/experimental/storage/pod-startup/config.yaml
+++ b/clusterloader2/testing/experimental/storage/pod-startup/config.yaml
@@ -166,14 +166,18 @@ steps:
     objectBundle:
     - basename: deployment
       objectTemplatePath: {{$DEPLOYMENT_TEMPLATE_PATH}}
-- name: Waiting for pods to be deleted
+- name: Waiting for deployments to be stopped
   measurements:
-    - Identifier: WaitForDeletedPods
-      Method: WaitForRunningPods
-      Params:
-        desiredPodCount: 0
-        labelSelector: group = volume-test
-        timeout: {{$POD_STARTUP_TIMEOUT}}
+  - Identifier: WaitForRunningDeployments
+    Method: WaitForControlledPodsRunning
+    Params:
+      action: gather
+- name: Stop deployment measurement
+  measurements:
+  - Identifier: WaitForRunningDeployments
+    Method: WaitForControlledPodsRunning
+    Params:
+      action: stop
 {{ end }}
 {{ if $PROVISION_VOLUME }}
 # Delete volumes


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Running the pod startup test at -v=2 produces too much (periodic status dumps in WaitForPods) and confusing log output (WaitForPods called while cleaning up).

**Special notes for your reviewer**:

See commit messages  for details. These problems were discussed on Slack: https://kubernetes.slack.com/archives/C09QZTRH7/p1646660039727209

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/cc @marseel 