### PR TITLE
 k8s-infra: Switch to registry.k8s.io

### DIFF
--- a/clusterloader2/testing/density/deployment.yaml
+++ b/clusterloader2/testing/density/deployment.yaml
@@ -16,7 +16,7 @@ spec:
         group: {{.Group}}
     spec:
       containers:
-      - image: k8s.gcr.io/pause:3.1
+      - image: registry.k8s.io/pause:3.1
         imagePullPolicy: IfNotPresent
         name: {{.Name}}
         ports:

--- a/clusterloader2/testing/density/scheduler/custom-scheduler-metrics/deployment-custom-schd-sample.yaml
+++ b/clusterloader2/testing/density/scheduler/custom-scheduler-metrics/deployment-custom-schd-sample.yaml
@@ -16,5 +16,5 @@ spec:
     spec:
       schedulerName: default-scheduler
       containers:
-      - image: k8s.gcr.io/pause:3.1
+      - image: registry.k8s.io/pause:3.1
         name: {{.Name}}

--- a/clusterloader2/testing/density/scheduler/pod-affinity/deployment.yaml
+++ b/clusterloader2/testing/density/scheduler/pod-affinity/deployment.yaml
@@ -25,7 +25,7 @@ spec:
               topologyKey: "kubernetes.io/hostname"
             weight: 1
       containers:
-      - image: k8s.gcr.io/pause:3.1
+      - image: registry.k8s.io/pause:3.1
         imagePullPolicy: IfNotPresent
         name: {{.Name}}
         ports:

--- a/clusterloader2/testing/density/scheduler/pod-anti-affinity/deployment.yaml
+++ b/clusterloader2/testing/density/scheduler/pod-anti-affinity/deployment.yaml
@@ -25,7 +25,7 @@ spec:
               topologyKey: "kubernetes.io/hostname"
             weight: 1
       containers:
-      - image: k8s.gcr.io/pause:3.1
+      - image: registry.k8s.io/pause:3.1
         imagePullPolicy: IfNotPresent
         name: {{.Name}}
         ports:

--- a/clusterloader2/testing/density/scheduler/pod-topology-spread/deployment.yaml
+++ b/clusterloader2/testing/density/scheduler/pod-topology-spread/deployment.yaml
@@ -27,7 +27,7 @@ spec:
           matchLabels:
             group: {{.Group}}
       containers:
-      - image: k8s.gcr.io/pause:3.1
+      - image: registry.k8s.io/pause:3.1
         imagePullPolicy: IfNotPresent
         name: {{.Name}}
         ports:

--- a/clusterloader2/testing/load/config.yaml
+++ b/clusterloader2/testing/load/config.yaml
@@ -79,7 +79,7 @@
 {{$EXIT_AFTER_EXEC := DefaultParam .CL2_EXIT_AFTER_EXEC false}}
 {{$SLEEP_AFTER_EXEC_DURATION := DefaultParam .CL2_SLEEP_AFTER_EXEC_DURATION "0s"}}
 
-{{$latencyPodImage := DefaultParam .CL2_LATENCY_POD_IMAGE "k8s.gcr.io/pause:3.1"}}
+{{$latencyPodImage := DefaultParam .CL2_LATENCY_POD_IMAGE "registry.k8s.io/pause:3.1"}}
 
 name: load
 namespace:

--- a/clusterloader2/testing/node-throughput/config.yaml
+++ b/clusterloader2/testing/node-throughput/config.yaml
@@ -4,7 +4,7 @@
 #Constants
 {{$POD_COUNT := DefaultParam .POD_COUNT 100}}
 {{$POD_THROUGHPUT := DefaultParam .POD_THROUGHPUT 5}}
-{{$CONTAINER_IMAGE := DefaultParam .CONTAINER_IMAGE "k8s.gcr.io/pause:3.1"}}
+{{$CONTAINER_IMAGE := DefaultParam .CONTAINER_IMAGE "registry.k8s.io/pause:3.1"}}
 {{$POD_STARTUP_LATENCY_THRESHOLD := DefaultParam .POD_STARTUP_LATENCY_THRESHOLD "5s"}}
 {{$OPERATION_TIMEOUT := DefaultParam .OPERATION_TIMEOUT "15m"}}
 


### PR DESCRIPTION
Related:
  - https://github.com/kubernetes/k8s.io/issues/3411

/kind feature

**What this PR does / why we need it**:

Switch the scalability jobs to the new proxy for Kubernetes container images.