### PR TITLE
Add snapshot clean-up script for boskos resources

### DIFF
--- a/clusterloader2/clean-up-old-snapshots-boskos.sh
+++ b/clusterloader2/clean-up-old-snapshots-boskos.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+
+# Copyright 2022 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+
+print-usage-and-exit() {
+  >&2 echo "Usage:"
+  >&2 echo "    $0 delete|list <comma-sep-prefixes> <days-old> <comma-sep-boskos-pools> <boskos-resources-file>"
+  >&2 echo "Example:"
+  >&2 echo "    $0 list ci-e2e-scalability,ci-e2e-kubemark 30 scalability-project ./boskos-resources.yaml"
+  exit "$1"
+}
+
+main() {
+  if [ "$#" -ne 5 ]; then
+    >&2 echo "Wrong number of parameters, expected 5, got $#"
+    print-usage-and-exit 1
+  fi
+
+  command=$1
+  prefixes=$2
+  days_old=$3
+  boskos_pools=$4
+  boskos_file=$5
+
+  if ! [[ "$boskos_pools" =~ ^[a-z0-9,-]+$ ]]; then
+    >&2 echo "Illegal characters in projects parameter: $boskos_pools"
+    print-usage-and-exit 2
+  fi
+
+  if ! [[ -f "$boskos_file" ]]; then
+    >&2 echo "$boskos_file file does not exist"
+    print-usage-and-exit 3
+  fi
+
+  projects=()
+
+  IFS=',' read -ra boskos_pools_arr <<< "$boskos_pools"
+  for boskos_pool in "${boskos_pools_arr[@]}"; do
+    readarray boskos_projects < \
+      <(yq ".resources.[] | select (.type == \"$boskos_pool\") | .names.[]" "$boskos_file")
+    if [ ${#boskos_projects[@]} -eq 0 ]; then
+      >&2 echo "Could not find any project under boskos pool $boskos_pool"
+      exit 4
+    fi
+
+    for project in "${boskos_projects[@]}"; do
+      projects+=("$(echo -e "$project" | tr -d '[:space:]')")
+    done
+  done
+
+  projects_str=$(IFS=','; echo "${projects[*]}")
+
+  (
+    set -o xtrace
+    "$SCRIPT_DIR/clean-up-old-snapshots.sh" \
+      "$command" "$projects_str" "$prefixes" "$days_old"
+  )
+}
+
+main "$@"

--- a/clusterloader2/clean-up-old-snapshots.sh
+++ b/clusterloader2/clean-up-old-snapshots.sh
@@ -23,7 +23,7 @@ print-usage-and-exit() {
   >&2 echo "    $0 delete|list <comma-sep-projects> <comma-sep-prefixes> <days-old>"
   >&2 echo "Example:"
   >&2 echo "    $0 list k8s-e2e-gce-1-1,k8s-e2e-gce-1-2  ci-e2e-scalability,ci-e2e-kubemark 30"
-  exit $1
+  exit "$1"
 }
 
 list-old-snapshots() {
@@ -94,4 +94,4 @@ main() {
   done
 }
 
-main $@
+main "$@"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
This script is intended to be used together with `clean-up-old-snapshots.sh`. It solves an issue of updating projects that are bound to a specific boskos pool.

Example usage (assuming [test-infra](https://github.com/kubernetes/test-infra/tree/fae5b9d844fc61966f2f69bfa57afb9cd27e4a88)):
``` sh
$ ./clean-up-old-snapshots-boskos.sh list ci-kubernetes-e2e-gci-gce-scalability 30 \
  scalability-project .../test-infra/config/prow/cluster/build/boskos-resources/boskos-resources.yaml
# Looking for snapshots matched by ^(ci-kubernetes-e2e-gci-gce-scalability).*-[0-9]{19}$
# Processing project k8s-e2e-gce-scalability-1-1
# ++ gcloud compute snapshots list --project k8s-e2e-gce-scalability-1-1 '--filter=creationTimestamp < -P30D AND name~"^(ci-kubernetes-e2e-gci-gce-scalability).*-[0-9]{19}$"' '--format=value(name)'
# WARNING: The following filter keys were not present in any resource : creationTimestamp, name
# Processing project k8s-e2e-gce-scalability-1-2
# ++ gcloud compute snapshots list --project k8s-e2e-gce-scalability-1-2 '--filter=creationTimestamp < -P30D AND name~"^(ci-kubernetes-e2e-gci-gce-scalability).*-[0-9]{19}$"' '--format=value(name)'
# WARNING: The following filter keys were not present in any resource : creationTimestamp, name
# ...
# Processing project k8s-periodic-scale-1
# ++ gcloud compute snapshots list --project k8s-periodic-scale-1 '--filter=creationTimestamp < -P30D AND name~"^(ci-kubernetes-e2e-gci-gce-scalability).*-[0-9]{19}$"' '--format=value(name)'
# Found: ci-kubernetes-e2e-gci-gce-scalability-1218465145471111170
# Found: ci-kubernetes-e2e-gci-gce-scalability-1218701701733683200
# Found: ci-kubernetes-e2e-gci-gce-scalability-1218780722337157123
# Found: ci-kubernetes-e2e-gci-gce-scalability-1219103597740953601
# Found: ci-kubernetes-e2e-gci-gce-scalability-1219181613049450497
# ...
```

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
/assign @jprzychodzen

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added a script that removes snapshots for given boskos resources.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```