### PR TITLE
Allow specifying clusterloader2 flags in the first argument of run-e2e.sh

### DIFF
--- a/run-e2e.sh
+++ b/run-e2e.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2017 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,8 +16,9 @@
 set -o nounset
 set -o pipefail
 
-PERFTEST_ROOT=$(dirname "${BASH_SOURCE}")
-echo "TOOL_NAME: $1"
+PERFTEST_ROOT=$(dirname "${BASH_SOURCE[0]}")
+TOOL_NAME=$(echo "$1" | cut -d " " -f1)
+echo "TOOL_NAME: $TOOL_NAME"
 
 # TODO(kubernetes/perf-tests/issues/1624): Get rid of the logic below.
 # Print the git history. This is useful in the CI jobs as it provides an ability
@@ -25,25 +26,26 @@ echo "TOOL_NAME: $1"
 if [[ "${PERF_TESTS_PRINT_COMMIT_HISTORY:-false}" == "true" ]]; then
   # The output file location assumes the script works inside a prow job.
   output_file="${ARTIFACTS}/perf-tests.gitlog"
-  echo "k8s.io/perf-tests git log:" | tee $output_file || true
-  git -C $PERFTEST_ROOT log -n 10 --format="%H - %ad (%s)" --date=local | tee -a $output_file || true
+  echo "k8s.io/perf-tests git log:" | tee "$output_file" || true
+  git -C "$PERFTEST_ROOT" log -n 10 --format="%H - %ad (%s)" --date=local | tee -a "$output_file" || true
 fi
 
-case "$1" in
+case "$TOOL_NAME" in
   cluster-loader2 )
     #CLUSTERLOADER2
-    echo "COMMAND: ${PERFTEST_ROOT}/clusterloader2 && ./run-e2e.sh ${@:2}"
-    cd ${PERFTEST_ROOT}/clusterloader2 && ./run-e2e.sh ${@:2}
+    IFS=' ' read -ra args_1 <<< "$1"
+    echo "COMMAND: ${PERFTEST_ROOT}/clusterloader2 && ./run-e2e.sh ${args_1[*]:1} ${*:2}"
+    cd "${PERFTEST_ROOT}/clusterloader2" && exec ./run-e2e.sh "${args_1[@]:1}" "${@:2}"
     exit
     ;;
   network-performance )
     #NETPERF
-    cd ${PERFTEST_ROOT}/network/benchmarks/netperf/ && go run ./launch.go  --kubeConfig="${HOME}/.kube/config" --hostnetworking --iterations 1
+    cd "${PERFTEST_ROOT}/network/benchmarks/netperf/" && go run ./launch.go  --kubeConfig="${HOME}/.kube/config" --hostnetworking --iterations 1
     exit
     ;;
   kube-dns|core-dns|node-local-dns )
-    cd ${PERFTEST_ROOT}/dns
-    ./run $@
+    cd "${PERFTEST_ROOT}/dns" || exit
+    ./run "$@"
     exit
     ;;
   --help | -h )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
`run-e2e.sh` is usually ran from [kubetest](https://github.com/kubernetes/test-infra/tree/master/kubetest). It is defined by repeatedly declaring `test-cmd-args` argument, which is itself a leftover after using `pflag` dependency. It may be wanted to use only a single declaration of this argument. In such a case, the first argument will contain all the parameters for ClusterLoader2.

This change makes the approach above possible by setting the tool name to the first word of the first argument value and adds the remainder as additional flags for the `clusterloader2/run-e2e.sh` command.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
This script is fully backwards compatible. Usage examples:
``` sh
$ ./run-e2e.sh cluster-loader2 --flag1 --flag2=val1
# TOOL_NAME: cluster-loader2
# COMMAND: ./clusterloader2 && ./run-e2e.sh  --flag1 --flag2=val1
```
``` sh
$ ./run-e2e.sh "cluster-loader2" --flag1 --flag2=val1
# TOOL_NAME: cluster-loader2
# COMMAND: ./clusterloader2 && ./run-e2e.sh  --flag1 --flag2=val1
```
``` sh
$ ./run-e2e.sh "cluster-loader2 --flag1" --flag2=val1
# TOOL_NAME: cluster-loader2
# COMMAND: ./clusterloader2 && ./run-e2e.sh --flag1  --flag2=val1
```
``` sh
$ ./run-e2e.sh "cluster-loader2 --flag1 --flag2=val1"
# TOOL_NAME: cluster-loader2
# COMMAND: ./clusterloader2 && ./run-e2e.sh --flag1 --flag2=val1
```

This PR consists of two commits. It's made this way for readability. I'll squash them after a LGTM.
/cc @jprzychodzen 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```