### PR TITLE
Further load test resource requests

### DIFF
--- a/clusterloader2/testing/load/simple-deployment.yaml
+++ b/clusterloader2/testing/load/simple-deployment.yaml
@@ -1,8 +1,8 @@
 {{$HostNetworkMode := DefaultParam .CL2_USE_HOST_NETWORK_PODS false}}
 # Keep the CpuRequest/MemoryRequest request equal percentage of 1-core, 4GB node.
-# For now we're setting it to 0.2%.
-{{$CpuRequest := DefaultParam .CpuRequest "2m"}}
-{{$MemoryRequest := DefaultParam .MemoryRequest "8M"}}
+# For now we're setting it to 0.5%.
+{{$CpuRequest := DefaultParam .CpuRequest "5m"}}
+{{$MemoryRequest := DefaultParam .MemoryRequest "20M"}}
 {{$Image := DefaultParam .Image "k8s.gcr.io/pause:3.1"}}
 
 apiVersion: apps/v1


### PR DESCRIPTION
Further follow up from https://github.com/kubernetes/perf-tests/pull/2031 and https://github.com/kubernetes/perf-tests/pull/2032

This should help with #1311 - currently the pods relatively small, so scheduling another one often doesn't change the scores for a given pod for subsequent pods. Increasing the number of resources means that the score will be changing more frequently.

/assign @mborsz 