### PR TITLE
Use *errors.ErrorList everywhere

### DIFF
--- a/clusterloader2/pkg/measurement/measurement_executor.go
+++ b/clusterloader2/pkg/measurement/measurement_executor.go
@@ -18,13 +18,14 @@ package measurement
 
 import (
 	"fmt"
+
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/perf-tests/clusterloader2/api"
 	"k8s.io/perf-tests/clusterloader2/pkg/errors"
 )
 
 // Execute executes a measurement, which can be a single measurement or a wrapper for multiple measurements.
-func Execute(mm Manager, m *api.Measurement) errors.ErrorList {
+func Execute(mm Manager, m *api.Measurement) *errors.ErrorList {
 	if m.Identifier != "" {
 		return executeSingleMeasurement(mm, m)
 	}
@@ -35,15 +36,15 @@ func formatError(method, identifier string, err error) error {
 	return fmt.Errorf("measurement call %s - %s error: %v", method, identifier, err)
 }
 
-func executeSingleMeasurement(mm Manager, m *api.Measurement) errors.ErrorList {
+func executeSingleMeasurement(mm Manager, m *api.Measurement) *errors.ErrorList {
 	errList := errors.NewErrorList()
 	if err := mm.Execute(m.Method, m.Identifier, m.Params); err != nil {
 		errList.Append(formatError(m.Method, m.Identifier, err))
 	}
-	return *errList
+	return errList
 }
 
-func executeWrapperMeasurement(mm Manager, m *api.Measurement) errors.ErrorList {
+func executeWrapperMeasurement(mm Manager, m *api.Measurement) *errors.ErrorList {
 	var wg wait.Group
 	errList := errors.NewErrorList()
 	for i := range m.Instances {
@@ -65,5 +66,5 @@ func executeWrapperMeasurement(mm Manager, m *api.Measurement) errors.ErrorList 
 		})
 	}
 	wg.Wait()
-	return *errList
+	return errList
 }

--- a/clusterloader2/pkg/test/simple_reporter.go
+++ b/clusterloader2/pkg/test/simple_reporter.go
@@ -72,7 +72,7 @@ func (str *simpleReporter) ReportTestStepFinish(duration time.Duration, stepName
 
 func (str *simpleReporter) ReportTestStep(result StepResult) {
 	for _, subtestResult := range result.getAllResults() {
-		str.ReportTestStepFinish(subtestResult.duration, subtestResult.name, &subtestResult.err)
+		str.ReportTestStepFinish(subtestResult.duration, subtestResult.name, subtestResult.err)
 	}
 }
 

--- a/clusterloader2/pkg/test/simple_test_executor.go
+++ b/clusterloader2/pkg/test/simple_test_executor.go
@@ -170,7 +170,7 @@ func (ste *simpleExecutor) ExecuteStep(ctx Context, step *api.Step) *errors.Erro
 		klog.Warningf("Got errors during step execution: %v", allErrors)
 	}
 	ctx.GetTestReporter().ReportTestStep(stepResults)
-	return &allErrors
+	return allErrors
 }
 
 // ExecutePhase executes single test phase based on provided phase configuration.

--- a/clusterloader2/pkg/test/step_summary.go
+++ b/clusterloader2/pkg/test/step_summary.go
@@ -28,14 +28,14 @@ type substepResult struct {
 	name     string
 	id       int
 	duration time.Duration
-	err      errors.ErrorList
+	err      *errors.ErrorList
 }
 
 type StepResult struct {
 	lock      sync.Mutex
 	startTime time.Time
 	name      string
-	err       errors.ErrorList
+	err       *errors.ErrorList
 
 	results []substepResult
 }
@@ -45,10 +45,11 @@ func NewStepResult(stepName string) StepResult {
 		name:      stepName,
 		startTime: time.Now(),
 		results:   []substepResult{},
+		err:       errors.NewErrorList(),
 	}
 }
 
-func (s *StepResult) AddSubStepResult(name string, id int, err errors.ErrorList) {
+func (s *StepResult) AddSubStepResult(name string, id int, err *errors.ErrorList) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
@@ -61,16 +62,16 @@ func (s *StepResult) AddSubStepResult(name string, id int, err errors.ErrorList)
 	})
 }
 
-func (s *StepResult) getAllErrorsUnsafe() errors.ErrorList {
+func (s *StepResult) getAllErrorsUnsafe() *errors.ErrorList {
 	errList := errors.NewErrorList()
-	errList.Concat(&s.err)
+	errList.Concat(s.err)
 	for _, value := range s.results {
-		errList.Concat(&value.err)
+		errList.Concat(value.err)
 	}
-	return *errList
+	return errList
 }
 
-func (s *StepResult) GetAllErrors() errors.ErrorList {
+func (s *StepResult) GetAllErrors() *errors.ErrorList {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 


### PR DESCRIPTION
Two goals:
* improving printability of the ErrorList, as *ErrorList as String() defined.
  Now it prints something like:
  ```
  W0408 20:12:39.992612   15124 simple_test_executor.go:174] Got errors during step execution: {{0 0} [0xc062068a90]}
  ```
  Not very helpful.
* improving safety -- while we copy that struct here and there, each copy has a separate lock, but keep using the same slice's underlying array. If we modify append concurrently we can have a race (two goroutines writing to the same underlying array). Even if this happens serially, one goroutine may override results of the second one, as both will share the same memory.

/assign @marseel 