### PR TITLE
Apply Windows Exporter manifests after Prometheus Core Manifests

### DIFF
--- a/clusterloader2/pkg/prometheus/prometheus.go
+++ b/clusterloader2/pkg/prometheus/prometheus.go
@@ -207,6 +207,18 @@ func (pc *Controller) SetUpPrometheusStack() error {
 	if err := client.CreateNamespace(k8sClient, namespace); err != nil {
 		return err
 	}
+	// Removing Storage Class as Reclaim Policy cannot be changed
+	if err := client.DeleteStorageClass(k8sClient, storageClass); err != nil {
+		return err
+	}
+	if err := pc.applyManifests(pc.clusterLoaderConfig.PrometheusConfig.CoreManifests); err != nil {
+		return err
+	}
+	if pc.clusterLoaderConfig.PrometheusConfig.ScrapeNodeExporter {
+		if err := pc.runNodeExporter(); err != nil {
+			return err
+		}
+	}
 	if pc.clusterLoaderConfig.PrometheusConfig.ScrapeWindowsNodeExporter {
 		if err := pc.applyManifests(pc.clusterLoaderConfig.PrometheusConfig.WindowsNodeExporterManifests); err != nil {
 			return err
@@ -218,18 +230,6 @@ func (pc *Controller) SetUpPrometheusStack() error {
 			if err := setUpWindowsNodeAndTemplate(k8sClient, pc.templateMapping); err != nil {
 				return err
 			}
-		}
-	}
-	// Removing Storage Class as Reclaim Policy cannot be changed
-	if err := client.DeleteStorageClass(k8sClient, storageClass); err != nil {
-		return err
-	}
-	if err := pc.applyManifests(pc.clusterLoaderConfig.PrometheusConfig.CoreManifests); err != nil {
-		return err
-	}
-	if pc.clusterLoaderConfig.PrometheusConfig.ScrapeNodeExporter {
-		if err := pc.runNodeExporter(); err != nil {
-			return err
 		}
 	}
 	if !pc.isKubemark() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
This PR: https://github.com/kubernetes/perf-tests/pull/2041 introduced Windows Exporter as a HostProcess container running as a daemonset.
Previously it was installed via SSH.

WindowsExporter manifests need to be applied after Prometheus Core manifests are applied.
Deployment fails with timed out waiting for the condition because of missing CRDs.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```