### PR TITLE
Log node allocatable on cluster loader startup

### DIFF
--- a/clusterloader2/pkg/util/cluster.go
+++ b/clusterloader2/pkg/util/cluster.go
@@ -83,7 +83,7 @@ func LogClusterNodes(c clientset.Interface) error {
 				externalIP = address.Address
 			}
 		}
-		klog.V(2).Infof("Name: %v, clusterIP: %v, externalIP: %v, isSchedulable: %v", nodeList[i].ObjectMeta.Name, internalIP, externalIP, isSchedulable)
+		klog.V(2).Infof("Name: %v, clusterIP: %v, externalIP: %v, isSchedulable: %v, allocatable: %#v", nodeList[i].ObjectMeta.Name, internalIP, externalIP, isSchedulable, nodeList[i].Status.Allocatable)
 	}
 	return nil
 }


### PR DESCRIPTION
Ref https://github.com/kubernetes/perf-tests/issues/1311#issuecomment-1108525343

/assign @mborsz 