### PR TITLE
Add konnectivity-agent to ignored restarts for node killer test

### DIFF
--- a/clusterloader2/testing/chaosmonkey/ignore_node_killer_container_restarts_100.yaml
+++ b/clusterloader2/testing/chaosmonkey/ignore_node_killer_container_restarts_100.yaml
@@ -4,6 +4,7 @@ RESTART_COUNT_THRESHOLD_OVERRIDES: |
   coredns: 1
   fluentd-gcp: 1
   kube-proxy: 1
+  konnectivity-agent: 1
   metadata-proxy: 1
   prometheus-to-sd-exporter: 1
   volume-snapshot-controller: 1


### PR DESCRIPTION
Fix node killer test.

Ref. kubernetes/kubernetes#109915

/assign @mborsz 

Sample failure from TestGrid (https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-scalability-node-killer/1526128802835468288)
```
{ Failure :0 [measurement call TestMetrics - TestMetrics error: [action gather failed for SystemPodMetrics measurement: restart counts violation: RestartCount(konnectivity-agent-w549l, konnectivity-agent)=1, want <= 0; RestartCount(konnectivity-agent-plt4b, konnectivity-agent)=1, want <= 0]] :0}
```

