### PR TITLE
Scrape dnsperfgo pods that generate DNS performance metrics

### DIFF
--- a/clusterloader2/pkg/prometheus/manifests/default/prometheus-podMonitorDNSPerf.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/default/prometheus-podMonitorDNSPerf.yaml
@@ -1,0 +1,21 @@
+{{$ENABLE_DNSTESTS := DefaultParam .CL2_ENABLE_DNSTESTS false}}
+
+{{if $ENABLE_DNSTESTS}}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  labels:
+    k8s-app: dns-client-pods
+  name: dns-client-pods
+  namespace: monitoring
+spec:
+  podMetricsEndpoints:
+    - interval: 30s
+      port: dnsperfmetrics
+  jobLabel: k8s-app
+  selector:
+    matchLabels:
+      dns-test: dnsperfgo
+  namespaceSelector:
+    any: true
+{{end}}


### PR DESCRIPTION
The load test is using dnsperfgo (https://github.com/kubernetes/perf-tests/tree/master/dns/dnsperfgo) pods to measure DNS performance. The DNS client pods, with `dns-test: dnsperfgo` label, expose Prometheus metrics on port `dnsperfmetrics`.

/kind feature
/assign @marseel 