### PR TITLE
Add 'do not evict' annotation to Prometheus

### DIFF
--- a/clusterloader2/pkg/prometheus/manifests/prometheus-prometheus.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/prometheus-prometheus.yaml
@@ -46,6 +46,9 @@ spec:
   serviceAccountName: prometheus-k8s
   serviceMonitorNamespaceSelector: {}
   serviceMonitorSelector: {}
+  podMetadata:
+    annotations:
+      cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
   podMonitorNamespaceSelector: {}
   podMonitorSelector: {}
   version: v2.25.0


### PR DESCRIPTION
The annotation prevents cluster autoscaler from evicting the pod, reducing potential for disruption to measurements.