### PR TITLE
Make exec_deployment.yaml path configurable

### DIFF
--- a/clusterloader2/cmd/clusterloader.go
+++ b/clusterloader2/cmd/clusterloader.go
@@ -119,12 +119,12 @@ func validateClusterFlags() *errors.ErrorList {
 
 func initFlags() {
 	flags.StringVar(&clusterLoaderConfig.ReportDir, "report-dir", "", "Path to the directory where the reports should be saved. Default is empty, which cause reports being written to standard output.")
-	flags.BoolEnvVar(&clusterLoaderConfig.EnableExecService, "enable-exec-service", "ENABLE_EXEC_SERVICE", true, "Whether to enable exec service that allows executing arbitrary commands from a pod running in the cluster.")
 	// TODO(https://github.com/kubernetes/perf-tests/issues/641): Remove testconfig and testoverrides flags when test suite is fully supported.
 	flags.StringArrayVar(&testConfigPaths, "testconfig", []string{}, "Paths to the test config files")
 	flags.StringArrayVar(&clusterLoaderConfig.OverridePaths, "testoverrides", []string{}, "Paths to the config overrides file. The latter overrides take precedence over changes in former files.")
 	flags.StringVar(&testSuiteConfigPath, "testsuite", "", "Path to the test suite config file")
 	initClusterFlags()
+	execservice.InitFlags(&clusterLoaderConfig.ExecServiceConfig)
 	modifier.InitFlags(&clusterLoaderConfig.ModifierConfig)
 	prometheus.InitFlags(&clusterLoaderConfig.PrometheusConfig)
 }
@@ -303,8 +303,8 @@ func main() {
 			prometheusController.EnableTearDownPrometheusStackOnInterrupt()
 		}
 	}
-	if clusterLoaderConfig.EnableExecService {
-		if err := execservice.SetUpExecService(f); err != nil {
+	if clusterLoaderConfig.ExecServiceConfig.Enable {
+		if err := execservice.SetUpExecService(f, clusterLoaderConfig.ExecServiceConfig); err != nil {
 			klog.Exitf("Error while setting up exec service: %v", err)
 		}
 	}
@@ -368,7 +368,7 @@ func main() {
 			klog.Errorf("Error while tearing down prometheus stack: %v", err)
 		}
 	}
-	if clusterLoaderConfig.EnableExecService {
+	if clusterLoaderConfig.ExecServiceConfig.Enable {
 		if err := execservice.TearDownExecService(f); err != nil {
 			klog.Errorf("Error while tearing down exec service: %v", err)
 		}

--- a/clusterloader2/pkg/config/cluster.go
+++ b/clusterloader2/pkg/config/cluster.go
@@ -26,7 +26,7 @@ import (
 type ClusterLoaderConfig struct {
 	ClusterConfig     ClusterConfig
 	ReportDir         string
-	EnableExecService bool
+	ExecServiceConfig ExecServiceConfig
 	ModifierConfig    ModifierConfig
 	PrometheusConfig  PrometheusConfig
 	// OverridePaths defines what override files should be applied
@@ -56,6 +56,14 @@ type ClusterConfig struct {
 	KubeletPort                   int
 	K8SClientsNumber              int
 	SkipClusterVerification       bool
+}
+
+// ExecServiceConfig represents all flags used by service config.
+type ExecServiceConfig struct {
+	// Determines if service config should be enabled.
+	Enable bool
+	// Sets path to the deployment definition.
+	DeploymentYaml string
 }
 
 // ModifierConfig represent all flags used by test modification

--- a/clusterloader2/pkg/measurement/common/api_availability_measurement.go
+++ b/clusterloader2/pkg/measurement/common/api_availability_measurement.go
@@ -186,7 +186,7 @@ func (a *apiAvailabilityMeasurement) initFields(config *measurement.Config) erro
 	a.threshold = threshold
 
 	a.clusterLevelMetrics = &apiAvailabilityMetrics{}
-	if config.ClusterLoaderConfig.EnableExecService {
+	if config.ClusterLoaderConfig.ExecServiceConfig.Enable {
 		a.hostIPs = config.ClusterFramework.GetClusterConfig().MasterInternalIPs
 		if len(a.hostIPs) == 0 {
 			klog.V(2).Infof("%s: host internal IP(s) are not provided, therefore only cluster-level availability will be measured", a)

--- a/clusterloader2/pkg/measurement/common/service_creation_latency.go
+++ b/clusterloader2/pkg/measurement/common/service_creation_latency.go
@@ -95,7 +95,7 @@ func (s *serviceCreationLatencyMeasurement) Execute(config *measurement.Config) 
 	if err != nil {
 		return nil, err
 	}
-	if !config.ClusterLoaderConfig.EnableExecService {
+	if !config.ClusterLoaderConfig.ExecServiceConfig.Enable {
 		return nil, fmt.Errorf("enable-exec-service flag not enabled")
 	}
 

--- a/clusterloader2/pkg/measurement/common/slos/api_responsiveness_prometheus_test.go
+++ b/clusterloader2/pkg/measurement/common/slos/api_responsiveness_prometheus_test.go
@@ -35,6 +35,8 @@ import (
 	"k8s.io/perf-tests/clusterloader2/pkg/measurement"
 	"k8s.io/perf-tests/clusterloader2/pkg/measurement/common/executors"
 	measurementutil "k8s.io/perf-tests/clusterloader2/pkg/measurement/util"
+
+	_ "k8s.io/perf-tests/clusterloader2/pkg/flags" // init klog
 )
 
 var (
@@ -49,7 +51,6 @@ var (
 
 func turnOffLoggingToStderrInKlog(t *testing.T) {
 	if klogLogToStderr {
-		klog.InitFlags(nil)
 		err := flag.Set("logtostderr", "false")
 		if err != nil {
 			t.Errorf("Unable to set flag %v", err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
Allows setting custom path to `exec_deployment.yaml`. Necessary if clusterloader is ran from another directory than `perf-tests/clusterloader2`.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
This does not introduce a breaking change.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```