### PR TITLE
Update CL2 APIResponsivenessPrometheus threasholds

### DIFF
--- a/clusterloader2/pkg/measurement/common/slos/api_responsiveness_prometheus.go
+++ b/clusterloader2/pkg/measurement/common/slos/api_responsiveness_prometheus.go
@@ -39,9 +39,8 @@ const (
 
 	// Thresholds for API call latency as defined in the official K8s SLO
 	// https://github.com/kubernetes/community/blob/master/sig-scalability/slos/api_call_latency.md
-	resourceThreshold  time.Duration = 1 * time.Second
-	namespaceThreshold time.Duration = 5 * time.Second
-	clusterThreshold   time.Duration = 30 * time.Second
+	singleResourceThreshold    time.Duration = 1 * time.Second
+	multipleResourcesThreshold time.Duration = 30 * time.Second
 
 	currentAPICallMetricsVersion = "v1"
 
@@ -405,11 +404,8 @@ func (ap *apiCallMetric) Validate(allowedSlowCalls int, threshold time.Duration)
 }
 
 func (ap *apiCallMetric) getSLOThreshold() time.Duration {
-	if ap.Verb != "LIST" {
-		return resourceThreshold
+	if ap.Scope == "resource" {
+		return singleResourceThreshold
 	}
-	if ap.Scope == "cluster" {
-		return clusterThreshold
-	}
-	return namespaceThreshold
+	return multipleResourcesThreshold
 }

--- a/clusterloader2/pkg/measurement/common/slos/api_responsiveness_prometheus_test.go
+++ b/clusterloader2/pkg/measurement/common/slos/api_responsiveness_prometheus_test.go
@@ -310,7 +310,7 @@ func TestAPIResponsivenessSummary(t *testing.T) {
 				{
 					resource:  "pod",
 					verb:      "POST",
-					scope:     "namespace",
+					scope:     "resource",
 					latency:   1.2,
 					count:     123,
 					slowCount: 5,
@@ -320,7 +320,7 @@ func TestAPIResponsivenessSummary(t *testing.T) {
 				{
 					resource:  "pod",
 					verb:      "POST",
-					scope:     "namespace",
+					scope:     "resource",
 					p99:       1200.,
 					count:     "123",
 					slowCount: "5",
@@ -334,7 +334,7 @@ func TestAPIResponsivenessSummary(t *testing.T) {
 				{
 					resource:  "pod",
 					verb:      "POST",
-					scope:     "namespace",
+					scope:     "resource",
 					latency:   1.2,
 					count:     123,
 					slowCount: 5,
@@ -344,7 +344,7 @@ func TestAPIResponsivenessSummary(t *testing.T) {
 				{
 					resource:  "pod",
 					verb:      "POST",
-					scope:     "namespace",
+					scope:     "resource",
 					p99:       1200.,
 					count:     "123",
 					slowCount: "5",
@@ -423,31 +423,37 @@ func TestLogging(t *testing.T) {
 				{
 					resource: "r1",
 					verb:     "POST",
+					scope:    "resource",
 					latency:  1.2,
 				},
 				{
 					resource: "r2",
 					verb:     "POST",
+					scope:    "resource",
 					latency:  .9,
 				},
 				{
 					resource: "r3",
 					verb:     "POST",
+					scope:    "resource",
 					latency:  .8,
 				},
 				{
 					resource: "r4",
 					verb:     "POST",
+					scope:    "resource",
 					latency:  .7,
 				},
 				{
 					resource: "r5",
 					verb:     "POST",
+					scope:    "resource",
 					latency:  .6,
 				},
 				{
 					resource: "r6",
 					verb:     "POST",
+					scope:    "resource",
 					latency:  .5,
 				},
 			},
@@ -468,36 +474,43 @@ func TestLogging(t *testing.T) {
 				{
 					resource: "r1",
 					verb:     "POST",
+					scope:    "resource",
 					latency:  1.2,
 				},
 				{
 					resource: "r2",
 					verb:     "POST",
+					scope:    "resource",
 					latency:  1.9,
 				},
 				{
 					resource: "r3",
 					verb:     "POST",
+					scope:    "resource",
 					latency:  1.8,
 				},
 				{
 					resource: "r4",
 					verb:     "POST",
+					scope:    "resource",
 					latency:  1.7,
 				},
 				{
 					resource: "r5",
 					verb:     "POST",
+					scope:    "resource",
 					latency:  1.6,
 				},
 				{
 					resource: "r6",
 					verb:     "POST",
+					scope:    "resource",
 					latency:  1.5,
 				},
 				{
 					resource: "r7",
 					verb:     "POST",
+					scope:    "resource",
 					latency:  .5,
 				},
 			},

--- a/clusterloader2/pkg/measurement/common/slos/testdata/get_slo_failure.yaml
+++ b/clusterloader2/pkg/measurement/common/slos/testdata/get_slo_failure.yaml
@@ -1,10 +1,10 @@
 interval: 1m
 input_series:
-  - series: apiserver_request_duration_seconds_bucket{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="namespace",subresource="",verb="GET",version="v1",le="1"}
+  - series: apiserver_request_duration_seconds_bucket{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="resource",subresource="",verb="GET",version="v1",le="1"}
     values: 0 0 0 0 0 0 1 71 71 71 71 
-  - series: apiserver_request_duration_seconds_bucket{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="namespace",subresource="",verb="GET",version="v1",le="2"}
+  - series: apiserver_request_duration_seconds_bucket{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="resource",subresource="",verb="GET",version="v1",le="2"}
     values: 0 0 0 0 0 0 1 100 100 100 100 
-  - series: apiserver_request_duration_seconds_bucket{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="namespace",subresource="",verb="GET",version="v1",le="+Inf"}
+  - series: apiserver_request_duration_seconds_bucket{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="resource",subresource="",verb="GET",version="v1",le="+Inf"}
     values: 0 0 0 0 0 0 1 101 101 101 101
-  - series: apiserver_request_duration_seconds_count{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="namespace",subresource="",verb="GET",version="v1"}
+  - series: apiserver_request_duration_seconds_count{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="resource",subresource="",verb="GET",version="v1"}
     values: 0 0 0 0 0 0 1 101 101 101 101

--- a/clusterloader2/pkg/measurement/common/slos/testdata/mutating_slo_failure.yaml
+++ b/clusterloader2/pkg/measurement/common/slos/testdata/mutating_slo_failure.yaml
@@ -1,10 +1,10 @@
 interval: 1m
 input_series:
-  - series: apiserver_request_duration_seconds_bucket{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="namespace",subresource="",verb="POST",version="v1",le="1"}
+  - series: apiserver_request_duration_seconds_bucket{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="resource",subresource="",verb="POST",version="v1",le="1"}
     values: 0 0 0 0 0 0 1 71 71 71 71 
-  - series: apiserver_request_duration_seconds_bucket{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="namespace",subresource="",verb="POST",version="v1",le="2"}
+  - series: apiserver_request_duration_seconds_bucket{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="resource",subresource="",verb="POST",version="v1",le="2"}
     values: 0 0 0 0 0 0 1 100 100 100 100 
-  - series: apiserver_request_duration_seconds_bucket{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="namespace",subresource="",verb="POST",version="v1",le="+Inf"}
+  - series: apiserver_request_duration_seconds_bucket{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="resource",subresource="",verb="POST",version="v1",le="+Inf"}
     values: 0 0 0 0 0 0 1 101 101 101 101
-  - series: apiserver_request_duration_seconds_count{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="namespace",subresource="",verb="POST",version="v1"}
+  - series: apiserver_request_duration_seconds_count{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="resource",subresource="",verb="POST",version="v1"}
     values: 0 0 0 0 0 0 1 101 101 101 101

--- a/clusterloader2/pkg/measurement/common/slos/testdata/namespace_list_slo_failure.yaml
+++ b/clusterloader2/pkg/measurement/common/slos/testdata/namespace_list_slo_failure.yaml
@@ -1,8 +1,8 @@
 interval: 1m
 input_series:
-  - series: apiserver_request_duration_seconds_bucket{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="namespace",subresource="",verb="LIST",version="v1",le="5"}
+  - series: apiserver_request_duration_seconds_bucket{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="namespace",subresource="",verb="LIST",version="v1",le="45"}
     values: 0 0 0 0 0 0 1 71 71 71 71 
-  - series: apiserver_request_duration_seconds_bucket{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="namespace",subresource="",verb="LIST",version="v1",le="10"}
+  - series: apiserver_request_duration_seconds_bucket{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="namespace",subresource="",verb="LIST",version="v1",le="60"}
     values: 0 0 0 0 0 0 1 100 100 100 100 
   - series: apiserver_request_duration_seconds_bucket{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="namespace",subresource="",verb="LIST",version="v1",le="+Inf"}
     values: 0 0 0 0 0 0 1 101 101 101 101


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

1. Update thresholds to reflect updated api_call_latency SLO definition: https://github.com/kubernetes/community/blob/master/sig-scalability/slos/api_call_latency.md#definition
2. Fix/Simplify the getSLOThreshold() logic - before, it would not work for DELETECOLLETION (`verb:DELETE` `scope:namespace`).

**Which issue(s) this PR fixes**:
Fixes #1908

**Does this PR introduce a user-facing change?**:
Change tests classification criteria. 