### PR TITLE
Increase prometheus timeout

### DIFF
--- a/clusterloader2/pkg/measurement/util/prometheus.go
+++ b/clusterloader2/pkg/measurement/util/prometheus.go
@@ -33,7 +33,7 @@ import (
 )
 
 const (
-	queryTimeout  = 5 * time.Minute
+	queryTimeout  = 15 * time.Minute
 	queryInterval = 30 * time.Second
 )
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

We are seeing that in some cases, the stateful pod (like prometheus) can be rescheduled and it can take even ~7m to start again due to volume remounting/6m force disk detach timeout.

Let's increase timeout to avoid failing test when this happens.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```