### PR TITLE
Add GCP Compute API quotas usage measurement

### DIFF
--- a/clusterloader2/go.mod
+++ b/clusterloader2/go.mod
@@ -45,7 +45,8 @@ require (
 	github.com/prometheus/prometheus v1.8.2-0.20210331101223-3cafc58827d1
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.0
-	golang.org/x/net v0.0.0-20211020060615-d418f374d309 // indirect
+	golang.org/x/net v0.0.0-20211020060615-d418f374d309
+	golang.org/x/oauth2 v0.0.0-20210323180902-22b0adad7558
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac

--- a/clusterloader2/pkg/measurement/common/probes/probes.go
+++ b/clusterloader2/pkg/measurement/common/probes/probes.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/perf-tests/clusterloader2/pkg/measurement"
 	measurementutil "k8s.io/perf-tests/clusterloader2/pkg/measurement/util"
 	"k8s.io/perf-tests/clusterloader2/pkg/prometheus"
+	prom "k8s.io/perf-tests/clusterloader2/pkg/prometheus/clients"
 	"k8s.io/perf-tests/clusterloader2/pkg/util"
 )
 
@@ -203,7 +204,8 @@ func (p *probesMeasurement) gather(params map[string]interface{}) (measurement.S
 	measurementEnd := time.Now()
 
 	query := prepareQuery(p.config.Query, p.startTime, measurementEnd)
-	executor := measurementutil.NewQueryExecutor(p.framework.GetClientSets().GetClient())
+	pc := prom.NewInClusterPrometheusClient(p.framework.GetClientSets().GetClient())
+	executor := measurementutil.NewQueryExecutor(pc)
 	samples, err := executor.Query(query, measurementEnd)
 	if err != nil {
 		return nil, err

--- a/clusterloader2/pkg/prometheus/clients/gcp_managed.go
+++ b/clusterloader2/pkg/prometheus/clients/gcp_managed.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package prom
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"os"
+	"time"
+
+	"golang.org/x/oauth2/google"
+)
+
+// gcpManagedPrometheusClient talks to the Google Cloud Managed Service for Prometheus.
+// This only works if the cluster is hosted in GCP.
+// Details: https://cloud.google.com/stackdriver/docs/managed-prometheus.
+type gcpManagedPrometheusClient struct {
+	client *http.Client
+	uri    string
+}
+
+func (mpc *gcpManagedPrometheusClient) Query(query string, queryTime time.Time) ([]byte, error) {
+	params := url.Values{}
+	params.Add("query", query)
+	params.Add("time", queryTime.Format(time.RFC3339))
+	res, err := mpc.client.Get(mpc.uri + "?" + params.Encode())
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+	resBody, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return nil, err
+	}
+	return resBody, nil
+}
+
+// NewGCPManagedPrometheusClient returns an HTTP client for talking to
+// the Google Cloud Managed Service for Prometheus.
+func NewGCPManagedPrometheusClient() (Client, error) {
+	client, err := google.DefaultClient(context.TODO(), "https://www.googleapis.com/auth/monitoring.read")
+	if err != nil {
+		return nil, err
+	}
+	return &gcpManagedPrometheusClient{
+		client: client,
+		uri:    fmt.Sprintf("https://monitoring.googleapis.com/v1/projects/%s/location/global/prometheus/api/v1/query", os.Getenv("PROJECT")),
+	}, nil
+}
+
+var _ Client = &gcpManagedPrometheusClient{}

--- a/clusterloader2/pkg/prometheus/clients/in_cluster.go
+++ b/clusterloader2/pkg/prometheus/clients/in_cluster.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package prom
+
+import (
+	"context"
+	"time"
+
+	clientset "k8s.io/client-go/kubernetes"
+)
+
+// inClusterPrometheusClient talks to the Prometheus instance deployed in the test cluster.
+type inClusterPrometheusClient struct {
+	client clientset.Interface
+}
+
+func (icpc *inClusterPrometheusClient) Query(query string, queryTime time.Time) ([]byte, error) {
+	params := map[string]string{
+		"query": query,
+		"time":  queryTime.Format(time.RFC3339),
+	}
+	return icpc.client.CoreV1().
+		Services("monitoring").
+		ProxyGet("http", "prometheus-k8s", "9090", "api/v1/query", params).
+		DoRaw(context.TODO())
+}
+
+func NewInClusterPrometheusClient(c clientset.Interface) Client {
+	return &inClusterPrometheusClient{client: c}
+}
+
+var _ Client = &inClusterPrometheusClient{}

--- a/clusterloader2/pkg/prometheus/clients/interface.go
+++ b/clusterloader2/pkg/prometheus/clients/interface.go
@@ -1,0 +1,28 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package prom
+
+import (
+	"time"
+)
+
+// Client provides interface for communicating with the Prometheus API.
+type Client interface {
+	// Query sends a GET request to Prometheus with the "query" field
+	// in the URL's query string set using the provided arguments.
+	Query(query string, queryTime time.Time) ([]byte, error)
+}

--- a/clusterloader2/pkg/provider/aks.go
+++ b/clusterloader2/pkg/provider/aks.go
@@ -18,6 +18,7 @@ package provider
 
 import (
 	clientset "k8s.io/client-go/kubernetes"
+	prom "k8s.io/perf-tests/clusterloader2/pkg/prometheus/clients"
 )
 
 type AKSProvider struct {
@@ -60,4 +61,8 @@ func (p *AKSProvider) RunSSHCommand(cmd, host string) (string, string, int, erro
 
 func (p *AKSProvider) Metadata(client clientset.Interface) (map[string]string, error) {
 	return nil, nil
+}
+
+func (p *AKSProvider) GetManagedPrometheusClient() (prom.Client, error) {
+	return nil, ErrNoManagedPrometheus
 }

--- a/clusterloader2/pkg/provider/autopilot.go
+++ b/clusterloader2/pkg/provider/autopilot.go
@@ -19,6 +19,7 @@ package provider
 import (
 	clientset "k8s.io/client-go/kubernetes"
 	sshutil "k8s.io/kubernetes/test/e2e/framework/ssh"
+	prom "k8s.io/perf-tests/clusterloader2/pkg/prometheus/clients"
 )
 
 type AutopilotProvider struct {
@@ -65,4 +66,8 @@ func (p *AutopilotProvider) RunSSHCommand(cmd, host string) (string, string, int
 
 func (p *AutopilotProvider) Metadata(client clientset.Interface) (map[string]string, error) {
 	return nil, nil
+}
+
+func (p *AutopilotProvider) GetManagedPrometheusClient() (prom.Client, error) {
+	return prom.NewGCPManagedPrometheusClient()
 }

--- a/clusterloader2/pkg/provider/aws.go
+++ b/clusterloader2/pkg/provider/aws.go
@@ -19,6 +19,7 @@ package provider
 import (
 	clientset "k8s.io/client-go/kubernetes"
 	sshutil "k8s.io/kubernetes/test/e2e/framework/ssh"
+	prom "k8s.io/perf-tests/clusterloader2/pkg/prometheus/clients"
 )
 
 type AWSProvider struct {
@@ -63,4 +64,8 @@ func (p *AWSProvider) RunSSHCommand(cmd, host string) (string, string, int, erro
 
 func (p *AWSProvider) Metadata(client clientset.Interface) (map[string]string, error) {
 	return nil, nil
+}
+
+func (p *AWSProvider) GetManagedPrometheusClient() (prom.Client, error) {
+	return nil, ErrNoManagedPrometheus
 }

--- a/clusterloader2/pkg/provider/eks.go
+++ b/clusterloader2/pkg/provider/eks.go
@@ -19,6 +19,7 @@ package provider
 import (
 	clientset "k8s.io/client-go/kubernetes"
 	sshutil "k8s.io/kubernetes/test/e2e/framework/ssh"
+	prom "k8s.io/perf-tests/clusterloader2/pkg/prometheus/clients"
 )
 
 type EKSProvider struct {
@@ -62,4 +63,8 @@ func (p *EKSProvider) RunSSHCommand(cmd, host string) (string, string, int, erro
 
 func (p *EKSProvider) Metadata(client clientset.Interface) (map[string]string, error) {
 	return nil, nil
+}
+
+func (p *EKSProvider) GetManagedPrometheusClient() (prom.Client, error) {
+	return nil, ErrNoManagedPrometheus
 }

--- a/clusterloader2/pkg/provider/gce.go
+++ b/clusterloader2/pkg/provider/gce.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/klog"
 	sshutil "k8s.io/kubernetes/test/e2e/framework/ssh"
 	"k8s.io/perf-tests/clusterloader2/pkg/framework/client"
+	prom "k8s.io/perf-tests/clusterloader2/pkg/prometheus/clients"
 	"k8s.io/perf-tests/clusterloader2/pkg/util"
 )
 
@@ -107,4 +108,8 @@ func (p *GCEProvider) Metadata(c clientset.Interface) (map[string]string, error)
 	}
 
 	return map[string]string{"masterInstanceIDs": strings.Join(masterInstanceIDs, ",")}, nil
+}
+
+func (p *GCEProvider) GetManagedPrometheusClient() (prom.Client, error) {
+	return prom.NewGCPManagedPrometheusClient()
 }

--- a/clusterloader2/pkg/provider/gke.go
+++ b/clusterloader2/pkg/provider/gke.go
@@ -19,6 +19,7 @@ package provider
 import (
 	clientset "k8s.io/client-go/kubernetes"
 	sshutil "k8s.io/kubernetes/test/e2e/framework/ssh"
+	prom "k8s.io/perf-tests/clusterloader2/pkg/prometheus/clients"
 )
 
 type GKEProvider struct {
@@ -65,4 +66,8 @@ func (p *GKEProvider) RunSSHCommand(cmd, host string) (string, string, int, erro
 
 func (p *GKEProvider) Metadata(client clientset.Interface) (map[string]string, error) {
 	return nil, nil
+}
+
+func (p *GKEProvider) GetManagedPrometheusClient() (prom.Client, error) {
+	return prom.NewGCPManagedPrometheusClient()
 }

--- a/clusterloader2/pkg/provider/gke_kubemark.go
+++ b/clusterloader2/pkg/provider/gke_kubemark.go
@@ -20,6 +20,7 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/klog"
 	sshutil "k8s.io/kubernetes/test/e2e/framework/ssh"
+	prom "k8s.io/perf-tests/clusterloader2/pkg/prometheus/clients"
 )
 
 type GKEKubemarkProvider struct {
@@ -70,4 +71,8 @@ func (p *GKEKubemarkProvider) RunSSHCommand(cmd, host string) (string, string, i
 
 func (p *GKEKubemarkProvider) Metadata(client clientset.Interface) (map[string]string, error) {
 	return nil, nil
+}
+
+func (p *GKEKubemarkProvider) GetManagedPrometheusClient() (prom.Client, error) {
+	return prom.NewGCPManagedPrometheusClient()
 }

--- a/clusterloader2/pkg/provider/kcp.go
+++ b/clusterloader2/pkg/provider/kcp.go
@@ -18,6 +18,7 @@ package provider
 
 import (
 	clientset "k8s.io/client-go/kubernetes"
+	prom "k8s.io/perf-tests/clusterloader2/pkg/prometheus/clients"
 )
 
 type KCPProvider struct {
@@ -60,4 +61,8 @@ func (p *KCPProvider) RunSSHCommand(cmd, host string) (string, string, int, erro
 
 func (p *KCPProvider) Metadata(client clientset.Interface) (map[string]string, error) {
 	return nil, nil
+}
+
+func (p *KCPProvider) GetManagedPrometheusClient() (prom.Client, error) {
+	return nil, ErrNoManagedPrometheus
 }

--- a/clusterloader2/pkg/provider/kind.go
+++ b/clusterloader2/pkg/provider/kind.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	clientset "k8s.io/client-go/kubernetes"
+	prom "k8s.io/perf-tests/clusterloader2/pkg/prometheus/clients"
 )
 
 type KindProvider struct {
@@ -65,4 +66,8 @@ func (p *KindProvider) RunSSHCommand(cmd, host string) (string, string, int, err
 
 func (p *KindProvider) Metadata(client clientset.Interface) (map[string]string, error) {
 	return nil, nil
+}
+
+func (p *KindProvider) GetManagedPrometheusClient() (prom.Client, error) {
+	return nil, ErrNoManagedPrometheus
 }

--- a/clusterloader2/pkg/provider/kubemark.go
+++ b/clusterloader2/pkg/provider/kubemark.go
@@ -20,6 +20,7 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/klog"
 	sshutil "k8s.io/kubernetes/test/e2e/framework/ssh"
+	prom "k8s.io/perf-tests/clusterloader2/pkg/prometheus/clients"
 )
 
 type KubemarkProvider struct {
@@ -71,4 +72,8 @@ func (p *KubemarkProvider) RunSSHCommand(cmd, host string) (string, string, int,
 // TODO(mborsz): Dump instanceIDs for master nodes (as in gce).
 func (p *KubemarkProvider) Metadata(client clientset.Interface) (map[string]string, error) {
 	return nil, nil
+}
+
+func (p *KubemarkProvider) GetManagedPrometheusClient() (prom.Client, error) {
+	return nil, ErrNoManagedPrometheus
 }

--- a/clusterloader2/pkg/provider/local.go
+++ b/clusterloader2/pkg/provider/local.go
@@ -19,6 +19,7 @@ package provider
 import (
 	clientset "k8s.io/client-go/kubernetes"
 	sshutil "k8s.io/kubernetes/test/e2e/framework/ssh"
+	prom "k8s.io/perf-tests/clusterloader2/pkg/prometheus/clients"
 )
 
 type LocalProvider struct {
@@ -64,4 +65,8 @@ func (p *LocalProvider) RunSSHCommand(cmd, host string) (string, string, int, er
 
 func (p *LocalProvider) Metadata(client clientset.Interface) (map[string]string, error) {
 	return nil, nil
+}
+
+func (p *LocalProvider) GetManagedPrometheusClient() (prom.Client, error) {
+	return nil, ErrNoManagedPrometheus
 }

--- a/clusterloader2/pkg/provider/provider.go
+++ b/clusterloader2/pkg/provider/provider.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	clientset "k8s.io/client-go/kubernetes"
+	prom "k8s.io/perf-tests/clusterloader2/pkg/prometheus/clients"
 )
 
 // InitOptions encapsulates the fields needed to init provider.
@@ -85,6 +86,9 @@ type Provider interface {
 	Features() *Features
 
 	GetConfig() Config
+
+	// GetManagedPrometheusClient returns HTTP client for communicating with the relevant cloud provider's managed Prometheus service.
+	GetManagedPrometheusClient() (prom.Client, error)
 
 	// GetComponentProtocolAndPort returns the protocol and port for the control plane components.
 	GetComponentProtocolAndPort(componentName string) (string, int, error)

--- a/clusterloader2/pkg/provider/skeleton.go
+++ b/clusterloader2/pkg/provider/skeleton.go
@@ -19,6 +19,7 @@ package provider
 import (
 	clientset "k8s.io/client-go/kubernetes"
 	sshutil "k8s.io/kubernetes/test/e2e/framework/ssh"
+	prom "k8s.io/perf-tests/clusterloader2/pkg/prometheus/clients"
 )
 
 type SkeletonProvider struct {
@@ -67,4 +68,8 @@ func (p *SkeletonProvider) RunSSHCommand(cmd, host string) (string, string, int,
 
 func (p *SkeletonProvider) Metadata(client clientset.Interface) (map[string]string, error) {
 	return nil, nil
+}
+
+func (p *SkeletonProvider) GetManagedPrometheusClient() (prom.Client, error) {
+	return nil, ErrNoManagedPrometheus
 }

--- a/clusterloader2/pkg/provider/util.go
+++ b/clusterloader2/pkg/provider/util.go
@@ -17,9 +17,14 @@ limitations under the License.
 package provider
 
 import (
+	"errors"
 	"fmt"
 
 	sshutil "k8s.io/kubernetes/test/e2e/framework/ssh"
+)
+
+var (
+	ErrNoManagedPrometheus = errors.New("no managed Prometheus service for this cloud provider")
 )
 
 func getComponentProtocolAndPort(componentName string) (string, int, error) {

--- a/clusterloader2/pkg/provider/vsphere.go
+++ b/clusterloader2/pkg/provider/vsphere.go
@@ -19,6 +19,7 @@ package provider
 import (
 	clientset "k8s.io/client-go/kubernetes"
 	sshutil "k8s.io/kubernetes/test/e2e/framework/ssh"
+	prom "k8s.io/perf-tests/clusterloader2/pkg/prometheus/clients"
 )
 
 type VsphereProvider struct {
@@ -64,4 +65,8 @@ func (p *VsphereProvider) RunSSHCommand(cmd, host string) (string, string, int, 
 
 func (p *VsphereProvider) Metadata(client clientset.Interface) (map[string]string, error) {
 	return nil, nil
+}
+
+func (p *VsphereProvider) GetManagedPrometheusClient() (prom.Client, error) {
+	return nil, ErrNoManagedPrometheus
 }

--- a/clusterloader2/testing/load/modules/measurements.yaml
+++ b/clusterloader2/testing/load/modules/measurements.yaml
@@ -21,6 +21,7 @@
 {{$CEP_PROPAGATION_DELAY_SLO_PERCENTILE := DefaultParam .CL2_CEP_PROPAGATION_DELAY_SLO_PERCENTILE 95.0}}
 {{$ENABLE_CONTAINER_RESTARTS_MEASUREMENT := DefaultParam .CL2_ENABLE_CONTAINER_RESTARTS_MEASUREMENT false}}
 {{$ENABLE_CONTAINER_RESOURCES_MEASUREMENT := DefaultParam .CL2_ENABLE_CONTAINER_RESOURCES_MEASUREMENT false}}
+{{$ENABLE_QUOTAS_USAGE_MEASUREMENT := DefaultParam .CL2_ENABLE_QUOTAS_USAGE_MEASUREMENT false}}
 {{$ALLOWED_CONTAINER_RESTARTS := DefaultParam .CL2_ALLOWED_CONTAINER_RESTARTS 1}}
 {{$CUSTOM_ALLOWED_CONTAINER_RESTARTS := DefaultParam .CL2_CUSTOM_ALLOWED_CONTAINER_RESTARTS ""}}
 {{$NODE_LOCAL_DNS_LATENCY_THRESHOLD := DefaultParam .CL2_NODE_LOCAL_DNS_LATENCY_THRESHOLD "5s"}}
@@ -150,6 +151,23 @@ steps:
         query: quantile_over_time(0.90, sum by (container) (container_memory_working_set_bytes / 1024 / 1024)[%v:])
       - name: Perc50
         query: quantile_over_time(0.50, sum by (container) (container_memory_working_set_bytes / 1024 / 1024)[%v:])
+{{end}}
+{{if $ENABLE_QUOTAS_USAGE_MEASUREMENT}}
+  - Identifier: Quotas total usage
+    Method: GenericPrometheusQuery
+    Params:
+      action: {{$action}}
+      metricName: Quota usage
+      metricVersion: v1
+      prometheusClient: managed
+      unit: QPMs
+      dimensions:
+      - quota_metric
+      queries:
+      - name: perc99
+        query: quantile_over_time(0.99, sum by (quota_metric) (irate(serviceruntime_googleapis_com:quota_rate_net_usage{monitored_resource="consumer_quota"}[1m]))[%v:]) * 60
+      - name: max
+        query: max_over_time(sum by (quota_metric) (irate(serviceruntime_googleapis_com:quota_rate_net_usage{monitored_resource="consumer_quota"}[1m]))[%v:]) * 60
 {{end}}
 {{if $ENABLE_CEP_PROPAGATION_DELAY_MEASUREMENT}}
   - Identifier: CiliumEndpointPropagationDelay


### PR DESCRIPTION
This change adds a GCE-related API quotas usage measurement to the `load` test.

Underneath, we extend the CL2's capabilities to use the [Google Cloud Managed Service for Prometheus](https://cloud.google.com/stackdriver/docs/managed-prometheus) as a backend instead of the in-cluster Prometheus instance. This backend be enabled through `prometheusClient: managed` parameter in the Prometheus-based measurements' params in the test scenario config and works only for a limited number of providers.

/sig scalability