### PR TITLE
Enable violations for the advanced DNS test

### DIFF
--- a/clusterloader2/testing/load/modules/measurements.yaml
+++ b/clusterloader2/testing/load/modules/measurements.yaml
@@ -198,6 +198,7 @@ steps:
       metricName: DNS Performance
       metricVersion: v1
       unit: s
+      enableViolations: true
       queries:
       - name: DNS Lookup Count
         query: sum(increase(dns_lookups_total[%v]))


### PR DESCRIPTION
The tests should fail when the DNS latency or error thresholds are exceeded.

/kind feature
/assign @marseel