### PR TITLE
Retry transient http2 errors

### DIFF
--- a/clusterloader2/pkg/framework/client/objects.go
+++ b/clusterloader2/pkg/framework/client/objects.go
@@ -47,6 +47,10 @@ const (
 	// Parameters for namespace deletion operations.
 	defaultNamespaceDeletionTimeout  = 10 * time.Minute
 	defaultNamespaceDeletionInterval = 5 * time.Second
+
+	// String const defined in https://go.googlesource.com/net/+/749bd193bc2bcebc5f1a048da8af0392cfb2fa5d/http2/transport.go#1041
+	// TODO(mborsz): Migrate to error object comparison when the error type is exported.
+	http2ClientConnectionLostErr = "http2: client connection lost"
 )
 
 // RetryWithExponentialBackOff a utility for retrying the given function with exponential backoff.
@@ -93,6 +97,10 @@ func isResourceQuotaConflictError(err error) bool {
 func IsRetryableNetError(err error) bool {
 	if netError, ok := err.(net.Error); ok {
 		return netError.Temporary() || netError.Timeout()
+	}
+
+	if err.Error() == http2ClientConnectionLostErr {
+		return true
 	}
 	return false
 }

--- a/clusterloader2/pkg/framework/client/objects_test.go
+++ b/clusterloader2/pkg/framework/client/objects_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package client
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
@@ -93,6 +94,32 @@ func TestIsRetryableAPIError(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			if got := IsRetryableAPIError(tc.err); tc.want != got {
 				t.Errorf("want: %v, got: %v", tc.want, got)
+			}
+		})
+	}
+}
+
+func TestIsRetryableNetError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "http2: client connection lost",
+			err:  errors.New("http2: client connection lost"),
+			want: true,
+		},
+		{
+			name: "http2: some other error",
+			err:  errors.New("http2: some other error"),
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsRetryableNetError(tt.err); got != tt.want {
+				t.Errorf("IsRetryableNetError() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
We rarely see "http2: client connection lost" error which means that ping for a given connection has timed out. Based on what we see it is usually transient issue and further calls seems to work fine.

Let's not fail the test on this error.

/assign @marseel 