### PR TITLE
Pass StepResult only as pointer as it contains lock which cannot be copied

### DIFF
--- a/clusterloader2/pkg/test/interface.go
+++ b/clusterloader2/pkg/test/interface.go
@@ -78,6 +78,6 @@ type Reporter interface {
 	BeginTestSuite()
 	EndTestSuite()
 	ReportTestStepFinish(duration time.Duration, stepName string, errList *errors.ErrorList)
-	ReportTestStep(result StepResult)
+	ReportTestStep(result *StepResult)
 	ReportTestFinish(duration time.Duration, testConfigPath string, errList *errors.ErrorList)
 }

--- a/clusterloader2/pkg/test/simple_reporter.go
+++ b/clusterloader2/pkg/test/simple_reporter.go
@@ -70,7 +70,7 @@ func (str *simpleReporter) ReportTestStepFinish(duration time.Duration, stepName
 	str.stepsSummaries = append(str.stepsSummaries, stepSummary)
 }
 
-func (str *simpleReporter) ReportTestStep(result StepResult) {
+func (str *simpleReporter) ReportTestStep(result *StepResult) {
 	for _, subtestResult := range result.getAllResults() {
 		str.ReportTestStepFinish(subtestResult.duration, subtestResult.name, subtestResult.err)
 	}

--- a/clusterloader2/pkg/test/step_summary.go
+++ b/clusterloader2/pkg/test/step_summary.go
@@ -40,8 +40,8 @@ type StepResult struct {
 	results []substepResult
 }
 
-func NewStepResult(stepName string) StepResult {
-	return StepResult{
+func NewStepResult(stepName string) *StepResult {
+	return &StepResult{
 		name:      stepName,
 		startTime: time.Now(),
 		results:   []substepResult{},


### PR DESCRIPTION
We copy the StepResult in multiple places which doesn't make sense as we have a lock inside, which cannot be copied.

/assign @marseel 