### PR TITLE
Cleanup of WaitForPods

### DIFF
--- a/clusterloader2/pkg/execservice/exec_service.go
+++ b/clusterloader2/pkg/execservice/exec_service.go
@@ -102,17 +102,16 @@ func SetUpExecService(f *framework.Framework, c config.ExecServiceConfig) error 
 		FieldSelector: "",
 	}
 	options := &measurementutil.WaitForPodOptions{
-		Selector:            selector,
 		DesiredPodCount:     func() int { return execPodReplicas },
 		CallerName:          execServiceName,
 		WaitForPodsInterval: execPodCheckInterval,
 	}
-	if err = measurementutil.WaitForPods(f.GetClientSets().GetClient(), stopCh, options); err != nil {
-		return err
-	}
 	podStore, err = measurementutil.NewPodStore(f.GetClientSets().GetClient(), selector)
 	if err != nil {
 		return fmt.Errorf("pod store creation error: %v", err)
+	}
+	if err = measurementutil.WaitForPods(podStore, stopCh, options); err != nil {
+		return err
 	}
 	klog.V(2).Infof("%v: service set up successfully!", execServiceName)
 	return nil

--- a/clusterloader2/pkg/measurement/common/wait_for_pods.go
+++ b/clusterloader2/pkg/measurement/common/wait_for_pods.go
@@ -65,12 +65,15 @@ func (w *waitForRunningPodsMeasurement) Execute(config *measurement.Config) ([]m
 		close(stopCh)
 	})
 	options := &measurementutil.WaitForPodOptions{
-		Selector:            selector,
 		DesiredPodCount:     func() int { return desiredPodCount },
 		CallerName:          w.String(),
 		WaitForPodsInterval: defaultWaitForPodsInterval,
 	}
-	return nil, measurementutil.WaitForPods(config.ClusterFramework.GetClientSets().GetClient(), stopCh, options)
+	podStore, err := measurementutil.NewPodStore(config.ClusterFramework.GetClientSets().GetClient(), selector)
+	if err != nil {
+		return nil, err
+	}
+	return nil, measurementutil.WaitForPods(podStore, stopCh, options)
 }
 
 // Dispose cleans up after the measurement.

--- a/clusterloader2/pkg/measurement/util/runtimeobjects/runtimeobjects_test.go
+++ b/clusterloader2/pkg/measurement/util/runtimeobjects/runtimeobjects_test.go
@@ -336,37 +336,6 @@ func TestGetResourceVersionFromRuntimeObject(t *testing.T) {
 	}
 }
 
-func TestGetSelectorFromRuntimeObject(t *testing.T) {
-	objects := []runtime.Object{
-		replicationcontroller,
-		replicaset,
-		deployment,
-		job,
-		daemonset,
-	}
-
-	ps := &metav1.LabelSelector{
-		MatchLabels: simpleLabel,
-	}
-	expected, err := metav1.LabelSelectorAsSelector(ps)
-	if err != nil {
-		t.Fatalf("create label selector failed: %v", err)
-	}
-	for _, obj := range objects {
-		unstructured := &unstructured.Unstructured{}
-		if err := scheme.Scheme.Convert(obj, unstructured, nil); err != nil {
-			t.Fatalf("error converting controller to unstructured: %v", err)
-		}
-		selector, err := runtimeobjects.GetSelectorFromRuntimeObject(unstructured)
-		if err != nil {
-			t.Fatalf("get selector from runtime object failed: %v", err)
-		}
-
-		if !reflect.DeepEqual(expected, selector) {
-			t.Fatalf("Unexpected selector from runtime object, expected: %d, actual: %d", expected, selector)
-		}
-	}
-}
 func TestGetSpecFromRuntimeObject(t *testing.T) {
 	objects := []runtime.Object{
 		replicationcontroller,

--- a/clusterloader2/pkg/measurement/util/wait_for_pods.go
+++ b/clusterloader2/pkg/measurement/util/wait_for_pods.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	v1 "k8s.io/api/core/v1"
-	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/klog"
 )
 
@@ -35,7 +34,6 @@ const (
 
 // WaitForPodOptions is an options used by WaitForPods methods.
 type WaitForPodOptions struct {
-	Selector            *ObjectSelector
 	DesiredPodCount     func() int
 	CountErrorMargin    int
 	CallerName          string
@@ -46,27 +44,15 @@ type WaitForPodOptions struct {
 	IsPodUpdated func(*v1.Pod) error
 }
 
-// WaitForPods waits till desired number of pods is running.
-// Pods are be specified by namespace, field and/or label selectors.
-// If stopCh is closed before all pods are running, the error will be returned.
-func WaitForPods(clientSet clientset.Interface, stopCh <-chan struct{}, options *WaitForPodOptions) error {
-	ps, err := NewPodStore(clientSet, options.Selector)
-	if err != nil {
-		return fmt.Errorf("pod store creation error: %v", err)
-	}
-	defer ps.Stop()
-
-	return WaitForPodsWithLister(ps, stopCh, options)
-}
-
 // PodLister is an interface around listing pods.
 type PodLister interface {
 	List() ([]*v1.Pod, error)
+	String() string
 }
 
-// WaitForPodWithStore waits till desired number of pods is running.
+// WaitForPods waits till desired number of pods is running.
 // The current set of pods are fetched by calling List() on the provided PodStore.
-func WaitForPodsWithLister(ps PodLister, stopCh <-chan struct{}, options *WaitForPodOptions) error {
+func WaitForPods(ps PodLister, stopCh <-chan struct{}, options *WaitForPodOptions) error {
 	oldPods, err := ps.List()
 	if err != nil {
 		return fmt.Errorf("failed to list pods: %w", err)
@@ -80,11 +66,11 @@ func WaitForPodsWithLister(ps PodLister, stopCh <-chan struct{}, options *WaitFo
 		case <-stopCh:
 			desiredPodCount := options.DesiredPodCount()
 			pods := ComputePodsStatus(oldPods)
-			klog.V(2).Infof("%s: %s: expected %d pods, got %d pods (not RunningAndReady pods: %v)", options.CallerName, options.Selector.String(), desiredPodCount, len(oldPods), pods.NotRunningAndReady())
-			klog.V(2).Infof("%s: %s: all pods: %v", options.CallerName, options.Selector.String(), pods)
-			klog.V(2).Infof("%s: %s: last IsPodUpdated error: %v", options.CallerName, options.Selector.String(), lastIsPodUpdatedError)
-			return fmt.Errorf("timeout while waiting for %d pods to be running in namespace '%v' with labels '%v' and fields '%v' - summary of pods : %s",
-				desiredPodCount, options.Selector.Namespace, options.Selector.LabelSelector, options.Selector.FieldSelector, podsStatus.String())
+			klog.V(2).Infof("%s: %s: expected %d pods, got %d pods (not RunningAndReady pods: %v)", options.CallerName, ps.String(), desiredPodCount, len(oldPods), pods.NotRunningAndReady())
+			klog.V(2).Infof("%s: %s: all pods: %v", options.CallerName, ps.String(), pods)
+			klog.V(2).Infof("%s: %s: last IsPodUpdated error: %v", options.CallerName, ps.String(), lastIsPodUpdatedError)
+			return fmt.Errorf("timeout while waiting for %d pods to be running in %s - summary of pods : %s",
+				desiredPodCount, ps.String(), podsStatus.String())
 		case <-time.After(options.WaitForPodsInterval):
 			desiredPodCount := options.DesiredPodCount()
 
@@ -109,13 +95,13 @@ func WaitForPodsWithLister(ps PodLister, stopCh <-chan struct{}, options *WaitFo
 			diff := DiffPods(oldPods, pods)
 			deletedPods := diff.DeletedPods()
 			if scaling != down && len(deletedPods) > 0 {
-				klog.Errorf("%s: %s: %d pods disappeared: %v", options.CallerName, options.Selector.String(), len(deletedPods), strings.Join(deletedPods, ", "))
+				klog.Errorf("%s: %s: %d pods disappeared: %v", options.CallerName, ps.String(), len(deletedPods), strings.Join(deletedPods, ", "))
 			}
 			addedPods := diff.AddedPods()
 			if scaling != up && len(addedPods) > 0 {
-				klog.Errorf("%s: %s: %d pods appeared: %v", options.CallerName, options.Selector.String(), len(addedPods), strings.Join(addedPods, ", "))
+				klog.Errorf("%s: %s: %d pods appeared: %v", options.CallerName, ps.String(), len(addedPods), strings.Join(addedPods, ", "))
 			}
-			klog.V(2).Infof("%s: %s: %s", options.CallerName, options.Selector.String(), podsStatus.String())
+			klog.V(2).Infof("%s: %s: %s", options.CallerName, ps.String(), podsStatus.String())
 			// We allow inactive pods (e.g. eviction happened).
 			// We wait until there is a desired number of pods running and all other pods are inactive.
 			if len(pods) == (podsStatus.Running+podsStatus.Inactive) && podsStatus.Running == podsStatus.RunningUpdated && podsStatus.RunningUpdated == desiredPodCount {


### PR DESCRIPTION
Few changes:
* Rename WaitForPodsWithLister to WaitForPods
* Remove Selector from WaitForPodOptions (as in the current state it doesn't need to match podStore, which may be misleading), as it's used only for providing human readable identifier of pods (this is being moved to PodLister interface).
* Remove GetSelectorFromRuntimeObject which is no longer used anywhere

/assign @wojtek-t 