### PR TITLE
Replace runtimeobjects.CreateMetaNamespaceKey with KeyFunc from cache package.

### DIFF
--- a/clusterloader2/pkg/measurement/common/service_creation_latency.go
+++ b/clusterloader2/pkg/measurement/common/service_creation_latency.go
@@ -37,7 +37,6 @@ import (
 	measurementutil "k8s.io/perf-tests/clusterloader2/pkg/measurement/util"
 	"k8s.io/perf-tests/clusterloader2/pkg/measurement/util/checker"
 	"k8s.io/perf-tests/clusterloader2/pkg/measurement/util/informer"
-	"k8s.io/perf-tests/clusterloader2/pkg/measurement/util/runtimeobjects"
 	"k8s.io/perf-tests/clusterloader2/pkg/measurement/util/workerqueue"
 	"k8s.io/perf-tests/clusterloader2/pkg/util"
 )
@@ -257,7 +256,7 @@ func (s *serviceCreationLatencyMeasurement) handleObject(oldObj, newObj interfac
 }
 
 func (s *serviceCreationLatencyMeasurement) deleteObject(svc *corev1.Service) error {
-	key, err := runtimeobjects.CreateMetaNamespaceKey(svc)
+	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(svc)
 	if err != nil {
 		return fmt.Errorf("meta key created error: %v", err)
 	}
@@ -272,7 +271,7 @@ func (s *serviceCreationLatencyMeasurement) updateObject(svc *corev1.Service) er
 	if svc.Spec.Type != corev1.ServiceTypeClusterIP && svc.Spec.Type != corev1.ServiceTypeNodePort && svc.Spec.Type != corev1.ServiceTypeLoadBalancer {
 		return nil
 	}
-	key, err := runtimeobjects.CreateMetaNamespaceKey(svc)
+	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(svc)
 	if err != nil {
 		return fmt.Errorf("meta key created error: %v", err)
 	}
@@ -315,7 +314,7 @@ type pingChecker struct {
 }
 
 func (p *pingChecker) run() {
-	key, err := runtimeobjects.CreateMetaNamespaceKey(p.svc)
+	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(p.svc)
 	if err != nil {
 		klog.Errorf("%s: meta key created error: %v", p.callerName, err)
 		return

--- a/clusterloader2/pkg/measurement/common/wait_for_controlled_pods.go
+++ b/clusterloader2/pkg/measurement/common/wait_for_controlled_pods.go
@@ -430,7 +430,7 @@ func (w *waitForControlledPodsRunningMeasurement) handleObjectLocked(oldObj, new
 	if isObjDeleted {
 		handledObj = oldObj
 	}
-	key, err := runtimeobjects.CreateMetaNamespaceKey(handledObj)
+	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(handledObj)
 	if err != nil {
 		return fmt.Errorf("meta key creation error: %v", err)
 	}
@@ -456,7 +456,7 @@ func (w *waitForControlledPodsRunningMeasurement) deleteObjectLocked(obj runtime
 	if obj == nil {
 		return nil
 	}
-	key, err := runtimeobjects.CreateMetaNamespaceKey(obj)
+	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
 	if err != nil {
 		return fmt.Errorf("meta key creation error: %v", err)
 	}
@@ -558,7 +558,7 @@ func (w *waitForControlledPodsRunningMeasurement) waitForRuntimeObject(obj runti
 	if isDeleted {
 		runtimeObjectReplicas = &runtimeobjects.ConstReplicas{0}
 	}
-	key, err := runtimeobjects.CreateMetaNamespaceKey(obj)
+	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
 	if err != nil {
 		return nil, fmt.Errorf("meta key creation error: %v", err)
 	}

--- a/clusterloader2/pkg/measurement/common/wait_for_jobs.go
+++ b/clusterloader2/pkg/measurement/common/wait_for_jobs.go
@@ -37,7 +37,6 @@ import (
 	"k8s.io/perf-tests/clusterloader2/pkg/measurement"
 	measurementutil "k8s.io/perf-tests/clusterloader2/pkg/measurement/util"
 	"k8s.io/perf-tests/clusterloader2/pkg/measurement/util/informer"
-	"k8s.io/perf-tests/clusterloader2/pkg/measurement/util/runtimeobjects"
 	"k8s.io/perf-tests/clusterloader2/pkg/measurement/util/workerqueue"
 	"k8s.io/perf-tests/clusterloader2/pkg/util"
 )
@@ -214,7 +213,7 @@ func (w *waitForFinishedJobsMeasurement) handleObject(oldObj, newObj interface{}
 	if newJob == nil {
 		handleJob = oldJob
 	}
-	key, err := runtimeobjects.CreateMetaNamespaceKey(handleJob)
+	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(handleJob)
 	if err != nil {
 		klog.Errorf("Failed obtaining meta key for Job: %v", err)
 		return
@@ -241,7 +240,7 @@ func (w *waitForFinishedJobsMeasurement) jobKeys() (sets.String, error) {
 	}
 	keys := sets.NewString()
 	for _, j := range objs.Items {
-		key, err := runtimeobjects.CreateMetaNamespaceKey(&j)
+		key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(&j)
 		if err != nil {
 			return nil, fmt.Errorf("getting key for Job: %w", err)
 		}

--- a/clusterloader2/pkg/measurement/util/runtimeobjects/runtimeobjects.go
+++ b/clusterloader2/pkg/measurement/util/runtimeobjects/runtimeobjects.go
@@ -65,20 +65,6 @@ func ListRuntimeObjectsForKind(d dynamic.Interface, gvr schema.GroupVersionResou
 	return runtimeObjectsList, nil
 }
 
-// GetNameFromRuntimeObject returns name of given runtime object.
-func GetNameFromRuntimeObject(obj runtime.Object) (string, error) {
-	switch typed := obj.(type) {
-	case *unstructured.Unstructured:
-		return typed.GetName(), nil
-	default:
-		metaObjectAccessor, ok := obj.(metav1.ObjectMetaAccessor)
-		if !ok {
-			return "", fmt.Errorf("unsupported kind when getting name: %v", obj)
-		}
-		return metaObjectAccessor.GetObjectMeta().GetName(), nil
-	}
-}
-
 // GetResourceVersionFromRuntimeObject returns resource version of given runtime object.
 func GetResourceVersionFromRuntimeObject(obj runtime.Object) (uint64, error) {
 	accessor, err := meta.Accessor(obj)
@@ -90,20 +76,6 @@ func GetResourceVersionFromRuntimeObject(obj runtime.Object) (uint64, error) {
 		return 0, nil
 	}
 	return strconv.ParseUint(version, 10, 64)
-}
-
-// GetNamespaceFromRuntimeObject returns namespace of given runtime object.
-func GetNamespaceFromRuntimeObject(obj runtime.Object) (string, error) {
-	switch typed := obj.(type) {
-	case *unstructured.Unstructured:
-		return typed.GetNamespace(), nil
-	default:
-		metaObjectAccessor, ok := obj.(metav1.ObjectMetaAccessor)
-		if !ok {
-			return "", fmt.Errorf("unsupported kind when getting namespace: %v", obj)
-		}
-		return metaObjectAccessor.GetObjectMeta().GetNamespace(), nil
-	}
 }
 
 // GetIsPodUpdatedPredicateFromRuntimeObject returns a func(*corev1.Pod) bool predicate
@@ -309,19 +281,6 @@ func IsEqualRuntimeObjectsSpec(runtimeObj1, runtimeObj2 runtime.Object) (bool, e
 	}
 
 	return equality.Semantic.DeepEqual(runtimeObj1Spec, runtimeObj2Spec), nil
-}
-
-// CreateMetaNamespaceKey returns meta key (namespace/name) for given runtime object.
-func CreateMetaNamespaceKey(obj runtime.Object) (string, error) {
-	namespace, err := GetNamespaceFromRuntimeObject(obj)
-	if err != nil {
-		return "", fmt.Errorf("retrieving namespace error: %v", err)
-	}
-	name, err := GetNameFromRuntimeObject(obj)
-	if err != nil {
-		return "", fmt.Errorf("retrieving name error: %v", err)
-	}
-	return namespace + "/" + name, nil
 }
 
 // GetNumObjectsMatchingSelector returns number of objects matching the given selector.

--- a/clusterloader2/pkg/measurement/util/runtimeobjects/runtimeobjects_test.go
+++ b/clusterloader2/pkg/measurement/util/runtimeobjects/runtimeobjects_test.go
@@ -263,55 +263,6 @@ func allocatableResources(memory, cpu string) v1.ResourceList {
 	}
 }
 
-func TestGetNameFromRuntimeObject(t *testing.T) {
-	objects := []runtime.Object{
-		replicationcontroller,
-		replicaset,
-		deployment,
-		job,
-		daemonset,
-	}
-
-	for _, obj := range objects {
-		unstructured := &unstructured.Unstructured{}
-		if err := scheme.Scheme.Convert(obj, unstructured, nil); err != nil {
-			t.Fatalf("error converting controller to unstructured: %v", err)
-		}
-		name, err := runtimeobjects.GetNameFromRuntimeObject(unstructured)
-		if err != nil {
-			t.Fatalf("get name from runtime object failed: %v", err)
-		}
-
-		if controllerName != name {
-			t.Fatalf("Unexpected name from runtime object, expected: %s, actual: %s", controllerName, name)
-		}
-	}
-}
-
-func TestGetNamespaceFromRuntimeObject(t *testing.T) {
-	objects := []runtime.Object{
-		replicationcontroller,
-		replicaset,
-		deployment,
-		job,
-		daemonset,
-	}
-	for _, obj := range objects {
-		unstructured := &unstructured.Unstructured{}
-		if err := scheme.Scheme.Convert(obj, unstructured, nil); err != nil {
-			t.Fatalf("error converting controller to unstructured: %v", err)
-		}
-		namespace, err := runtimeobjects.GetNamespaceFromRuntimeObject(unstructured)
-		if err != nil {
-			t.Fatalf("get namespace from runtime object failed: %v", err)
-		}
-
-		if testNamespace != namespace {
-			t.Fatalf("Unexpected namespace from runtime object, expected: %s, actual: %s", testNamespace, namespace)
-		}
-	}
-}
-
 func TestGetResourceVersionFromRuntimeObject(t *testing.T) {
 	objects := []runtime.Object{
 		replicationcontroller,


### PR DESCRIPTION
It looks like CL2 tries to duplicate logic we already have in cache package and which is widely used in kubernetes already.

Let's get rid of this custom code. This PR also removes other dead code: GetNameFromRuntimeObject and GetNamespaceFromRuntimeObject, which are used only in removed function.

/assign @wojtek-t 