### PR TITLE
Add sleep after deleting LBs in l4lb test

### DIFF
--- a/clusterloader2/testing/l4lb/config.yaml
+++ b/clusterloader2/testing/l4lb/config.yaml
@@ -10,6 +10,9 @@
 {{$NODE_SYNC_TIMEOUT := DefaultParam .CL2_NODE_SYNC_TIMEOUT "30m"}}
 # L4LB_SYNC_TIMEOUT specifies the timeout to wait for LB creation to complete
 {{$L4LB_SYNC_TIMEOUT := DefaultParam .CL2_L4LB_SYNC_TIMEOUT "30m"}}
+# AFTER_DELETION_SLEEP_TIMEOUT specifies the timeout to sleep after marking resources for deletion
+# Set default to 0, cause only ILB tests need this wait
+{{$AFTER_DELETION_SLEEP_TIMEOUT := DefaultParam .CL2_AFTER_DELETION_SLEEP_TIMEOUT "0m"}}
 
 # adding a fixed value for first version of the test, rate of pod creation not a concern yet.
 {{$lbQPS := 20}}
@@ -87,6 +90,12 @@ steps:
       objectTemplatePath: service.yaml
     - basename: lb-dep
       objectTemplatePath: dep.yaml
+- name: Sleep
+  measurements:
+  - Identifier: sleep
+    Method: Sleep
+    Params:
+      duration: {{$AFTER_DELETION_SLEEP_TIMEOUT}}
 - name: Gather Measurements
   measurements:
   - Identifier: LBServiceCreationLatency


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Add sleep to wait for LB resources to be cleaned up, before deleting 

In the current state, cluster gets deleted, and 10 minutes (default wait to clean up resources) is not enough to remove all LBs and Deployments, that is why tests are failing