### PR TITLE
Add parameters for DNS test thresholds

### DIFF
--- a/clusterloader2/testing/load/modules/measurements.yaml
+++ b/clusterloader2/testing/load/modules/measurements.yaml
@@ -16,6 +16,10 @@
 {{$ENABLE_DNSTESTS := DefaultParam .CL2_ENABLE_DNSTESTS false}}
 # Guard the new DNS tests. Remove it once it's confirmed that it works on a subset of tests.
 {{$USE_ADVANCED_DNSTEST := DefaultParam .CL2_USE_ADVANCED_DNSTEST false}}
+# DNS test threshold parameters.
+{{$DNS_ERROR_COUNT_THRESHOLD := DefaultParam .CL2_DNS_ERROR_COUNT_THRESHOLD 1}}
+{{$DNS_LOOKUP_LATENCY_50_THRESHOLD := DefaultParam .CL2_DNS_LOOKUP_LATENCY_50_THRESHOLD 0.02}}
+{{$DNS_LOOKUP_LATENCY_99_THRESHOLD := DefaultParam .CL2_DNS_LOOKUP_LATENCY_99_THRESHOLD 0.1}}
 {{$ENABLE_NODE_LOCAL_DNS_LATENCY := DefaultParam .CL2_ENABLE_NODE_LOCAL_DNS_LATENCY false}}
 {{$ENABLE_RESTART_COUNT_CHECK := DefaultParam .ENABLE_RESTART_COUNT_CHECK true}}
 {{$ENABLE_SYSTEM_POD_METRICS:= DefaultParam .ENABLE_SYSTEM_POD_METRICS true}}
@@ -212,11 +216,11 @@ steps:
         query: sum(increase(dns_timeouts_total[%v]))
       - name: DNS Error Count
         query: sum(increase(dns_errors_total[%v]))
-        threshold: 1
+        threshold: {{$DNS_ERROR_COUNT_THRESHOLD}}
       - name: DNS Lookup Latency - Perc50
         query: histogram_quantile(0.5, sum(rate(dns_lookup_latency_bucket[%v])) by (le))
-        threshold: 0.01
+        threshold: {{$DNS_LOOKUP_LATENCY_50_THRESHOLD}}
       - name: DNS Lookup Latency - Perc99
         query: histogram_quantile(0.99, sum(rate(dns_lookup_latency_bucket[%v])) by (le))
-        threshold: 0.1
+        threshold: {{$DNS_LOOKUP_LATENCY_99_THRESHOLD}}
 {{end}}


### PR DESCRIPTION
Make DNS test thresholds adjustable through CL2 parameters.
Change the default value for 50th percentile from 0.01 (10ms) to 0.02 (20ms).

/kind feature
/assign @marseel