### PR TITLE
Hide  ADC mode behind a flag

### DIFF
--- a/perfdash/Makefile
+++ b/perfdash/Makefile
@@ -1,7 +1,7 @@
 all: push
 
 # See deployment.yaml for the version currently running-- bump this ahead before rebuilding!
-TAG?=2.43
+TAG?=2.44
 
 REPO?=gcr.io/k8s-staging-perf-tests
 

--- a/perfdash/deployment.yaml
+++ b/perfdash/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: perfdash
-        image: gcr.io/k8s-staging-perf-tests/perfdash:2.43
+        image: gcr.io/k8s-staging-perf-tests/perfdash:2.44
         command:
           - /perfdash
           -   --www=true

--- a/perfdash/gcs_metrics_bucket.go
+++ b/perfdash/gcs_metrics_bucket.go
@@ -37,7 +37,7 @@ type GCSMetricsBucket struct {
 }
 
 // NewGCSMetricsBucket creates a new GCSMetricsBucket.
-func NewGCSMetricsBucket(bucket, path, credentialPath string) (MetricsBucket, error) {
+func NewGCSMetricsBucket(bucket, path, credentialPath string, useADC bool) (MetricsBucket, error) {
 	var c *storage.Client
 	var err error
 	ctx := context.Background()
@@ -45,7 +45,12 @@ func NewGCSMetricsBucket(bucket, path, credentialPath string) (MetricsBucket, er
 		authOpt := option.WithCredentialsFile(credentialPath)
 		c, err = storage.NewClient(ctx, authOpt)
 	} else {
-		c, err = storage.NewClient(ctx)
+		if useADC {
+			c, err = storage.NewClient(ctx)
+		} else {
+			authOpt := option.WithoutAuthentication()
+			c, err = storage.NewClient(ctx, authOpt)
+		}
 	}
 	if err != nil {
 		return nil, err

--- a/perfdash/perfdash.go
+++ b/perfdash/perfdash.go
@@ -53,6 +53,7 @@ var (
 
 	// Google GCS Specific flags
 	credentialPath = pflag.String("credentialPath", "", "Path to the gcs credential json")
+	useADC         = pflag.Bool("useADC", false, "If true, use Application Default Credentials. See https://cloud.google.com/docs/authentication/production for details")
 
 	// AWS S3 Specific flags
 	awsRegion = pflag.String("aws-region", "us-west-2", "AWS region of the S3 bucket")
@@ -94,7 +95,7 @@ func run() error {
 
 	switch options.Mode {
 	case gcsMode:
-		metricsBucket, err = NewGCSMetricsBucket(*logsBucket, *logsPath, *credentialPath)
+		metricsBucket, err = NewGCSMetricsBucket(*logsBucket, *logsPath, *credentialPath, *useADC)
 	case s3Mode:
 		metricsBucket, err = NewS3MetricsBucket(*logsBucket, *logsPath, *awsRegion)
 	default:


### PR DESCRIPTION
Public Perfdash uses buckets that are not compatible with Application Default Credentials:

Thrown error:
```
<?xml version='1.0' encoding='UTF-8'?><Error><Code>PreconditionFailed</Code><Message>The operation requires that Uniform Bucket Level Access be enabled.</Message><Details>The type of authentication token used for this request requires that Uniform Bucket Level Access be enabled.</Details></Error>
```

/assign @marseel 