### PR TITLE
Refactor WaitForControlledPodsRunning to use context

### DIFF
--- a/clusterloader2/pkg/measurement/common/network/network_performance_measurement.go
+++ b/clusterloader2/pkg/measurement/common/network/network_performance_measurement.go
@@ -226,10 +226,8 @@ func (npm *networkPerformanceMeasurement) createAndWaitForWorkerPods() error {
 		return fmt.Errorf("failed to create worked pods: %v ", err)
 	}
 	// Wait for all worker pods to be ready
-	stopCh := make(chan struct{})
-	time.AfterFunc(podReadyTimeout, func() {
-		close(stopCh)
-	})
+	ctx, cancel := context.WithTimeout(context.TODO(), podReadyTimeout)
+	defer cancel()
 	selector := &measurementutil.ObjectSelector{Namespace: netperfNamespace}
 	options := &measurementutil.WaitForPodOptions{
 		DesiredPodCount:     func() int { return npm.numberOfClients + npm.numberOfServers },
@@ -240,7 +238,7 @@ func (npm *networkPerformanceMeasurement) createAndWaitForWorkerPods() error {
 	if err != nil {
 		return err
 	}
-	return measurementutil.WaitForPods(podStore, stopCh, options)
+	return measurementutil.WaitForPods(ctx, podStore, options)
 }
 
 func (*networkPerformanceMeasurement) String() string {

--- a/clusterloader2/pkg/measurement/common/wait_for_pods.go
+++ b/clusterloader2/pkg/measurement/common/wait_for_pods.go
@@ -17,6 +17,7 @@ limitations under the License.
 package common
 
 import (
+	"context"
 	"time"
 
 	"k8s.io/klog"
@@ -60,10 +61,8 @@ func (w *waitForRunningPodsMeasurement) Execute(config *measurement.Config) ([]m
 		return nil, err
 	}
 
-	stopCh := make(chan struct{})
-	time.AfterFunc(timeout, func() {
-		close(stopCh)
-	})
+	ctx, cancel := context.WithTimeout(context.TODO(), timeout)
+	defer cancel()
 	options := &measurementutil.WaitForPodOptions{
 		DesiredPodCount:     func() int { return desiredPodCount },
 		CallerName:          w.String(),
@@ -73,7 +72,7 @@ func (w *waitForRunningPodsMeasurement) Execute(config *measurement.Config) ([]m
 	if err != nil {
 		return nil, err
 	}
-	return nil, measurementutil.WaitForPods(podStore, stopCh, options)
+	return nil, measurementutil.WaitForPods(ctx, podStore, options)
 }
 
 // Dispose cleans up after the measurement.

--- a/clusterloader2/pkg/measurement/util/runtimeobjects/replicaswatcher.go
+++ b/clusterloader2/pkg/measurement/util/runtimeobjects/replicaswatcher.go
@@ -50,7 +50,7 @@ const (
 type ReplicasWatcher interface {
 	Replicas() int
 	// Start must block until Replicas() returns a correct value.
-	Start(stopCh chan struct{}) error
+	Start(stopCh <-chan struct{}) error
 }
 
 // ConstReplicas is a ReplicasWatcher implementation that returns a constant value.
@@ -62,7 +62,7 @@ func (c *ConstReplicas) Replicas() int {
 	return c.ReplicasCount
 }
 
-func (c *ConstReplicas) Start(_ chan struct{}) error {
+func (c *ConstReplicas) Start(_ <-chan struct{}) error {
 	return nil
 }
 
@@ -89,7 +89,7 @@ func NewNodeCounter(client clientset.Interface, nodeSelector labels.Selector, af
 	}
 }
 
-func (n *NodeCounter) Start(stopCh chan struct{}) error {
+func (n *NodeCounter) Start(stopCh <-chan struct{}) error {
 	i := informer.NewInformer(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {

--- a/clusterloader2/pkg/measurement/util/wait_for_pods.go
+++ b/clusterloader2/pkg/measurement/util/wait_for_pods.go
@@ -17,6 +17,7 @@ limitations under the License.
 package util
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -52,7 +53,7 @@ type PodLister interface {
 
 // WaitForPods waits till desired number of pods is running.
 // The current set of pods are fetched by calling List() on the provided PodStore.
-func WaitForPods(ps PodLister, stopCh <-chan struct{}, options *WaitForPodOptions) error {
+func WaitForPods(ctx context.Context, ps PodLister, options *WaitForPodOptions) error {
 	oldPods, err := ps.List()
 	if err != nil {
 		return fmt.Errorf("failed to list pods: %w", err)
@@ -63,7 +64,7 @@ func WaitForPods(ps PodLister, stopCh <-chan struct{}, options *WaitForPodOption
 
 	for {
 		select {
-		case <-stopCh:
+		case <-ctx.Done():
 			desiredPodCount := options.DesiredPodCount()
 			pods := ComputePodsStatus(oldPods)
 			klog.V(2).Infof("%s: %s: expected %d pods, got %d pods (not RunningAndReady pods: %v)", options.CallerName, ps.String(), desiredPodCount, len(oldPods), pods.NotRunningAndReady())


### PR DESCRIPTION
This PR refactors WaitForControlledPodsRunning measurement to:
* cleanup tidy terminate logic (which e.g. never closes stopCh on happy path) and is spread between two pieces of code
* use context as a termination signal -- this will be needed in the next PRs

I'm going to extend WaitForControlledPodsRunning to handle different timeout pattern (waiting on timeout defined in gather) and it will be easier this way.

/assign @marseel 