### PR TITLE
Shorten pod startup latency

### DIFF
--- a/clusterloader2/pkg/config/template_functions.go
+++ b/clusterloader2/pkg/config/template_functions.go
@@ -41,6 +41,7 @@ func GetFuncs() template.FuncMap {
 	return template.FuncMap{
 		"AddFloat":      addFloat,
 		"AddInt":        addInt,
+		"Ceil":          ceil,
 		"DefaultParam":  defaultParam,
 		"DivideFloat":   divideFloat,
 		"DivideInt":     divideInt,
@@ -267,4 +268,8 @@ func loop(size interface{}) []int {
 		slice[i] = i
 	}
 	return slice
+}
+
+func ceil(i interface{}) float64 {
+	return math.Ceil(toFloat64(i))
 }

--- a/clusterloader2/testing/load/modules/pod-startup-latency.yaml
+++ b/clusterloader2/testing/load/modules/pod-startup-latency.yaml
@@ -13,10 +13,10 @@
 # TODO(https://github.com/kubernetes/perf-tests/issues/1024): See whether we can get rid of this
 {{$LATENCY_POD_CPU := DefaultParam .CL2_LATENCY_POD_CPU 50}}
 {{$LATENCY_POD_MEMORY := DefaultParam .CL2_LATENCY_POD_MEMORY 200}}
-{{$LATENCY_POD_COUNT := DefaultParam .CL2_LATENCY_POD_COUNT (MaxInt $minPodsInSmallCluster .Nodes)}}
+{{$LATENCY_POD_COUNT := DefaultParam .CL2_LATENCY_POD_COUNT $minPodsInSmallCluster}}
 
 ## Variables
-{{$latencyReplicas := DivideInt $LATENCY_POD_COUNT $namespaces}}
+{{$latencyReplicas := Ceil (DivideFloat $LATENCY_POD_COUNT $namespaces)}}
 {{$podStartupLatencyThreshold := DefaultParam .CL2_POD_STARTUP_LATENCY_THRESHOLD "5s"}}
 {{$CHECK_IF_PODS_ARE_UPDATED := DefaultParam .CL2_CHECK_IF_PODS_ARE_UPDATED true}}
 


### PR DESCRIPTION
This PR tries to shorten pod startup latency phase in large clusters.

Reasoning:
* Given that we artificially slow down pod creation introducing delay between each, we can think about them as independent random variables
* In 100 node tests, we see that sample size of 500 is enough to reduce variance of the result
* In 5k it should be also case, as we don't expect the variance to grow with cluster size, as the latency is dominated by "schedule_to_run" phase which happens on each independent kubelet.

In this attempt we try to reduce this to 500 in any scale.

The preliminary result suggests that it's sufficient. I will try to start few more runs before merging.

/assign @marseel 
/hold for manual runs