### PR TITLE
Revert "Remove artificial pod creation/update/delete rate limiting"

### DIFF
--- a/clusterloader2/pkg/measurement/common/wait_for_controlled_pods.go
+++ b/clusterloader2/pkg/measurement/common/wait_for_controlled_pods.go
@@ -19,7 +19,6 @@ package common
 import (
 	"context"
 	"fmt"
-	"os"
 	"strings"
 	"sync"
 	"time"
@@ -448,11 +447,7 @@ func (w *waitForControlledPodsRunningMeasurement) handleObjectLocked(oldObj, new
 	}
 
 	operationTimeout := w.operationTimeout
-	// exactOperationTimeout controls whether we should skip multiplying by two operationTimeout on scale down/deletion.
-	// Defaults to false for backward compatibility.
-	// TODO(mborsz): Change default to true and remove.
-	_, exactOperationTimeout := os.LookupEnv("CL2_WAIT_FOR_CONTROLLED_PODS_USE_EXACT_OPERATION_TIMEOUT")
-	if !exactOperationTimeout && (isObjDeleted || isScalingDown) {
+	if isObjDeleted || isScalingDown {
 		// In case of deleting pods, twice as much time is required.
 		// The pod deletion throughput equals half of the pod creation throughput.
 		// NOTE: Starting from k8s 1.23 it's not true anymore, at least not in all cases.

--- a/clusterloader2/testing/load/config.yaml
+++ b/clusterloader2/testing/load/config.yaml
@@ -12,7 +12,6 @@
 {{$PODS_PER_NODE := DefaultParam .PODS_PER_NODE 30}}
 {{$LOAD_TEST_THROUGHPUT := DefaultParam .CL2_LOAD_TEST_THROUGHPUT 10}}
 {{$DELETE_TEST_THROUGHPUT := DefaultParam .CL2_DELETE_TEST_THROUGHPUT $LOAD_TEST_THROUGHPUT}}
-{{$RATE_LIMIT_POD_CREATION := DefaultParam .CL2_RATE_LIMIT_POD_CREATION true}}
 {{$BIG_GROUP_SIZE := DefaultParam .BIG_GROUP_SIZE 250}}
 {{$MEDIUM_GROUP_SIZE := DefaultParam .MEDIUM_GROUP_SIZE 30}}
 {{$SMALL_GROUP_SIZE := DefaultParam .SMALL_GROUP_SIZE 5}}
@@ -153,13 +152,7 @@ steps:
     params:
       actionName: "create"
       namespaces: {{$namespaces}}
-      {{if .RATE_LIMIT_POD_CREATION}}
       tuningSet: RandomizedSaturationTimeLimited
-      operationTimeout: 15m
-      {{else}}
-      tuningSet: Global100qps
-      operationTimeout: {{AddInt $saturationTime 900}}s
-      {{end}}
       testMaxReplicaFactor: {{$RANDOM_SCALE_FACTOR}}
       # We rely on the fact that daemonset is using the same image as the 'pod-startup-latency' module.
       # The goal is to cache the image to all nodes before we start any latency pod,
@@ -268,13 +261,7 @@ steps:
     params:
       actionName: "scale and update"
       namespaces: {{$namespaces}}
-      {{if .RATE_LIMIT_POD_CREATION}}
       tuningSet: RandomizedScalingTimeLimited
-      operationTimeout: 15m
-      {{else}}
-      tuningSet: Global100qps
-      operationTimeout: {{AddInt (DivideInt $saturationTime 4) 900}}s
-      {{end}}
       randomScaleFactor: {{$RANDOM_SCALE_FACTOR}}
       testMaxReplicaFactor: {{$RANDOM_SCALE_FACTOR}}
       daemonSetImage: {{$latencyPodImage}}
@@ -302,13 +289,7 @@ steps:
     params:
       actionName: "delete"
       namespaces: {{$namespaces}}
-      {{if .RATE_LIMIT_POD_CREATION}}
       tuningSet: RandomizedDeletionTimeLimited
-      operationTimeout: 15m
-      {{else}}
-      tuningSet: Global100qps
-      operationTimeout: {{AddInt $deletionTime 900}}s
-      {{end}}
       testMaxReplicaFactor: {{$RANDOM_SCALE_FACTOR}}
       daemonSetReplicas: 0
       bigDeploymentSize: {{$BIG_GROUP_SIZE}}

--- a/clusterloader2/testing/load/modules/reconcile-objects.yaml
+++ b/clusterloader2/testing/load/modules/reconcile-objects.yaml
@@ -10,7 +10,6 @@
 {{$minReplicaFactor := SubtractFloat 1 $randomScaleFactor}}
 {{$maxReplicaFactor := AddFloat 1 $randomScaleFactor}}
 {{$testMaxReplicaFactor := AddFloat 1 .testMaxReplicaFactor}}
-{{$operationTimeout := .operationTimeout}}
 
 # DaemonSets
 {{$daemonSetImage := DefaultParam .daemonSetImage "k8s.gcr.io/pause:3.0"}}
@@ -76,7 +75,7 @@ steps:
       action: start
       checkIfPodsAreUpdated: {{$CHECK_IF_PODS_ARE_UPDATED}}
       labelSelector: group = load
-      operationTimeout: {{$operationTimeout}}
+      operationTimeout: 15m
 
 - name: {{$actionName}}
   phases:
@@ -213,7 +212,7 @@ steps:
       min: 1
       max: {{$namespaces}}
     replicasPerNamespace: 0
-    tuningSet: {{$tuningSet}}
+    tuningSet: RandomizedDeletionTimeLimited
     objectBundle:
   {{range $ssIndex := Loop $pvSmallStatefulSetSize}}
       - basename: pv-small-statefulset-{{$ssIndex}}
@@ -227,7 +226,7 @@ steps:
       min: 1
       max: {{$namespaces}}
     replicasPerNamespace: 0
-    tuningSet: {{$tuningSet}}
+    tuningSet: RandomizedDeletionTimeLimited
     objectBundle:
   {{range $ssIndex := Loop $pvMediumStatefulSetSize}}
       - basename: pv-medium-statefulset-{{$ssIndex}}
@@ -255,5 +254,5 @@ steps:
     Params:
       desiredPVCCount: 0
       labelSelector: group = load
-      timeout: {{$operationTimeout}}
+      timeout: 15m
 {{end}}


### PR DESCRIPTION
Reverts kubernetes/perf-tests#2128

For some reason change guarding doesn't work. Even without changing flag we change tuningset to 100qps in 100 node tests.