### PR TITLE
Increase operationTimeout to 30m in huge-service test

### DIFF
--- a/clusterloader2/testing/huge-service/modules/service.yaml
+++ b/clusterloader2/testing/huge-service/modules/service.yaml
@@ -28,7 +28,7 @@ steps:
       checkIfPodsAreUpdated: {{$CHECK_IF_PODS_ARE_UPDATED}}
       kind: Deployment
       labelSelector: group = {{$serviceName}}
-      operationTimeout: 20m
+      operationTimeout: 30m
 - name: Creating {{$serviceName}} pods
   phases:
   - namespaceRange:


### PR DESCRIPTION
In some environments, upgrade process takes even 17m. Let's increase timeout to have some slack.

/assign @jupblb 