### PR TITLE
Add DNS lookup error percentage threshold instead of error count

### DIFF
--- a/clusterloader2/pkg/measurement/common/generic_query_measurement.go
+++ b/clusterloader2/pkg/measurement/common/generic_query_measurement.go
@@ -19,6 +19,7 @@ package common
 import (
 	goerrors "errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/prometheus/common/model"
@@ -182,7 +183,8 @@ func (g *genericQueryGatherer) String() string {
 
 func (g *genericQueryGatherer) query(q GenericQuery, executor QueryExecutor, startTime, endTime time.Time) ([]*model.Sample, error) {
 	duration := endTime.Sub(startTime)
-	boundedQuery := fmt.Sprintf(q.Query, measurementutil.ToPrometheusTime(duration))
+	// Replace all provided duration placeholders (%v) with the test duration.
+	boundedQuery := strings.ReplaceAll(q.Query, "%v", measurementutil.ToPrometheusTime(duration))
 	klog.V(2).Infof("bounded query: %s, duration: %v", boundedQuery, duration)
 	return executor.Query(boundedQuery, endTime)
 }

--- a/clusterloader2/pkg/measurement/common/generic_query_measurement_test.go
+++ b/clusterloader2/pkg/measurement/common/generic_query_measurement_test.go
@@ -66,18 +66,24 @@ func TestGather(t *testing.T) {
 						"name":  "no-threshold",
 						"query": "no-threshold-query[%v]",
 					},
+					{
+						"name":  "multiple-duration-placeholders",
+						"query": "placeholder-a[%v] + placeholder-b[%v]",
+					},
 				},
 			},
 			samples: map[string][]*model.Sample{
-				"below-threshold-query[1m]": {{Value: model.SampleValue(7)}},
-				"no-threshold-query[1m]":    {{Value: model.SampleValue(120)}},
+				"below-threshold-query[1m]":             {{Value: model.SampleValue(7)}},
+				"no-threshold-query[1m]":                {{Value: model.SampleValue(120)}},
+				"placeholder-a[1m] + placeholder-b[1m]": {{Value: model.SampleValue(5)}},
 			},
 			wantDataItems: []measurementutil.DataItem{
 				{
 					Unit: "ms",
 					Data: map[string]float64{
-						"below-threshold": 7.0,
-						"no-threshold":    120.0,
+						"below-threshold":                7.0,
+						"no-threshold":                   120.0,
+						"multiple-duration-placeholders": 5.0,
 					},
 				},
 			},

--- a/clusterloader2/testing/load/modules/measurements.yaml
+++ b/clusterloader2/testing/load/modules/measurements.yaml
@@ -17,7 +17,7 @@
 # Guard the new DNS tests. Remove it once it's confirmed that it works on a subset of tests.
 {{$USE_ADVANCED_DNSTEST := DefaultParam .CL2_USE_ADVANCED_DNSTEST false}}
 # DNS test threshold parameters.
-{{$DNS_ERROR_COUNT_THRESHOLD := DefaultParam .CL2_DNS_ERROR_COUNT_THRESHOLD 1}}
+{{$DNS_ERROR_PERC_THRESHOLD := DefaultParam .CL2_DNS_ERROR_PERC_THRESHOLD 0.1}}
 {{$DNS_LOOKUP_LATENCY_50_THRESHOLD := DefaultParam .CL2_DNS_LOOKUP_LATENCY_50_THRESHOLD 0.02}}
 {{$DNS_LOOKUP_LATENCY_99_THRESHOLD := DefaultParam .CL2_DNS_LOOKUP_LATENCY_99_THRESHOLD 0.1}}
 {{$ENABLE_NODE_LOCAL_DNS_LATENCY := DefaultParam .CL2_ENABLE_NODE_LOCAL_DNS_LATENCY false}}
@@ -216,7 +216,9 @@ steps:
         query: sum(increase(dns_timeouts_total[%v]))
       - name: DNS Error Count
         query: sum(increase(dns_errors_total[%v]))
-        threshold: {{$DNS_ERROR_COUNT_THRESHOLD}}
+      - name: DNS Error Percentage
+        query: sum(increase(dns_errors_total[%v])) / sum(increase(dns_lookups_total[%v])) * 100
+        threshold: {{$DNS_ERROR_PERC_THRESHOLD}}
       - name: DNS Lookup Latency - Perc50
         query: histogram_quantile(0.5, sum(rate(dns_lookup_latency_bucket[%v])) by (le))
         threshold: {{$DNS_LOOKUP_LATENCY_50_THRESHOLD}}


### PR DESCRIPTION
Changes:
1. Modify generic_query_measurement to support PromQL queries that have multiple duration placeholders `[%v]`.
2. Add DNS lookup error percentage query to the advanced DNS test measurement in load test config, and move the threshold from DNS lookup error count to the DNS lookup error percentage query, with 0.1% threshold, meaning that there must be at least 99.9% of successful DNS lookups.

/kind feature
/assign @marseel