### PR TITLE
Use DNS performance test and metrics in huge-services

### DIFF
--- a/clusterloader2/testing/huge-service/modules/measurements.yaml
+++ b/clusterloader2/testing/huge-service/modules/measurements.yaml
@@ -68,3 +68,7 @@ steps:
       defaultAllowedRestarts: {{$ALLOWED_CONTAINER_RESTARTS}}
       customAllowedRestarts: {{YamlQuote $CUSTOM_ALLOWED_CONTAINER_RESTARTS 4}}
 {{end}}
+- module:
+    path: ../load/modules/dns-performance-metrics.yaml
+    params:
+      action: {{$action}}

--- a/clusterloader2/testing/huge-service/modules/service.yaml
+++ b/clusterloader2/testing/huge-service/modules/service.yaml
@@ -52,6 +52,10 @@ steps:
     Method: WaitForControlledPodsRunning
     Params:
       action: gather
+
+- module:
+    path: ../load/modules/dns-k8s-hostnames.yaml
+
 - name: Updating {{$serviceName}} pods
   phases:
   - namespaceRange:

--- a/clusterloader2/testing/load/modules/dns-performance-metrics.yaml
+++ b/clusterloader2/testing/load/modules/dns-performance-metrics.yaml
@@ -1,0 +1,40 @@
+# Valid actions: "start", "gather"
+{{$action := .action}}
+
+{{$ENABLE_DNSTESTS := DefaultParam .CL2_ENABLE_DNSTESTS false}}
+# Guard the new DNS tests. Remove it once it's confirmed that it works on a subset of tests.
+{{$USE_ADVANCED_DNSTEST := DefaultParam .CL2_USE_ADVANCED_DNSTEST false}}
+# DNS test threshold parameters.
+{{$DNS_ERROR_PERC_THRESHOLD := DefaultParam .CL2_DNS_ERROR_PERC_THRESHOLD 0.1}}
+{{$DNS_LOOKUP_LATENCY_50_THRESHOLD := DefaultParam .CL2_DNS_LOOKUP_LATENCY_50_THRESHOLD 0.02}}
+{{$DNS_LOOKUP_LATENCY_99_THRESHOLD := DefaultParam .CL2_DNS_LOOKUP_LATENCY_99_THRESHOLD 0.1}}
+
+{{if and $ENABLE_DNSTESTS $USE_ADVANCED_DNSTEST}}
+steps:
+- name: "{{$action}}ing measurements"
+  measurements:
+  - Identifier: DNSPerformanceMetrics
+    Method: GenericPrometheusQuery
+    Params:
+      action: {{$action}}
+      metricName: DNS Performance
+      metricVersion: v1
+      unit: s
+      enableViolations: true
+      queries:
+      - name: DNS Lookup Count
+        query: sum(increase(dns_lookups_total[%v]))
+      - name: DNS Timeout Count
+        query: sum(increase(dns_timeouts_total[%v]))
+      - name: DNS Error Count
+        query: sum(increase(dns_errors_total[%v]))
+      - name: DNS Error Percentage
+        query: sum(increase(dns_errors_total[%v])) / sum(increase(dns_lookups_total[%v])) * 100
+        threshold: {{$DNS_ERROR_PERC_THRESHOLD}}
+      - name: DNS Lookup Latency - Perc50
+        query: histogram_quantile(0.5, sum(rate(dns_lookup_latency_bucket[%v])) by (le))
+        threshold: {{$DNS_LOOKUP_LATENCY_50_THRESHOLD}}
+      - name: DNS Lookup Latency - Perc99
+        query: histogram_quantile(0.99, sum(rate(dns_lookup_latency_bucket[%v])) by (le))
+        threshold: {{$DNS_LOOKUP_LATENCY_99_THRESHOLD}}
+{{end}}

--- a/clusterloader2/testing/load/modules/measurements.yaml
+++ b/clusterloader2/testing/load/modules/measurements.yaml
@@ -13,13 +13,6 @@
 {{$ENABLE_IN_CLUSTER_NETWORK_LATENCY := DefaultParam .CL2_ENABLE_IN_CLUSTER_NETWORK_LATENCY true}}
 {{$ENABLE_SLO_MEASUREMENT := DefaultParam .CL2_ENABLE_SLO_MEASUREMENT true}}
 {{$ENABLE_CLUSTER_OOMS_TRACKER := DefaultParam .CL2_ENABLE_CLUSTER_OOMS_TRACKER true}}
-{{$ENABLE_DNSTESTS := DefaultParam .CL2_ENABLE_DNSTESTS false}}
-# Guard the new DNS tests. Remove it once it's confirmed that it works on a subset of tests.
-{{$USE_ADVANCED_DNSTEST := DefaultParam .CL2_USE_ADVANCED_DNSTEST false}}
-# DNS test threshold parameters.
-{{$DNS_ERROR_PERC_THRESHOLD := DefaultParam .CL2_DNS_ERROR_PERC_THRESHOLD 0.1}}
-{{$DNS_LOOKUP_LATENCY_50_THRESHOLD := DefaultParam .CL2_DNS_LOOKUP_LATENCY_50_THRESHOLD 0.02}}
-{{$DNS_LOOKUP_LATENCY_99_THRESHOLD := DefaultParam .CL2_DNS_LOOKUP_LATENCY_99_THRESHOLD 0.1}}
 {{$ENABLE_NODE_LOCAL_DNS_LATENCY := DefaultParam .CL2_ENABLE_NODE_LOCAL_DNS_LATENCY false}}
 {{$ENABLE_RESTART_COUNT_CHECK := DefaultParam .ENABLE_RESTART_COUNT_CHECK true}}
 {{$ENABLE_SYSTEM_POD_METRICS:= DefaultParam .ENABLE_SYSTEM_POD_METRICS true}}
@@ -200,29 +193,7 @@ steps:
       clusterOOMsTrackerEnabled: {{$ENABLE_CLUSTER_OOMS_TRACKER}}
       restartCountThresholdOverrides: {{YamlQuote $RESTART_COUNT_THRESHOLD_OVERRIDES 4}}
       enableRestartCountCheck: {{$ENABLE_RESTART_COUNT_CHECK}}
-{{if and $ENABLE_DNSTESTS $USE_ADVANCED_DNSTEST}}
-  - Identifier: DNSPerformanceMetrics
-    Method: GenericPrometheusQuery
-    Params:
+- module:
+    path: modules/dns-performance-metrics.yaml
+    params:
       action: {{$action}}
-      metricName: DNS Performance
-      metricVersion: v1
-      unit: s
-      enableViolations: true
-      queries:
-      - name: DNS Lookup Count
-        query: sum(increase(dns_lookups_total[%v]))
-      - name: DNS Timeout Count
-        query: sum(increase(dns_timeouts_total[%v]))
-      - name: DNS Error Count
-        query: sum(increase(dns_errors_total[%v]))
-      - name: DNS Error Percentage
-        query: sum(increase(dns_errors_total[%v])) / sum(increase(dns_lookups_total[%v])) * 100
-        threshold: {{$DNS_ERROR_PERC_THRESHOLD}}
-      - name: DNS Lookup Latency - Perc50
-        query: histogram_quantile(0.5, sum(rate(dns_lookup_latency_bucket[%v])) by (le))
-        threshold: {{$DNS_LOOKUP_LATENCY_50_THRESHOLD}}
-      - name: DNS Lookup Latency - Perc99
-        query: histogram_quantile(0.99, sum(rate(dns_lookup_latency_bucket[%v])) by (le))
-        threshold: {{$DNS_LOOKUP_LATENCY_99_THRESHOLD}}
-{{end}}


### PR DESCRIPTION
Changes:

1. In `load` test, create a module `dns-performance-metrics.yaml` out of `DNSPerformanceMetrics` measurement.
2. Use `load` test modules `dns-k8s-hostnames.yaml` and `dns-performance-metrics.yaml` in the `huge-service` test.

/kind feature
/assign @jupblb 