### PR TITLE
Add requireSamples field to GenericQueryMeasurement

### DIFF
--- a/clusterloader2/examples/generic_query_example.yaml
+++ b/clusterloader2/examples/generic_query_example.yaml
@@ -4,6 +4,7 @@
 #       metricName will be logged in place of "GenericPrometheusQuery"
 #       query must be parametrized by duration and return exactly 1 sample
 #       threshold is optional
+#       requireSamples is optional and causes the test to fail if no samples are found
 
 {{$duration := "60s"}}
 {{$namespaces := 1}}
@@ -30,6 +31,7 @@ steps:
         - name: Perc50
           query: histogram_quantile(0.5, sum(rate(apiserver_request_duration_seconds_bucket[%v])) by (le))
           threshold: 5
+          requireSamples: true
         - name: non-existent
           query: histogram_quantile(0.5, sum(rate(fake_apiserver_request_duration_seconds_bucket[%v])) by (le))
           threshold: 42

--- a/clusterloader2/pkg/measurement/common/generic_query_measurement.go
+++ b/clusterloader2/pkg/measurement/common/generic_query_measurement.go
@@ -80,9 +80,10 @@ func (p *StartParams) Validate() error {
 }
 
 type GenericQuery struct {
-	Name      string
-	Query     string
-	Threshold *float64
+	Name           string
+	Query          string
+	Threshold      *float64
+	RequireSamples bool
 }
 
 func (q *GenericQuery) Validate() error {
@@ -141,6 +142,9 @@ func (g *genericQueryGatherer) Gather(executor QueryExecutor, startTime, endTime
 		}
 
 		if len(samples) == 0 {
+			if q.RequireSamples {
+				errs = append(errs, errors.NewMetricViolationError(q.Name, fmt.Sprintf("query returned no samples for %v", g.MetricName)))
+			}
 			klog.Warningf("query returned no samples for %v: %v", g.MetricName, q.Name)
 			continue
 		}

--- a/clusterloader2/pkg/measurement/common/generic_query_measurement_test.go
+++ b/clusterloader2/pkg/measurement/common/generic_query_measurement_test.go
@@ -89,6 +89,36 @@ func TestGather(t *testing.T) {
 			},
 		},
 		{
+			desc: "no samples, but samples not required",
+			params: map[string]interface{}{
+				"metricName":    "no-samples",
+				"metricVersion": "v1",
+				"unit":          "ms",
+				"queries": []map[string]interface{}{
+					{
+						"name":  "no-samples",
+						"query": "no-samples-query[%v]",
+					},
+				},
+			},
+		},
+		{
+			desc: "no samples, but samples required",
+			params: map[string]interface{}{
+				"metricName":    "no-samples",
+				"metricVersion": "v1",
+				"unit":          "ms",
+				"queries": []map[string]interface{}{
+					{
+						"name":           "no-samples",
+						"query":          "no-samples-query[%v]",
+						"requireSamples": true,
+					},
+				},
+			},
+			wantErr: "no samples",
+		},
+		{
 			desc: "too many samples",
 			params: map[string]interface{}{
 				"metricName":    "many-samples",


### PR DESCRIPTION
Add support for `requireSamples` field to GenericQueryMeasurement. Setting it true will cause the test to fail in case no samples are found for the query.