### PR TITLE
Add statefulset behind a headless service to huge-service test

### DIFF
--- a/clusterloader2/testing/huge-service/config.yaml
+++ b/clusterloader2/testing/huge-service/config.yaml
@@ -1,6 +1,7 @@
 # Huge service test config
 {{$HUGE_SERVICE_HEADLESS := DefaultParam .CL2_HUGE_SERVICE_HEADLESS false}}
 {{$HUGE_SERVICE_ENDPOINTS := DefaultParam .CL2_HUGE_SERVICE_ENDPOINTS 1000}}
+{{$STATEFULSET_ENDPOINTS := DefaultParam .CL2_STATEFULSET_ENDPOINTS 100}}
 
 name: huge-service
 namespace:
@@ -18,6 +19,7 @@ steps:
     path: modules/service.yaml
     params:
       endpoints: {{$HUGE_SERVICE_ENDPOINTS}}
+      statefulsetEndpoints: {{$STATEFULSET_ENDPOINTS}}
       isHeadless: {{$HUGE_SERVICE_HEADLESS}}
       serviceName: huge-service
 - module:

--- a/clusterloader2/testing/huge-service/modules/service.yaml
+++ b/clusterloader2/testing/huge-service/modules/service.yaml
@@ -1,11 +1,23 @@
 {{$endpoints := .endpoints}}
+{{$statefulsetEndpoints := .statefulsetEndpoints}}
 {{$isHeadless := .isHeadless}}
 {{$serviceName := .serviceName}}
 
 ## CL2 params
 {{$CHECK_IF_PODS_ARE_UPDATED := DefaultParam .CL2_CHECK_IF_PODS_ARE_UPDATED true}}
+{{$ENABLE_LARGE_STATEFULSET := DefaultParam .CL2_ENABLE_LARGE_STATEFULSET false}}
 
 steps:
+{{if $ENABLE_LARGE_STATEFULSET}}
+- module:
+    path: modules/statefulset.yaml
+    params:
+      action: "create"
+      replicasPerNamespace: 1
+      endpoints: {{$statefulsetEndpoints}}
+      serviceName: {{$serviceName}}-statefulset
+{{end}}
+
 - name: Create {{$serviceName}}
   phases:
   - namespaceRange:
@@ -79,6 +91,16 @@ steps:
     Method: WaitForControlledPodsRunning
     Params:
       action: gather
+
+{{if $ENABLE_LARGE_STATEFULSET}}
+- module:
+    path: modules/statefulset.yaml
+    params:
+      action: "delete"
+      replicasPerNamespace: 0
+      serviceName: {{$serviceName}}-statefulset
+{{end}}      
+
 - name: Deleting {{$serviceName}} pods
   phases:
   - namespaceRange:

--- a/clusterloader2/testing/huge-service/modules/statefulset.yaml
+++ b/clusterloader2/testing/huge-service/modules/statefulset.yaml
@@ -1,0 +1,47 @@
+# Valid actions: "create", "delete"
+{{$action := .action}}
+
+{{$replicasPerNamespace := .replicasPerNamespace}}
+{{$endpoints := DefaultParam .endpoints 100}}
+{{$serviceName := .serviceName}}
+
+steps:
+- name: {{$action}} {{$serviceName}}
+  phases:
+  - namespaceRange:
+      min: 1
+      max: 1
+    replicasPerNamespace: {{$replicasPerNamespace}}
+    tuningSet: Sequence
+    objectBundle:
+    - basename: {{$serviceName}}
+      objectTemplatePath: statefulset_service.yaml
+- name: Creating {{$serviceName}} measurements
+  measurements:
+  - Identifier: WaitForHugeServiceStatefulSet
+    Method: WaitForControlledPodsRunning
+    Params:
+      action: start
+      apiVersion: apps/v1
+      kind: StatefulSet
+      labelSelector: group = load
+      operationTimeout: 30m
+- name: {{$action}} {{$serviceName}} pods
+  phases:
+  - namespaceRange:
+      min: 1
+      max: 1
+    replicasPerNamespace: {{$replicasPerNamespace}}
+    tuningSet: Sequence
+    objectBundle:
+    - basename: {{$serviceName}}
+      objectTemplatePath: statefulset.yaml
+      templateFillMap:
+        ReplicasMin: {{$endpoints}}
+        ReplicasMax: {{$endpoints}}
+- name: Waiting for {{$serviceName}} pods to be {{$action}}d
+  measurements:
+  - Identifier: WaitForHugeServiceStatefulSet
+    Method: WaitForControlledPodsRunning
+    Params:
+      action: gather

--- a/clusterloader2/testing/huge-service/statefulset.yaml
+++ b/clusterloader2/testing/huge-service/statefulset.yaml
@@ -1,0 +1,1 @@
+../load/statefulset.yaml

--- a/clusterloader2/testing/huge-service/statefulset_service.yaml
+++ b/clusterloader2/testing/huge-service/statefulset_service.yaml
@@ -1,0 +1,1 @@
+../load/statefulset_service.yaml


### PR DESCRIPTION
Expand DNS test coverage in the huge-service test to verify that DNS lookups work for all in-cluster hostnames.

Statefulset pods automatically have hostnames assigned to them. Pods with hostnames behind headless services get their own DNS records.

/kind feature
/assign @marseel