### PR TITLE
Replace golint with revive

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,7 +24,7 @@ linters:
   disable-all: true
   enable:
     - gofmt
-    - golint
+    - revive
     - govet
     - errcheck
     - deadcode


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
`golangci-lint` suggests replacing `golint` with `revive`:
```
level=warning msg="[runner] The linter 'golint' is deprecated (since v1.41.0) due to: The repository of the linter has been archived by the owner.  Replaced by revive."
```
Example: https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/perf-tests/2156/pull-perf-tests-verify-lint/1580176208107147264

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
/assign @marseel