### PR TITLE
Add a health check to request benchmark

### DIFF
--- a/util-images/request-benchmark/Makefile
+++ b/util-images/request-benchmark/Makefile
@@ -1,6 +1,6 @@
 PROJECT ?= k8s-testimages
 IMG = gcr.io/$(PROJECT)/perf-tests-util/request-benchmark
-TAG = v0.0.4
+TAG = v0.0.5
 
 all: build push
 


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
If benchmark's URI is invalid then the process will continue nonetheless. Added a loop of `10` iterations that ensures the tool can reach desired URI. This is useful because in case of failure the pod will restart and a CL2 scenario using this tool will stop in pod deployment phase.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
/assign @mborsz 