### PR TITLE
Improve error message on module parsing

### DIFF
--- a/clusterloader2/pkg/test/modules.go
+++ b/clusterloader2/pkg/test/modules.go
@@ -68,7 +68,7 @@ func loadModule(ctx Context, moduleRef *api.ModuleRef) (*api.Module, error) {
 	}
 	var module api.Module
 	if err := ctx.GetTemplateProvider().TemplateInto(moduleRef.Path, mapping, &module); err != nil {
-		return nil, fmt.Errorf("erorr while processing module %#v: %w", module, err)
+		return nil, fmt.Errorf("error while processing module %#v: %w", moduleRef, err)
 	}
 	return &module, nil
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Error message now (example):
```
F1019 12:19:24.281334   28900 clusterloader.go:379] Test compilation failed: [error flattening module steps: erorr while processing module api.Module{Steps:[]*api.Step(nil)}: decoding failed: error converting YAML to JSON: yaml: line 15: mapping values are not allowed in this context]
```
Error message after this PR (example):
```
F1019 12:21:40.998204   29714 clusterloader.go:379] Test compilation failed: [error flattening module steps: error while processing module modules/benchmark-deployment.yaml: decoding failed: error converting YAML to JSON: yaml: line 15: mapping values are not allowed in this context]
```

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
/assign @jkaniuk 
