### PR TITLE
support building multi-arch image for perfdash

### DIFF
--- a/perfdash/Dockerfile
+++ b/perfdash/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 ARG GOLANG_VERSION=1.18
-FROM golang:${GOLANG_VERSION} as builder
+FROM --platform=$BUILDPLATFORM golang:${GOLANG_VERSION} as builder
 
 WORKDIR /workspace
 
@@ -23,7 +23,8 @@ COPY go.mod go.mod
 RUN go mod download
 
 COPY *.go /workspace/
-RUN GO111MODULE=on go build -a -installsuffix cgo -ldflags '-w' -o $PWD/perfdash
+ARG TARGETOS TARGETARCH
+RUN GOOS=$TARGETOS GOARCH=$TARGETARCH GO111MODULE=on go build -a -installsuffix cgo -ldflags '-w' -o $PWD/perfdash
 
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/base:nonroot

--- a/perfdash/Makefile
+++ b/perfdash/Makefile
@@ -19,12 +19,14 @@ run: perfdash
 		--force-builds \
 		--githubConfigDir=https://api.github.com/repos/kubernetes/perf-tests/contents/perfdash/test
 
-# Use buildkit to have "COPY --chmod=" support (availability of it in "regular" docker build depends on docker version).
 container:
-	DOCKER_BUILDKIT=1 docker build --pull -t $(REPO)/perfdash:$(TAG) .
+	docker buildx create --use
+	docker buildx build --load -t $(REPO)/perfdash:$(TAG) .
 
 push: container
-	gcloud docker -s $(REPO) -- push $(REPO)/perfdash:$(TAG)
+	gcloud auth configure-docker
+	docker buildx create --use
+	docker buildx build --push -t $(REPO)/perfdash:$(TAG) --platform "linux/amd64,linux/arm64" .
 
 clean:
 	rm -f perfdash


### PR DESCRIPTION
Perfdash currently only release amd64 image.
This PR adds support for building multi-arch images for perfdash using docker buildx.
It follows https://www.docker.com/blog/faster-multi-platform-builds-dockerfile-cross-compilation-guide/
