### PR TITLE
Extend benchmark duration

### DIFF
--- a/clusterloader2/testing/request-benchmark/config.yaml
+++ b/clusterloader2/testing/request-benchmark/config.yaml
@@ -47,6 +47,10 @@ steps:
         bytes: {{$configMapBytes}}
         group: {{$configMapGroup}}
 - module:
+    path: modules/measurements.yaml
+    params:
+      name: baseline
+- module:
     path: modules/benchmark-deployment.yaml
     params:
       replicas: {{$benchmarkReplicas}}
@@ -55,17 +59,7 @@ steps:
 - module:
     path: modules/measurements.yaml
     params:
-      action: start
-- name: Wait 5min
-  measurements:
-    - Identifier: Wait
-      Method: Sleep
-      Params:
-        duration: 5m
-- module:
-    path: modules/measurements.yaml
-    params:
-      action: gather
+      name: benchmark
 - module:
     path: modules/benchmark-deployment.yaml
     params:

--- a/clusterloader2/testing/request-benchmark/modules/measurements.yaml
+++ b/clusterloader2/testing/request-benchmark/modules/measurements.yaml
@@ -1,16 +1,42 @@
 ## Measurement module defines test scoped measurement.
 
-## Input params
-# Valid actions: "start", "gather"
-{{$action := .action}}
-
 steps:
-- name: "{{$action}}ing measurements"
+- name: Wait 1 minute
   measurements:
-  - Identifier: ContainerCPU
+    - Identifier: Wait
+      Method: Sleep
+      Params:
+        duration: 1m
+- name: "Starting measurement - {{.name}}"
+  measurements:
+  - Identifier: ContainerCPU-{{.name}}
     Method: GenericPrometheusQuery
     Params:
-      action: {{$action}}
+      action: start
+      metricName: Container CPU
+      metricVersion: v1
+      unit: cores
+      dimensions:
+      - container
+      queries:
+      - name: Perc99
+        query: quantile_over_time(0.99, sum by (container) (rate(container_cpu_usage_seconds_total[1m]))[%v:])
+      - name: Perc90
+        query: quantile_over_time(0.90, sum by (container) (rate(container_cpu_usage_seconds_total[1m]))[%v:])
+      - name: Perc50
+        query: quantile_over_time(0.50, sum by (container) (rate(container_cpu_usage_seconds_total[1m]))[%v:])
+- name: Wait 5 minutes
+  measurements:
+    - Identifier: Wait
+      Method: Sleep
+      Params:
+        duration: 5m
+- name: "Gathering measurement - {{.name}}"
+  measurements:
+  - Identifier: ContainerCPU-{{.name}}
+    Method: GenericPrometheusQuery
+    Params:
+      action: gather
       metricName: Container CPU
       metricVersion: v1
       unit: cores


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
We noticed that variance of different indicators is higher at the beginning of the test so this PR adds 1m before the CPU measurement starts so that we are sure this does not influence results.

#### Which issue(s) this PR fixes:
N/A

#### Special notes for your reviewer:
/assign @mborsz 
/assign @marseel 
