### PR TITLE
Bump benchmark requests

### DIFF
--- a/clusterloader2/testing/request-benchmark/deployment.yaml
+++ b/clusterloader2/testing/request-benchmark/deployment.yaml
@@ -1,5 +1,5 @@
 {{$image := DefaultParam .CL2_BENCHMARK_IMAGE "gcr.io/k8s-testimages/perf-tests-util/request-benchmark:latest"}}
-{{$cpu := DefaultParam .CL2_BENCHMARK_POD_CPU "500m"}}
+{{$cpu := DefaultParam .CL2_BENCHMARK_POD_CPU (MultiplyInt .Inflight 2)}}
 {{$memory := DefaultParam .CL2_BENCHMARK_POD_MEMORY "100Mi"}}
 
 apiVersion: apps/v1
@@ -29,5 +29,8 @@ spec:
         - --uri={{.Uri}}
         resources:
           requests:
+            cpu: {{$cpu}}
+            memory: {{$memory}}
+          limits:
             cpu: {{$cpu}}
             memory: {{$memory}}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Benchmark may reach something like 800 QPS easily for a single inflight so it's better to ensure it has enough processing throughput on the client side.

#### Which issue(s) this PR fixes:
N/A

#### Special notes for your reviewer:
/assign @marseel 

