### PR TITLE
Reduce benchmark requests

### DIFF
--- a/clusterloader2/testing/request-benchmark/deployment.yaml
+++ b/clusterloader2/testing/request-benchmark/deployment.yaml
@@ -1,5 +1,5 @@
 {{$image := DefaultParam .CL2_BENCHMARK_IMAGE "gcr.io/k8s-testimages/perf-tests-util/request-benchmark:latest"}}
-{{$cpu := DefaultParam .CL2_BENCHMARK_POD_CPU (MultiplyInt .Inflight 2)}}
+{{$cpu := DefaultParam .CL2_BENCHMARK_POD_CPU (AddInt .Inflight 1)}}
 {{$memory := DefaultParam .CL2_BENCHMARK_POD_MEMORY "100Mi"}}
 
 apiVersion: apps/v1


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
A single inflight is generated by a single go routine. Additionally, there is one main go routine. Therefore instead of requesting `2 * Inflight` CPUs we can have `Inflight + 1` instead.

#### Which issue(s) this PR fixes:
N/A

#### Special notes for your reviewer:
/assign @mborsz 

