### PR TITLE
Fix consecutive failed probes counting in API availability measurement

### DIFF
--- a/clusterloader2/pkg/measurement/common/api_availability_metrics.go
+++ b/clusterloader2/pkg/measurement/common/api_availability_metrics.go
@@ -41,6 +41,7 @@ type apiAvailabilityOutput struct {
 func (a *apiAvailabilityMetrics) update(availability bool) {
 	if availability {
 		a.numSuccesses++
+		a.consecutiveFailedProbes = 0
 		return
 	}
 	a.numFailures++


### PR DESCRIPTION
Fixes https://github.com/kubernetes/perf-tests/issues/2092

/assign @marseel 