### PR TITLE
Enable overriding scheduler name in PSL measurement in load test

### DIFF
--- a/clusterloader2/testing/load/modules/pod-startup-latency.yaml
+++ b/clusterloader2/testing/load/modules/pod-startup-latency.yaml
@@ -14,6 +14,7 @@
 {{$LATENCY_POD_CPU := DefaultParam .CL2_LATENCY_POD_CPU 50}}
 {{$LATENCY_POD_MEMORY := DefaultParam .CL2_LATENCY_POD_MEMORY 200}}
 {{$LATENCY_POD_COUNT := DefaultParam .CL2_LATENCY_POD_COUNT $minPodsInSmallCluster}}
+{{$SCHEDULER_NAME := DefaultParam .CL2_SCHEDULER_NAME "default-scheduler"}}
 
 ## Variables
 {{$latencyReplicas := Ceil (DivideFloat $LATENCY_POD_COUNT $namespaces)}}
@@ -82,3 +83,4 @@ steps:
       Method: PodStartupLatency
       Params:
         action: gather
+        schedulerName: {{$SCHEDULER_NAME}}


### PR DESCRIPTION
No-op PR from the CI tests' perspective as this is already defaulted to `default-scheduler` in [pod_startup_latency.go](https://github.com/kubernetes/perf-tests/blob/0fec4121b19f4db2b96df2a0ee526247b52f25b8/clusterloader2/pkg/measurement/common/slos/pod_startup_latency.go#L42).

/assign @marseel