### PR TITLE
Disable resource usage measurement for Autopilot provider

### DIFF
--- a/clusterloader2/pkg/measurement/common/resource_usage.go
+++ b/clusterloader2/pkg/measurement/common/resource_usage.go
@@ -58,6 +58,12 @@ type resourceUsageMetricMeasurement struct {
 // - start - Starts resource metrics collecting.
 // - gather - Gathers and prints current resource usage metrics.
 func (e *resourceUsageMetricMeasurement) Execute(config *measurement.Config) ([]measurement.Summary, error) {
+	provider := config.ClusterFramework.GetClusterConfig().Provider
+	if !provider.Features().SupportResourceUsageMetering {
+		klog.Warningf("fetching resource usage metrics is not possible for provider %q", provider.Name())
+		return nil, nil
+	}
+
 	action, err := util.GetString(config.Params, "action")
 	if err != nil {
 		return nil, err

--- a/clusterloader2/pkg/provider/aks.go
+++ b/clusterloader2/pkg/provider/aks.go
@@ -33,6 +33,7 @@ func NewAKSProvider(_ map[string]string) Provider {
 			SupportGrabMetricsFromKubelets:      true,
 			SupportSnapshotPrometheusDisk:       true,
 			SupportEnablePrometheusServer:       true,
+			SupportResourceUsageMetering:        true,
 			ShouldPrometheusScrapeApiserverOnly: true,
 			ShouldScrapeKubeProxy:               true,
 		},

--- a/clusterloader2/pkg/provider/aws.go
+++ b/clusterloader2/pkg/provider/aws.go
@@ -35,6 +35,7 @@ func NewAWSProvider(_ map[string]string) Provider {
 			SupportEnablePrometheusServer:       true,
 			SupportGrabMetricsFromKubelets:      true,
 			SupportAccessAPIServerPprofEndpoint: true,
+			SupportResourceUsageMetering:        true,
 			ShouldScrapeKubeProxy:               true,
 		},
 	}

--- a/clusterloader2/pkg/provider/eks.go
+++ b/clusterloader2/pkg/provider/eks.go
@@ -34,6 +34,7 @@ func NewEKSProvider(_ map[string]string) Provider {
 			SupportEnablePrometheusServer:       true,
 			SupportGrabMetricsFromKubelets:      true,
 			SupportAccessAPIServerPprofEndpoint: true,
+			SupportResourceUsageMetering:        true,
 			ShouldScrapeKubeProxy:               true,
 		},
 	}

--- a/clusterloader2/pkg/provider/gce.go
+++ b/clusterloader2/pkg/provider/gce.go
@@ -47,6 +47,7 @@ func NewGCEProvider(_ map[string]string) Provider {
 			SupportAccessAPIServerPprofEndpoint: true,
 			SupportKubeStateMetrics:             true,
 			SupportMetricsServerMetrics:         true,
+			SupportResourceUsageMetering:        true,
 			ShouldScrapeKubeProxy:               true,
 		},
 	}

--- a/clusterloader2/pkg/provider/gke.go
+++ b/clusterloader2/pkg/provider/gke.go
@@ -36,6 +36,7 @@ func NewGKEProvider(_ map[string]string) Provider {
 			SupportGrabMetricsFromKubelets:      true,
 			SupportAccessAPIServerPprofEndpoint: true,
 			SupportNodeKiller:                   true,
+			SupportResourceUsageMetering:        true,
 			ShouldPrometheusScrapeApiserverOnly: true,
 			ShouldScrapeKubeProxy:               false,
 		},

--- a/clusterloader2/pkg/provider/gke_kubemark.go
+++ b/clusterloader2/pkg/provider/gke_kubemark.go
@@ -41,6 +41,7 @@ func NewGKEKubemarkProvider(config map[string]string) *GKEKubemarkProvider {
 			SupportAccessAPIServerPprofEndpoint: true,
 			SupportSnapshotPrometheusDisk:       true,
 			ShouldScrapeKubeProxy:               false,
+			SupportResourceUsageMetering:        true,
 			ShouldPrometheusScrapeApiserverOnly: true,
 		},
 		config: config,

--- a/clusterloader2/pkg/provider/kcp.go
+++ b/clusterloader2/pkg/provider/kcp.go
@@ -34,6 +34,7 @@ func NewKCPProvider(_ map[string]string) Provider {
 			SupportEnablePrometheusServer:       false,
 			SupportGrabMetricsFromKubelets:      false,
 			SupportAccessAPIServerPprofEndpoint: false,
+			SupportResourceUsageMetering:        true,
 			ShouldScrapeKubeProxy:               false,
 		},
 	}

--- a/clusterloader2/pkg/provider/kind.go
+++ b/clusterloader2/pkg/provider/kind.go
@@ -37,6 +37,7 @@ func NewKindProvider(_ map[string]string) Provider {
 			SupportGrabMetricsFromKubelets:      true,
 			SupportAccessAPIServerPprofEndpoint: true,
 			SupportMetricsServerMetrics:         true,
+			SupportResourceUsageMetering:        true,
 			ShouldScrapeKubeProxy:               true,
 		},
 	}

--- a/clusterloader2/pkg/provider/kubemark.go
+++ b/clusterloader2/pkg/provider/kubemark.go
@@ -41,6 +41,7 @@ func NewKubemarkProvider(config map[string]string) *KubemarkProvider {
 			SupportEnablePrometheusServer:       supportEnablePrometheusServer,
 			SupportAccessAPIServerPprofEndpoint: true,
 			SupportSnapshotPrometheusDisk:       true,
+			SupportResourceUsageMetering:        true,
 			ShouldScrapeKubeProxy:               true,
 		},
 		config: config,

--- a/clusterloader2/pkg/provider/local.go
+++ b/clusterloader2/pkg/provider/local.go
@@ -36,6 +36,7 @@ func NewLocalProvider(_ map[string]string) Provider {
 			SupportGrabMetricsFromKubelets:      true,
 			SupportAccessAPIServerPprofEndpoint: true,
 			SupportMetricsServerMetrics:         true,
+			SupportResourceUsageMetering:        true,
 			ShouldScrapeKubeProxy:               true,
 		},
 	}

--- a/clusterloader2/pkg/provider/provider.go
+++ b/clusterloader2/pkg/provider/provider.go
@@ -59,6 +59,8 @@ type Features struct {
 	SupportKubeStateMetrics bool
 	// SupportMetricsServerMetrics determines if running metrics server is supported.
 	SupportMetricsServerMetrics bool
+	// SupportResourceUsageMetering determines if resource usage measurement is supported.
+	SupportResourceUsageMetering bool
 
 	// ShouldPrometheusScrapeApiserverOnly determines if we should set PROMETHEUS_SCRAPE_APISERVER_ONLY by default.
 	ShouldPrometheusScrapeApiserverOnly bool

--- a/clusterloader2/pkg/provider/skeleton.go
+++ b/clusterloader2/pkg/provider/skeleton.go
@@ -35,6 +35,7 @@ func NewSkeletonProvider(_ map[string]string) Provider {
 			SupportEnablePrometheusServer:       true,
 			SupportGrabMetricsFromKubelets:      true,
 			SupportAccessAPIServerPprofEndpoint: true,
+			SupportResourceUsageMetering:        true,
 			ShouldScrapeKubeProxy:               true,
 		},
 	}

--- a/clusterloader2/pkg/provider/vsphere.go
+++ b/clusterloader2/pkg/provider/vsphere.go
@@ -35,6 +35,7 @@ func NewVsphereProvider(_ map[string]string) Provider {
 			SupportEnablePrometheusServer:       true,
 			SupportGrabMetricsFromKubelets:      true,
 			SupportAccessAPIServerPprofEndpoint: true,
+			SupportResourceUsageMetering:        true,
 			ShouldScrapeKubeProxy:               true,
 		},
 	}


### PR DESCRIPTION
Currently, to get the resource usage of containers, the resource usage measurement queries `nodes/proxy` subresource underneath to access the `/stats/summary` endpoint of kubelets. Autopilot provider doesn't permit the user to access that subresource at all.

/assign @marseel