### PR TITLE
kube-proxy iptables partial restore failures

### DIFF
--- a/clusterloader2/testing/load/modules/measurements.yaml
+++ b/clusterloader2/testing/load/modules/measurements.yaml
@@ -92,6 +92,18 @@ steps:
     Method: NetworkProgrammingLatency
     Params:
       action: {{$action}}
+  - Identifier: Kube-proxy partial iptables restore failures
+    Method: GenericPrometheusQuery
+    Params:
+      action: {{$action}}
+      metricName: KubeProxyIptablesRestoreFailures
+      metricVersion: v1alpha1
+      unit: failures
+      queries:
+      - name: Total
+        query: sum(kubeproxy_sync_proxy_rules_iptables_partial_restore_failures_total)
+        requireSamples: false # It is a feature gate and may not be enabled
+        threshold: 0
 {{end}}
 {{if $PROMETHEUS_SCRAPE_KUBE_STATE_METRICS}}
   - Identifier: KubeStateMetricsLatency


### PR DESCRIPTION
kube-proxy implemented a new feature to do only partial restore of iptables rules to improve its performance.

The feature adds a new metrics that signals the operator if something goes wrong during the partial resttore. If this metrics is different than zero it most probably a bug in the code.


/kind feature


Ref: https://github.com/kubernetes/enhancements/pull/3454/files#r979617744

