### PR TITLE
fix: master kubelets service monitor in CL2

### DIFF
--- a/clusterloader2/pkg/prometheus/manifests/master-ip/master-serviceMonitor.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/master-ip/master-serviceMonitor.yaml
@@ -42,12 +42,14 @@ spec:
     scheme: https
     tlsConfig:
       insecureSkipVerify: true
+    bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
   - interval: 5s
     port: kubelet
     path: /metrics/cadvisor
     scheme: https
     tlsConfig:
       insecureSkipVerify: true
+    bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
   {{end}}
   - interval: 5s
     port: kube-scheduler


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This PR fixes master kubelets service monitor in CL2.

The service monitor lacks `bearerTokenFile` leading to 401 when scraping master kubelets.