### PR TITLE
feat: allow overriding prometheus memory request

### DIFF
--- a/clusterloader2/pkg/config/cluster.go
+++ b/clusterloader2/pkg/config/cluster.go
@@ -106,6 +106,7 @@ type PrometheusConfig struct {
 	StorageClassVolumeType       string
 	PVCStorageClass              string
 	ReadyTimeout                 time.Duration
+	PrometheusMemoryRequest      string
 }
 
 // GetMasterIP returns the first master ip, added for backward compatibility.

--- a/clusterloader2/pkg/prometheus/manifests/prometheus-prometheus.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/prometheus-prometheus.yaml
@@ -6,6 +6,7 @@
 {{$PROMETHEUS_NODE_SELECTOR := DefaultParam .CL2_PROMETHEUS_NODE_SELECTOR ""}}
 {{$PROMETHEUS_TOLERATE_MASTER := DefaultParam .CL2_PROMETHEUS_TOLERATE_MASTER false}}
 {{$PROMETHEUS_PVC_STORAGE_CLASS := DefaultParam .PROMETHEUS_PVC_STORAGE_CLASS "ssd"}}
+{{$PROMETHEUS_MEMORY_REQUEST := DefaultParam .PROMETHEUS_MEMORY_REQUEST "10Gi"}}
 
 apiVersion: monitoring.coreos.com/v1
 kind: Prometheus
@@ -26,7 +27,7 @@ spec:
     requests:
       cpu: {{AddInt 200 (MultiplyInt $PROMETHEUS_CPU_SCALE_FACTOR 500 (DivideInt .Nodes 1000))}}m
       {{if $PROMETHEUS_SCRAPE_KUBELETS}}
-      memory: 10Gi
+      memory: {{$PROMETHEUS_MEMORY_REQUEST}}
       {{else}}
       # Start with 2Gi and add 2Gi for each 1K nodes.
       memory: {{MultiplyInt $PROMETHEUS_MEMORY_SCALE_FACTOR (AddInt 1 (DivideInt .Nodes 1000))}}Gi

--- a/clusterloader2/pkg/prometheus/prometheus.go
+++ b/clusterloader2/pkg/prometheus/prometheus.go
@@ -73,6 +73,7 @@ func InitFlags(p *config.PrometheusConfig) {
 	flags.StringEnvVar(&p.StorageClassVolumeType, "prometheus-storage-class-volume-type", "PROMETHEUS_STORAGE_CLASS_VOLUME_TYPE", "pd-ssd", "Volume types of storage class, This will be different depending on the provisioner.")
 	flags.StringEnvVar(&p.PVCStorageClass, "prometheus-pvc-storage-class", "PROMETHEUS_PVC_STORAGE_CLASS", "ssd", "Storage class used with prometheus persistent volume claim.")
 	flags.DurationEnvVar(&p.ReadyTimeout, "prometheus-ready-timeout", "PROMETHEUS_READY_TIMEOUT", 15*time.Minute, "Timeout for waiting for Prometheus stack to become healthy.")
+	flags.StringEnvVar(&p.PrometheusMemoryRequest, "prometheus-memory-request", "PROMETHEUS_MEMORY_REQUEST", "10Gi", "Memory request to be used by promehteus.")
 }
 
 // ValidatePrometheusFlags validates prometheus flags.
@@ -191,6 +192,7 @@ func NewController(clusterLoaderConfig *config.ClusterLoaderConfig) (pc *Control
 	mapping["PROMETHEUS_STORAGE_CLASS_VOLUME_TYPE"] = clusterLoaderConfig.PrometheusConfig.StorageClassVolumeType
 	mapping["PROMETHEUS_KUBE_PROXY_SELECTOR_KEY"] = clusterLoaderConfig.PrometheusConfig.KubeProxySelectorKey
 	mapping["PROMETHEUS_PVC_STORAGE_CLASS"] = clusterLoaderConfig.PrometheusConfig.PVCStorageClass
+	mapping["PROMETHEUS_MEMORY_REQUEST"] = clusterLoaderConfig.PrometheusConfig.PrometheusMemoryRequest
 	snapshotEnabled, _ := pc.isEnabled()
 	mapping["RetainPD"] = snapshotEnabled
 


### PR DESCRIPTION

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR allows overriding prometheus memory request.
It currently is hardcoded to `10Gi` when scraping kubelets.
When running CL2 on small clusters this request can too high, this PR allows one the configure the memory request used by the prometheus pod.
