### PR TITLE
[ClusterLoader2] Enable usage of public IPs for master scraping

### DIFF
--- a/clusterloader2/pkg/config/cluster.go
+++ b/clusterloader2/pkg/config/cluster.go
@@ -91,6 +91,7 @@ type PrometheusConfig struct {
 	ScrapeNodeLocalDNS           bool
 	ScrapeAnet                   bool
 	ScrapeCiliumOperator         bool
+	ScrapeMastersWithPublicIPs   bool
 	APIServerScrapePort          int
 	SnapshotProject              string
 	ManifestPath                 string


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Enables Prometheus manifests that scrape Master to use public ips, instead of internal ones.

/assign @mborsz 