### PR TITLE
CL2: Use embed FS instead of relying on $GOPATH.

### DIFF
--- a/clusterloader2/pkg/config/cluster.go
+++ b/clusterloader2/pkg/config/cluster.go
@@ -62,8 +62,6 @@ type ClusterConfig struct {
 type ExecServiceConfig struct {
 	// Determines if service config should be enabled.
 	Enable bool
-	// Sets path to the deployment definition.
-	DeploymentYaml string
 }
 
 // ModifierConfig represent all flags used by test modification

--- a/clusterloader2/pkg/config/template_provider.go
+++ b/clusterloader2/pkg/config/template_provider.go
@@ -20,9 +20,9 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
+	"io/fs"
 	"io/ioutil"
 	"os"
-	"path/filepath"
 	"reflect"
 	"regexp"
 	"strconv"
@@ -39,7 +39,7 @@ import (
 // TemplateProvider provides object templates. Templates in unstructured form
 // are served by reading file from given path or by using cache if available.
 type TemplateProvider struct {
-	basepath string
+	fsys fs.FS
 
 	binLock  sync.RWMutex
 	binCache map[string][]byte
@@ -49,9 +49,9 @@ type TemplateProvider struct {
 }
 
 // NewTemplateProvider creates new template provider.
-func NewTemplateProvider(basepath string) *TemplateProvider {
+func NewTemplateProvider(fsys fs.FS) *TemplateProvider {
 	return &TemplateProvider{
-		basepath:      basepath,
+		fsys:          fsys,
 		binCache:      make(map[string][]byte),
 		templateCache: make(map[string]*template.Template),
 	}
@@ -68,7 +68,7 @@ func (tp *TemplateProvider) getRaw(path string) ([]byte, error) {
 		bin, exists = tp.binCache[path]
 		if !exists {
 			var err error
-			bin, err = ioutil.ReadFile(filepath.Join(tp.basepath, path))
+			bin, err = fs.ReadFile(tp.fsys, path)
 			if err != nil {
 				return []byte{}, fmt.Errorf("reading error: %v", err)
 			}


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Clusterloader now reads a lot from $GOPATH which is problematic (e.g. when is executed from a different path or when binary has been built with different version than is now available in $GOPATH).

This is a first PR that aims to break this dependency in favour of embed.FS: we will embed necessary files (such as manifests which are considered a part of measurements). The test config files (such as load/config.yaml) will be still stored externally as they are not part of the testing framework.

This PR implements necessary interface and migrates the first that reads data in runtime: exec measurement as POC.

See https://github.com/kubernetes/perf-tests/pull/2199 for ~goal where are we going.

/assign @jupblb 


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

