### PR TITLE
Migrate prometheus manifests to embed FS

### DIFF
--- a/clusterloader2/cmd/clusterloader.go
+++ b/clusterloader2/cmd/clusterloader.go
@@ -195,7 +195,6 @@ func completeConfig(m *framework.MultiClientSet) error {
 	if clusterLoaderConfig.ClusterConfig.K8SClientsNumber == 0 {
 		clusterLoaderConfig.ClusterConfig.K8SClientsNumber = getClientsNumber(clusterLoaderConfig.ClusterConfig.Nodes)
 	}
-	prometheus.CompleteConfig(&clusterLoaderConfig.PrometheusConfig)
 	return nil
 }
 

--- a/clusterloader2/pkg/config/cluster.go
+++ b/clusterloader2/pkg/config/cluster.go
@@ -74,38 +74,30 @@ type ModifierConfig struct {
 
 // PrometheusConfig represents all flags used by prometheus.
 type PrometheusConfig struct {
-	TearDownServer               bool
-	EnableServer                 bool
-	EnablePushgateway            bool
-	ScrapeEtcd                   bool
-	ScrapeNodeExporter           bool
-	ScrapeWindowsNodeExporter    bool
-	ScrapeKubelets               bool
-	ScrapeMasterKubelets         bool
-	ScrapeKubeProxy              bool
-	KubeProxySelectorKey         string
-	ScrapeKubeStateMetrics       bool
-	ScrapeMetricsServerMetrics   bool
-	ScrapeNodeLocalDNS           bool
-	ScrapeAnet                   bool
-	ScrapeCiliumOperator         bool
-	ScrapeMastersWithPublicIPs   bool
-	APIServerScrapePort          int
-	SnapshotProject              string
-	ManifestPath                 string
-	CoreManifests                string
-	DefaultServiceMonitors       string
-	KubeStateMetricsManifests    string
-	MasterIPServiceMonitors      string
-	MetricsServerManifests       string
-	NodeExporterPod              string
-	WindowsNodeExporterManifests string
-	PushgatewayManifests         string
-	StorageClassProvisioner      string
-	StorageClassVolumeType       string
-	PVCStorageClass              string
-	ReadyTimeout                 time.Duration
-	PrometheusMemoryRequest      string
+	TearDownServer             bool
+	EnableServer               bool
+	EnablePushgateway          bool
+	ScrapeEtcd                 bool
+	ScrapeNodeExporter         bool
+	ScrapeWindowsNodeExporter  bool
+	ScrapeKubelets             bool
+	ScrapeMasterKubelets       bool
+	ScrapeKubeProxy            bool
+	KubeProxySelectorKey       string
+	ScrapeKubeStateMetrics     bool
+	ScrapeMetricsServerMetrics bool
+	ScrapeNodeLocalDNS         bool
+	ScrapeAnet                 bool
+	ScrapeCiliumOperator       bool
+	ScrapeMastersWithPublicIPs bool
+	APIServerScrapePort        int
+	SnapshotProject            string
+	ManifestPath               string
+	StorageClassProvisioner    string
+	StorageClassVolumeType     string
+	PVCStorageClass            string
+	ReadyTimeout               time.Duration
+	PrometheusMemoryRequest    string
 }
 
 // GetMasterIP returns the first master ip, added for backward compatibility.

--- a/clusterloader2/pkg/config/template_provider.go
+++ b/clusterloader2/pkg/config/template_provider.go
@@ -109,7 +109,7 @@ func (tp *TemplateProvider) getRawTemplate(path string) (*template.Template, err
 			if err != nil {
 				return nil, err
 			}
-			raw = template.New("").Funcs(GetFuncs())
+			raw = template.New("").Funcs(GetFuncs(tp.fsys))
 			raw, err = raw.Parse(string(bin))
 			if err != nil {
 				return nil, fmt.Errorf("parsing error: %v", err)

--- a/clusterloader2/pkg/prometheus/manifests/grafana-dashboardDefinitions.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/grafana-dashboardDefinitions.yaml
@@ -7,25 +7,25 @@ items:
       name: grafana-dashboard-network
       namespace: monitoring
     data:
-      network-programming-latency.json: {{YamlQuote (IncludeFile "pkg/prometheus/manifests/dashboards/network.json") 4}}
+      network-programming-latency.json: {{YamlQuote (IncludeEmbedFile "dashboards/network.json") 4}}
   - apiVersion: v1
     kind: ConfigMap
     metadata:
       name: grafana-dashboard-dns
       namespace: monitoring
     data:
-      master-dashboard.json: {{YamlQuote (IncludeFile "pkg/prometheus/manifests/dashboards/dns.json") 4}}
+      master-dashboard.json: {{YamlQuote (IncludeEmbedFile "dashboards/dns.json") 4}}
   - apiVersion: v1
     kind: ConfigMap
     metadata:
       name: grafana-dashboard-master-dashboard
       namespace: monitoring
     data:
-      master-dashboard.json: {{YamlQuote (IncludeFile "pkg/prometheus/manifests/dashboards/master-dashboard.json") 4}}
+      master-dashboard.json: {{YamlQuote (IncludeEmbedFile "dashboards/master-dashboard.json") 4}}
   - apiVersion: v1
     kind: ConfigMap
     metadata:
       name: grafana-dashboard-slo
       namespace: monitoring
     data:
-      master-dashboard.json: {{YamlQuote (IncludeFile "pkg/prometheus/manifests/dashboards/slo.json") 4}}
+      master-dashboard.json: {{YamlQuote (IncludeEmbedFile "dashboards/slo.json") 4}}


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
#### What this PR does / why we need it:

This is a follow up to https://github.com/kubernetes/perf-tests/pull/2200

This PR migrates the most manifest-heavy part of CL2: prometheus.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

It includes https://github.com/kubernetes/perf-tests/pull/2200, please review the second commit only.

/assign @jupblb 
