### PR TITLE
Migrate remaining manifests to embed

### DIFF
--- a/clusterloader2/pkg/imagepreload/imagepreload.go
+++ b/clusterloader2/pkg/imagepreload/imagepreload.go
@@ -18,6 +18,7 @@ package imagepreload
 
 import (
 	"context"
+	"embed"
 	"strings"
 	"sync"
 	"time"
@@ -39,14 +40,18 @@ import (
 
 const (
 	informerTimeout = time.Minute
-	manifest        = "$GOPATH/src/k8s.io/perf-tests/clusterloader2/pkg/imagepreload/manifests/daemonset.yaml"
+	manifest        = "manifests/daemonset.yaml"
 	namespace       = "preload"
 	daemonsetName   = "preload"
 	pollingInterval = 5 * time.Second
 	pollingTimeout  = 15 * time.Minute
 )
 
-var images []string
+var (
+	images []string
+	//go:embed manifests
+	manifestsFS embed.FS
+)
 
 func init() {
 	flags.StringSliceEnvVar(&images, "node-preload-images", "NODE_PRELOAD_IMAGES", []string{}, "List of images to preload on each node in the test cluster before executing tests")
@@ -119,7 +124,7 @@ func (c *controller) PreloadImages() error {
 
 	klog.V(2).Info("Creating daemonset to preload images...")
 	c.templateMapping["Images"] = c.images
-	if err := c.framework.ApplyTemplatedManifests(manifest, c.templateMapping); err != nil {
+	if err := c.framework.ApplyTemplatedManifestsFS(manifestsFS, manifest, c.templateMapping); err != nil {
 		return err
 	}
 

--- a/clusterloader2/pkg/measurement/common/dns/dns_performance-k8s-hostnames.go
+++ b/clusterloader2/pkg/measurement/common/dns/dns_performance-k8s-hostnames.go
@@ -18,8 +18,8 @@ package dns
 
 import (
 	"context"
+	"embed"
 	"fmt"
-	"path/filepath"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -45,15 +45,14 @@ const (
 	dnsPerfK8sHostnamesMeasureName = "DNSPerformanceK8sHostnames"
 	dnsPerfTestNamespace           = "dns-perf-test"
 	dnsPerfTestPermissionsName     = "dns-test-client"
-	manifestPathPrefix             = "./pkg/measurement/common/dns/manifests"
+	serviceAccountFilePath         = "manifests/serviceaccount.yaml"
+	clusterRoleFilePath            = "manifests/clusterrole.yaml"
+	clusterRoleBindingFilePath     = "manifests/clusterrolebinding.yaml"
+	clientDeploymentFilePath       = "manifests/dns-client.yaml"
 )
 
-var (
-	serviceAccountFilePath     = filepath.Join(manifestPathPrefix, "serviceaccount.yaml")
-	clusterRoleFilePath        = filepath.Join(manifestPathPrefix, "clusterrole.yaml")
-	clusterRoleBindingFilePath = filepath.Join(manifestPathPrefix, "clusterrolebinding.yaml")
-	clientDeploymentFilePath   = filepath.Join(manifestPathPrefix, "dns-client.yaml")
-)
+//go:embed manifests
+var manifestsFS embed.FS
 
 func init() {
 	klog.Info("Registering measurement: DNS Performance for K8s Hostnames")
@@ -143,15 +142,15 @@ func (m *dnsPerfK8sHostnamesMeasurement) createDNSClientPermissions() error {
 		"Namespace": m.testClientNamespace,
 	}
 
-	if err := m.framework.ApplyTemplatedManifests(serviceAccountFilePath, templateMap); err != nil {
+	if err := m.framework.ApplyTemplatedManifestsFS(manifestsFS, serviceAccountFilePath, templateMap); err != nil {
 		return fmt.Errorf("error while creating serviceaccount: %v", err)
 	}
 
-	if err := m.framework.ApplyTemplatedManifests(clusterRoleFilePath, templateMap); err != nil {
+	if err := m.framework.ApplyTemplatedManifestsFS(manifestsFS, clusterRoleFilePath, templateMap); err != nil {
 		return fmt.Errorf("error while creating clusterrole: %v", err)
 	}
 
-	if err := m.framework.ApplyTemplatedManifests(clusterRoleBindingFilePath, templateMap); err != nil {
+	if err := m.framework.ApplyTemplatedManifestsFS(manifestsFS, clusterRoleBindingFilePath, templateMap); err != nil {
 		return fmt.Errorf("error while creating clusterrolebinding: %v", err)
 	}
 
@@ -166,7 +165,7 @@ func (m *dnsPerfK8sHostnamesMeasurement) createDNSClientDeployment() error {
 		"ServiceAccountName": dnsPerfTestPermissionsName,
 	}
 
-	return m.framework.ApplyTemplatedManifests(clientDeploymentFilePath, templateMap)
+	return m.framework.ApplyTemplatedManifestsFS(manifestsFS, clientDeploymentFilePath, templateMap)
 }
 
 func (m *dnsPerfK8sHostnamesMeasurement) deleteDNSClientPermissions() error {

--- a/clusterloader2/pkg/measurement/common/network/network_performance_measurement.go
+++ b/clusterloader2/pkg/measurement/common/network/network_performance_measurement.go
@@ -22,6 +22,7 @@ package network
 
 import (
 	"context"
+	"embed"
 	"fmt"
 	"math"
 	"sync"
@@ -54,11 +55,10 @@ const (
 )
 
 const (
-	manifestPathPrefix                  = "$GOPATH/src/k8s.io/perf-tests/clusterloader2/pkg/measurement/common/network/manifests"
-	workerPodDeploymentManifestFilePath = manifestPathPrefix + "/" + "*deployment.yaml"
-	networkTestRequestFilePath          = manifestPathPrefix + "/" + "networktestrequests.yaml"
-	crdManifestFilePath                 = manifestPathPrefix + "/" + "*CustomResourceDefinition.yaml"
-	clusterRoleBindingFilePath          = manifestPathPrefix + "/" + "roleBinding.yaml"
+	workerPodDeploymentManifestFilePath = "manifests/*deployment.yaml"
+	networkTestRequestFilePath          = "manifests/networktestrequests.yaml"
+	crdManifestFilePath                 = "manifests/*CustomResourceDefinition.yaml"
+	clusterRoleBindingFilePath          = "manifests/roleBinding.yaml"
 	customResourceDefinitionName        = "networktestrequests.clusterloader.io"
 	rbacName                            = "networktestrequests-rbac"
 )
@@ -81,6 +81,9 @@ var (
 		Kind:    "NetworkTestRequest",
 		Version: "v1alpha1",
 	}
+
+	//go:embed manifests
+	manifestsFS embed.FS
 )
 
 func init() {
@@ -191,10 +194,10 @@ func (npm *networkPerformanceMeasurement) prepareCluster() error {
 	if err := client.CreateNamespace(npm.k8sClient, netperfNamespace); err != nil {
 		return fmt.Errorf("error while creating namespace: %v", err)
 	}
-	if err := npm.framework.ApplyTemplatedManifests(clusterRoleBindingFilePath, nil); err != nil {
+	if err := npm.framework.ApplyTemplatedManifestsFS(manifestsFS, clusterRoleBindingFilePath, nil); err != nil {
 		return fmt.Errorf("error while creating clusterRoleBinding: %v", err)
 	}
-	if err := npm.framework.ApplyTemplatedManifests(crdManifestFilePath, nil); err != nil {
+	if err := npm.framework.ApplyTemplatedManifestsFS(manifestsFS, crdManifestFilePath, nil); err != nil {
 		return fmt.Errorf("error while creating CRD: %v", err)
 	}
 	return nil
@@ -222,7 +225,7 @@ func (npm *networkPerformanceMeasurement) cleanupCluster() {
 func (npm *networkPerformanceMeasurement) createAndWaitForWorkerPods() error {
 	// Create worker pods
 	var replicas = map[string]interface{}{"Replicas": npm.numberOfClients + npm.numberOfServers}
-	if err := npm.framework.ApplyTemplatedManifests(workerPodDeploymentManifestFilePath, replicas); err != nil {
+	if err := npm.framework.ApplyTemplatedManifestsFS(manifestsFS, workerPodDeploymentManifestFilePath, replicas); err != nil {
 		return fmt.Errorf("failed to create worked pods: %v ", err)
 	}
 	// Wait for all worker pods to be ready
@@ -327,7 +330,7 @@ func (npm *networkPerformanceMeasurement) createCustomResourcePerUniquePodPair(u
 	npm.startTimeStampForTestExecution = currTime.Add(initialDelayForTestExecution).Unix()
 	for pairIndex, podPair := range uniquePodPairList {
 		templateMapping := npm.populateTemplate(podPair, pairIndex)
-		if err := npm.framework.ApplyTemplatedManifests(networkTestRequestFilePath, templateMapping); err != nil {
+		if err := npm.framework.ApplyTemplatedManifestsFS(manifestsFS, networkTestRequestFilePath, templateMapping); err != nil {
 			klog.Error(err)
 		}
 	}

--- a/clusterloader2/pkg/measurement/common/probes/probes.go
+++ b/clusterloader2/pkg/measurement/common/probes/probes.go
@@ -17,6 +17,7 @@ limitations under the License.
 package probes
 
 import (
+	"embed"
 	"fmt"
 	"path"
 	"time"
@@ -36,7 +37,7 @@ import (
 const (
 	probesNamespace = "probes"
 
-	manifestsPathPrefix = "$GOPATH/src/k8s.io/perf-tests/clusterloader2/pkg/measurement/common/probes/manifests/"
+	manifestsPathPrefix = "manifests/"
 
 	checkProbesReadyInterval = 15 * time.Second
 
@@ -67,6 +68,9 @@ var (
 		Manifests:        "metricsServer/*.yaml",
 		ProbeLabelValues: []string{"metrics-server-prober"},
 	}
+
+	//go:embed manifests
+	manifestsFS embed.FS
 )
 
 func init() {
@@ -235,7 +239,7 @@ func (p *probesMeasurement) gather(params map[string]interface{}) (measurement.S
 }
 
 func (p *probesMeasurement) createProbesObjects() error {
-	return p.framework.ApplyTemplatedManifests(path.Join(manifestsPathPrefix, p.config.Manifests), p.templateMapping)
+	return p.framework.ApplyTemplatedManifestsFS(manifestsFS, path.Join(manifestsPathPrefix, p.config.Manifests), p.templateMapping)
 }
 
 func (p *probesMeasurement) waitForProbesReady(config *measurement.Config) error {


### PR DESCRIPTION
/kind cleanup

#### What this PR does / why we need it:
Follow up to https://github.com/kubernetes/perf-tests/pull/2200.

This PR migrates remaining part of manifests to embed FS.

The goal is to reduce runtime dependency on $GOPATH.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:


/assign @tosi3k 
