### PR TITLE
clusterloader2: use new apiserver latency SLI

### DIFF
--- a/clusterloader2/examples/generic_query_example.yaml
+++ b/clusterloader2/examples/generic_query_example.yaml
@@ -24,16 +24,16 @@ steps:
       unit: ms
       queries:
         - name: Perc99
-          query: histogram_quantile(0.99, sum(rate(apiserver_request_duration_seconds_bucket[%v])) by (le))
+          query: histogram_quantile(0.99, sum(rate(apiserver_request_sli_duration_seconds_bucket[%v])) by (le))
           threshold: 60
         - name: Perc90
-          query: histogram_quantile(0.9, sum(rate(apiserver_request_duration_seconds_bucket[%v])) by (le))
+          query: histogram_quantile(0.9, sum(rate(apiserver_request_sli_duration_seconds_bucket[%v])) by (le))
         - name: Perc50
-          query: histogram_quantile(0.5, sum(rate(apiserver_request_duration_seconds_bucket[%v])) by (le))
+          query: histogram_quantile(0.5, sum(rate(apiserver_request_sli_duration_seconds_bucket[%v])) by (le))
           threshold: 5
           requireSamples: true
         - name: non-existent
-          query: histogram_quantile(0.5, sum(rate(fake_apiserver_request_duration_seconds_bucket[%v])) by (le))
+          query: histogram_quantile(0.5, sum(rate(fake_apiserver_request_sli_duration_seconds_bucket[%v])) by (le))
           threshold: 42
 - name: Sleep
   measurements:

--- a/clusterloader2/pkg/framework/framework.go
+++ b/clusterloader2/pkg/framework/framework.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/perf-tests/clusterloader2/pkg/framework/client"
 	frconfig "k8s.io/perf-tests/clusterloader2/pkg/framework/config"
 
+	"k8s.io/client-go/discovery"
 	restclient "k8s.io/client-go/rest"
 
 	// ensure auth plugins are loaded
@@ -51,6 +52,7 @@ type Framework struct {
 	dynamicClients        *MultiDynamicClient
 	clusterConfig         *config.ClusterConfig
 	restClientConfig      *restclient.Config
+	discoveryClient       *discovery.DiscoveryClient
 }
 
 // NewFramework creates new framework based on given clusterConfig.
@@ -85,6 +87,11 @@ func newFramework(clusterConfig *config.ClusterConfig, clientsNumber int, kubeCo
 	if f.restClientConfig, err = frconfig.GetConfig(kubeConfigPath); err != nil {
 		return nil, fmt.Errorf("rest client creation error: %v", err)
 	}
+
+	if f.discoveryClient, err = discovery.NewDiscoveryClientForConfig(f.restClientConfig); err != nil {
+		return nil, fmt.Errorf("discovery client creation error: %v", err)
+	}
+
 	return &f, nil
 }
 
@@ -115,6 +122,10 @@ func (f *Framework) GetRestClient() *restclient.Config {
 // GetClusterConfig returns cluster config.
 func (f *Framework) GetClusterConfig() *config.ClusterConfig {
 	return f.clusterConfig
+}
+
+func (f *Framework) GetDiscoveryClient() *discovery.DiscoveryClient {
+	return f.discoveryClient
 }
 
 // CreateAutomanagedNamespaces creates automanged namespaces.

--- a/clusterloader2/pkg/measurement/common/metrics_server_prometheus.go
+++ b/clusterloader2/pkg/measurement/common/metrics_server_prometheus.go
@@ -30,7 +30,7 @@ import (
 const (
 	metricsServerPrometheusMeasurementName = "MetricsServerPrometheus"
 
-	metricsServerLatencyQuery = `histogram_quantile(%v, sum(rate(apiserver_request_duration_seconds_bucket{group="metrics.k8s.io",resource="pods",scope="cluster"}[%v])) by (le))`
+	metricsServerLatencyQuery = `histogram_quantile(%v, sum(rate(apiserver_request_sli_duration_seconds_bucket{group="metrics.k8s.io",resource="pods",scope="cluster"}[%v])) by (le))`
 )
 
 var (

--- a/clusterloader2/pkg/measurement/common/metrics_server_prometheus.go
+++ b/clusterloader2/pkg/measurement/common/metrics_server_prometheus.go
@@ -30,7 +30,7 @@ import (
 const (
 	metricsServerPrometheusMeasurementName = "MetricsServerPrometheus"
 
-	metricsServerLatencyQuery = `histogram_quantile(%v, sum(rate(apiserver_request_sli_duration_seconds_bucket{group="metrics.k8s.io",resource="pods",scope="cluster"}[%v])) by (le))`
+	metricsServerLatencyQuery = `histogram_quantile(%v, sum(rate(%v_bucket{group="metrics.k8s.io",resource="pods",scope="cluster"}[%v])) by (le))`
 )
 
 var (
@@ -47,7 +47,7 @@ func init() {
 type metricsServerGatherer struct{}
 
 func (g *metricsServerGatherer) Gather(executor QueryExecutor, startTime, endTime time.Time, config *measurement.Config) ([]measurement.Summary, error) {
-	latencyMetrics, err := g.gatherLatencyMetrics(executor, startTime, endTime)
+	latencyMetrics, err := g.gatherLatencyMetrics(executor, startTime, endTime, config)
 	if err != nil {
 		return nil, err
 	}
@@ -71,16 +71,17 @@ func (g *metricsServerGatherer) String() string {
 	return metricsServerPrometheusMeasurementName
 }
 
-func (g *metricsServerGatherer) gatherLatencyMetrics(executor QueryExecutor, startTime, endTime time.Time) (*measurementutil.LatencyMetric, error) {
+func (g *metricsServerGatherer) gatherLatencyMetrics(executor QueryExecutor, startTime, endTime time.Time, config *measurement.Config) (*measurementutil.LatencyMetric, error) {
 	measurementDuration := endTime.Sub(startTime)
 	promDuration := measurementutil.ToPrometheusTime(measurementDuration)
+	apiserverSLI := measurementutil.GetApiserverSLI(config.ClusterVersion)
 
 	errList := errors.NewErrorList()
 	result := &measurementutil.LatencyMetric{}
 
 	for _, percentile := range desiredMsPercentiles {
 
-		query := fmt.Sprintf(metricsServerLatencyQuery, percentile, promDuration)
+		query := fmt.Sprintf(metricsServerLatencyQuery, percentile, apiserverSLI, promDuration)
 		samples, err := executor.Query(query, endTime)
 		if err != nil {
 			errList.Append(fmt.Errorf("failed to execute query %q, err - %v", query, err))

--- a/clusterloader2/pkg/measurement/common/slos/api_responsiveness_prometheus.go
+++ b/clusterloader2/pkg/measurement/common/slos/api_responsiveness_prometheus.go
@@ -55,12 +55,12 @@ const (
 	// it doesn't match SLI, but is useful in shorter tests, where we don't have enough number of windows to use latencyQuery meaningfully.
 	//
 	// simpleLatencyQuery: placeholders should be replaced with (1) quantile (2) filters and (3) query window size.
-	simpleLatencyQuery = "histogram_quantile(%.2f, sum(rate(apiserver_request_duration_seconds_bucket{%v}[%v])) by (resource,  subresource, verb, scope, le))"
+	simpleLatencyQuery = "histogram_quantile(%.2f, sum(rate(apiserver_request_sli_duration_seconds_bucket{%v}[%v])) by (resource,  subresource, verb, scope, le))"
 
 	// countQuery %v should be replaced with (1) filters and (2) query window size.
-	countQuery = "sum(increase(apiserver_request_duration_seconds_count{%v}[%v])) by (resource, subresource, scope, verb)"
+	countQuery = "sum(increase(apiserver_request_sli_duration_seconds_count{%v}[%v])) by (resource, subresource, scope, verb)"
 
-	countFastQuery = "sum(increase(apiserver_request_duration_seconds_bucket{%v}[%v])) by (resource, subresource, scope, verb)"
+	countFastQuery = "sum(increase(apiserver_request_sli_duration_seconds_bucket{%v}[%v])) by (resource, subresource, scope, verb)"
 
 	// exclude all buckets of 1s and shorter
 	filterGetAndMutating = `verb!~"WATCH|LIST", subresource!="proxy", le="1"`

--- a/clusterloader2/pkg/measurement/common/slos/api_responsiveness_prometheus.go
+++ b/clusterloader2/pkg/measurement/common/slos/api_responsiveness_prometheus.go
@@ -49,7 +49,7 @@ const (
 	// latencyQuery matches description of the API call latency SLI and measure 99th percentaile over 5m windows
 	//
 	// latencyQuery: %v should be replaced with (1) filters and (2) query window size..
-	latencyQuery = "quantile_over_time(0.99, apiserver:apiserver_request_latency_1m:histogram_quantile{%v}[%v])"
+	latencyQuery = "quantile_over_time(0.99, %v{%v}[%v])"
 
 	// simpleLatencyQuery measures 99th percentile of API call latency  over given period of time
 	// it doesn't match SLI, but is useful in shorter tests, where we don't have enough number of windows to use latencyQuery meaningfully.
@@ -165,6 +165,7 @@ func (a *apiResponsivenessGatherer) gatherAPICalls(executor common.QueryExecutor
 	measurementDuration := endTime.Sub(startTime)
 	promDuration := measurementutil.ToPrometheusTime(measurementDuration)
 	apiserverSLI := measurementutil.GetApiserverSLI(config.ClusterVersion)
+	apiserverLatency := measurementutil.GetApiserverLatency(config.ClusterVersion)
 
 	useSimple, err := util.GetBoolOrDefault(config.Params, "useSimpleLatencyQuery", false)
 	if err != nil {
@@ -195,7 +196,7 @@ func (a *apiResponsivenessGatherer) gatherAPICalls(executor common.QueryExecutor
 		}
 		duration := measurementutil.ToPrometheusTime(latencyMeasurementDuration)
 
-		query := fmt.Sprintf(latencyQuery, filters, duration)
+		query := fmt.Sprintf(latencyQuery, apiserverLatency, filters, duration)
 		latencySamples, err = executor.Query(query, endTime)
 		if err != nil {
 			return nil, err

--- a/clusterloader2/pkg/measurement/common/testdata/api_responsiveness_prometheus/above_slow_count_failure.yaml
+++ b/clusterloader2/pkg/measurement/common/testdata/api_responsiveness_prometheus/above_slow_count_failure.yaml
@@ -1,11 +1,11 @@
 interval: 1m
 comment: Two calls in bucket less than 50seconds should be enough to raise 0.99 percentile to >1s and measurement should report an error because alloweSlowCalls is 1
 input_series:
-  - series: apiserver_request_duration_seconds_bucket{component="apiserver",dry_run="",group="storage.k8s.io",resource="r1",scope="namespace",subresource="",verb="POST",version="v1",le="1"}
+  - series: apiserver_request_sli_duration_seconds_bucket{component="apiserver",dry_run="",group="storage.k8s.io",resource="r1",scope="namespace",subresource="",verb="POST",version="v1",le="1"}
     values: 0 0 0 0 0 0 1 51 51 51 51 
-  - series: apiserver_request_duration_seconds_bucket{component="apiserver",dry_run="",group="storage.k8s.io",resource="r1",scope="namespace",subresource="",verb="POST",version="v1",le="50"}
+  - series: apiserver_request_sli_duration_seconds_bucket{component="apiserver",dry_run="",group="storage.k8s.io",resource="r1",scope="namespace",subresource="",verb="POST",version="v1",le="50"}
     values: 0 0 0 0 0 0 1 53 53 53 53 
-  - series: apiserver_request_duration_seconds_bucket{component="apiserver",dry_run="",group="storage.k8s.io",resource="r1",scope="namespace",subresource="",verb="POST",version="v1",le="+Inf"}
+  - series: apiserver_request_sli_duration_seconds_bucket{component="apiserver",dry_run="",group="storage.k8s.io",resource="r1",scope="namespace",subresource="",verb="POST",version="v1",le="+Inf"}
     values: 0 0 0 0 0 0 1 53 53 53 53 
-  - series: apiserver_request_duration_seconds_count{component="apiserver",dry_run="",group="storage.k8s.io",resource="r1",scope="namespace",subresource="",verb="POST",version="v1"}
+  - series: apiserver_request_sli_duration_seconds_count{component="apiserver",dry_run="",group="storage.k8s.io",resource="r1",scope="namespace",subresource="",verb="POST",version="v1"}
     values: 0 0 0 0 0 0 1 53 53 53 53 

--- a/clusterloader2/pkg/measurement/common/testdata/api_responsiveness_prometheus/below_slow_count_pass.yaml
+++ b/clusterloader2/pkg/measurement/common/testdata/api_responsiveness_prometheus/below_slow_count_pass.yaml
@@ -1,11 +1,11 @@
 interval: 1m
 comment: One call in bucket less than 50seconds should be enough to raise 0.99 percentile to >1s, but measurement should not report an error because alloweSlowCalls is 1
 input_series:
-  - series: apiserver_request_duration_seconds_bucket{component="apiserver",dry_run="",group="storage.k8s.io",resource="r1",scope="namespace",subresource="",verb="POST",version="v1",le="1"}
+  - series: apiserver_request_sli_duration_seconds_bucket{component="apiserver",dry_run="",group="storage.k8s.io",resource="r1",scope="namespace",subresource="",verb="POST",version="v1",le="1"}
     values: 0 0 0 0 0 0 1 51 51 51 51 
-  - series: apiserver_request_duration_seconds_bucket{component="apiserver",dry_run="",group="storage.k8s.io",resource="r1",scope="namespace",subresource="",verb="POST",version="v1",le="50"}
+  - series: apiserver_request_sli_duration_seconds_bucket{component="apiserver",dry_run="",group="storage.k8s.io",resource="r1",scope="namespace",subresource="",verb="POST",version="v1",le="50"}
     values: 0 0 0 0 0 0 1 52 52 52 52 
-  - series: apiserver_request_duration_seconds_bucket{component="apiserver",dry_run="",group="storage.k8s.io",resource="r1",scope="namespace",subresource="",verb="POST",version="v1",le="+Inf"}
+  - series: apiserver_request_sli_duration_seconds_bucket{component="apiserver",dry_run="",group="storage.k8s.io",resource="r1",scope="namespace",subresource="",verb="POST",version="v1",le="+Inf"}
     values: 0 0 0 0 0 0 1 52 52 52 52 
-  - series: apiserver_request_duration_seconds_count{component="apiserver",dry_run="",group="storage.k8s.io",resource="r1",scope="namespace",subresource="",verb="POST",version="v1"}
+  - series: apiserver_request_sli_duration_seconds_count{component="apiserver",dry_run="",group="storage.k8s.io",resource="r1",scope="namespace",subresource="",verb="POST",version="v1"}
     values: 0 0 0 0 0 0 1 52 52 52 52 

--- a/clusterloader2/pkg/measurement/common/testdata/api_responsiveness_prometheus/cluster_list_slo_failure.yaml
+++ b/clusterloader2/pkg/measurement/common/testdata/api_responsiveness_prometheus/cluster_list_slo_failure.yaml
@@ -1,10 +1,10 @@
 interval: 1m
 input_series:
-  - series: apiserver_request_duration_seconds_bucket{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="cluster",subresource="",verb="LIST",version="v1",le="30"}
+  - series: apiserver_request_sli_duration_seconds_bucket{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="cluster",subresource="",verb="LIST",version="v1",le="30"}
     values: 0 0 0 0 0 0 1 71 71 71 71 
-  - series: apiserver_request_duration_seconds_bucket{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="cluster",subresource="",verb="LIST",version="v1",le="45"}
+  - series: apiserver_request_sli_duration_seconds_bucket{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="cluster",subresource="",verb="LIST",version="v1",le="45"}
     values: 0 0 0 0 0 0 1 101 101 101 101
-  - series: apiserver_request_duration_seconds_bucket{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="cluster",subresource="",verb="LIST",version="v1",le="+Inf"}
+  - series: apiserver_request_sli_duration_seconds_bucket{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="cluster",subresource="",verb="LIST",version="v1",le="+Inf"}
     values: 0 0 0 0 0 0 1 101 101 101 101
-  - series: apiserver_request_duration_seconds_count{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="cluster",subresource="",verb="LIST",version="v1"}
+  - series: apiserver_request_sli_duration_seconds_count{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="cluster",subresource="",verb="LIST",version="v1"}
     values: 0 0 0 0 0 0 1 101 101 101 101

--- a/clusterloader2/pkg/measurement/common/testdata/api_responsiveness_prometheus/get_slo_failure.yaml
+++ b/clusterloader2/pkg/measurement/common/testdata/api_responsiveness_prometheus/get_slo_failure.yaml
@@ -1,10 +1,10 @@
 interval: 1m
 input_series:
-  - series: apiserver_request_duration_seconds_bucket{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="resource",subresource="",verb="GET",version="v1",le="1"}
+  - series: apiserver_request_sli_duration_seconds_bucket{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="resource",subresource="",verb="GET",version="v1",le="1"}
     values: 0 0 0 0 0 0 1 71 71 71 71 
-  - series: apiserver_request_duration_seconds_bucket{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="resource",subresource="",verb="GET",version="v1",le="2"}
+  - series: apiserver_request_sli_duration_seconds_bucket{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="resource",subresource="",verb="GET",version="v1",le="2"}
     values: 0 0 0 0 0 0 1 100 100 100 100 
-  - series: apiserver_request_duration_seconds_bucket{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="resource",subresource="",verb="GET",version="v1",le="+Inf"}
+  - series: apiserver_request_sli_duration_seconds_bucket{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="resource",subresource="",verb="GET",version="v1",le="+Inf"}
     values: 0 0 0 0 0 0 1 101 101 101 101
-  - series: apiserver_request_duration_seconds_count{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="resource",subresource="",verb="GET",version="v1"}
+  - series: apiserver_request_sli_duration_seconds_count{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="resource",subresource="",verb="GET",version="v1"}
     values: 0 0 0 0 0 0 1 101 101 101 101

--- a/clusterloader2/pkg/measurement/common/testdata/api_responsiveness_prometheus/mutating_slo_failure.yaml
+++ b/clusterloader2/pkg/measurement/common/testdata/api_responsiveness_prometheus/mutating_slo_failure.yaml
@@ -1,10 +1,10 @@
 interval: 1m
 input_series:
-  - series: apiserver_request_duration_seconds_bucket{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="resource",subresource="",verb="POST",version="v1",le="1"}
+  - series: apiserver_request_sli_duration_seconds_bucket{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="resource",subresource="",verb="POST",version="v1",le="1"}
     values: 0 0 0 0 0 0 1 71 71 71 71 
-  - series: apiserver_request_duration_seconds_bucket{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="resource",subresource="",verb="POST",version="v1",le="2"}
+  - series: apiserver_request_sli_duration_seconds_bucket{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="resource",subresource="",verb="POST",version="v1",le="2"}
     values: 0 0 0 0 0 0 1 100 100 100 100 
-  - series: apiserver_request_duration_seconds_bucket{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="resource",subresource="",verb="POST",version="v1",le="+Inf"}
+  - series: apiserver_request_sli_duration_seconds_bucket{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="resource",subresource="",verb="POST",version="v1",le="+Inf"}
     values: 0 0 0 0 0 0 1 101 101 101 101
-  - series: apiserver_request_duration_seconds_count{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="resource",subresource="",verb="POST",version="v1"}
+  - series: apiserver_request_sli_duration_seconds_count{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="resource",subresource="",verb="POST",version="v1"}
     values: 0 0 0 0 0 0 1 101 101 101 101

--- a/clusterloader2/pkg/measurement/common/testdata/api_responsiveness_prometheus/namespace_list_slo_failure.yaml
+++ b/clusterloader2/pkg/measurement/common/testdata/api_responsiveness_prometheus/namespace_list_slo_failure.yaml
@@ -1,10 +1,10 @@
 interval: 1m
 input_series:
-  - series: apiserver_request_duration_seconds_bucket{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="namespace",subresource="",verb="LIST",version="v1",le="45"}
+  - series: apiserver_request_sli_duration_seconds_bucket{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="namespace",subresource="",verb="LIST",version="v1",le="45"}
     values: 0 0 0 0 0 0 1 71 71 71 71 
-  - series: apiserver_request_duration_seconds_bucket{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="namespace",subresource="",verb="LIST",version="v1",le="60"}
+  - series: apiserver_request_sli_duration_seconds_bucket{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="namespace",subresource="",verb="LIST",version="v1",le="60"}
     values: 0 0 0 0 0 0 1 100 100 100 100 
-  - series: apiserver_request_duration_seconds_bucket{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="namespace",subresource="",verb="LIST",version="v1",le="+Inf"}
+  - series: apiserver_request_sli_duration_seconds_bucket{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="namespace",subresource="",verb="LIST",version="v1",le="+Inf"}
     values: 0 0 0 0 0 0 1 101 101 101 101
-  - series: apiserver_request_duration_seconds_count{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="namespace",subresource="",verb="LIST",version="v1"}
+  - series: apiserver_request_sli_duration_seconds_count{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="namespace",subresource="",verb="LIST",version="v1"}
     values: 0 0 0 0 0 0 1 101 101 101 101

--- a/clusterloader2/pkg/measurement/common/testdata/api_responsiveness_prometheus/rules.yml
+++ b/clusterloader2/pkg/measurement/common/testdata/api_responsiveness_prometheus/rules.yml
@@ -2,17 +2,17 @@ groups:
 - name: apiserver.rules
   rules:
   - expr: |
-      histogram_quantile(0.99, sum(rate(apiserver_request_duration_seconds_bucket[5m])) by (resource,  subresource, verb, scope, le))
+      histogram_quantile(0.99, sum(rate(apiserver_request_sli_duration_seconds_bucket[5m])) by (resource,  subresource, verb, scope, le))
     record: apiserver:apiserver_request_latency:histogram_quantile
     labels:
       quantile: "0.99"
   - expr: |
-      histogram_quantile(0.9, sum(rate(apiserver_request_duration_seconds_bucket[5m])) by (resource,  subresource, verb, scope, le))
+      histogram_quantile(0.9, sum(rate(apiserver_request_sli_duration_seconds_bucket[5m])) by (resource,  subresource, verb, scope, le))
     record: apiserver:apiserver_request_latency:histogram_quantile
     labels:
       quantile: "0.90"
   - expr: |
-      histogram_quantile(0.5, sum(rate(apiserver_request_duration_seconds_bucket[5m])) by (resource,  subresource, verb, scope, le))
+      histogram_quantile(0.5, sum(rate(apiserver_request_sli_duration_seconds_bucket[5m])) by (resource,  subresource, verb, scope, le))
     record: apiserver:apiserver_request_latency:histogram_quantile
     labels:
       quantile: "0.50"
@@ -86,17 +86,17 @@ groups:
 - name: apiserver.1m.rules
   rules:
   - expr: |
-      histogram_quantile(0.99, sum(rate(apiserver_request_duration_seconds_bucket[1m])) by (resource,  subresource, verb, scope, le))
+      histogram_quantile(0.99, sum(rate(apiserver_request_sli_duration_seconds_bucket[1m])) by (resource,  subresource, verb, scope, le))
     record: apiserver:apiserver_request_latency_1m:histogram_quantile
     labels:
       quantile: "0.99"
   - expr: |
-      histogram_quantile(0.9, sum(rate(apiserver_request_duration_seconds_bucket[1m])) by (resource,  subresource, verb, scope, le))
+      histogram_quantile(0.9, sum(rate(apiserver_request_sli_duration_seconds_bucket[1m])) by (resource,  subresource, verb, scope, le))
     record: apiserver:apiserver_request_latency_1m:histogram_quantile
     labels:
       quantile: "0.90"
   - expr: |
-      histogram_quantile(0.5, sum(rate(apiserver_request_duration_seconds_bucket[1m])) by (resource,  subresource, verb, scope, le))
+      histogram_quantile(0.5, sum(rate(apiserver_request_sli_duration_seconds_bucket[1m])) by (resource,  subresource, verb, scope, le))
     record: apiserver:apiserver_request_latency_1m:histogram_quantile
     labels:
       quantile: "0.50"

--- a/clusterloader2/pkg/measurement/common/testdata/api_responsiveness_prometheus/rules.yml
+++ b/clusterloader2/pkg/measurement/common/testdata/api_responsiveness_prometheus/rules.yml
@@ -2,17 +2,24 @@ groups:
 - name: apiserver.rules
   rules:
   - expr: |
-      histogram_quantile(0.99, sum(rate(apiserver_request_sli_duration_seconds_bucket[5m])) by (resource,  subresource, verb, scope, le))
+      rate(apiserver_request_duration_seconds_bucket[5m]) and on (job) kubernetes_build_info{major="[0-1]",minor=~"^([0-9]|1[0-9]|2[0-2])$"}
+      or
+      rate(apiserver_request_slo_duration_seconds_bucket[5m]) and on (job) kubernetes_build_info{major="1",minor=~"^2[3-5]$"}
+      or
+      rate(apiserver_request_sli_duration_seconds_bucket[5m]) and on (job) kubernetes_build_info{major="1",minor=~"^(2[6-9]|[3-9][0-9])$"}
+    record: apiserver:request_latency:rate5m
+  - expr: |
+      histogram_quantile(0.99, sum(apiserver:request_latency:rate5m) by (resource,  subresource, verb, scope, le))
     record: apiserver:apiserver_request_latency:histogram_quantile
     labels:
       quantile: "0.99"
   - expr: |
-      histogram_quantile(0.9, sum(rate(apiserver_request_sli_duration_seconds_bucket[5m])) by (resource,  subresource, verb, scope, le))
+      histogram_quantile(0.9, sum(apiserver:request_latency:rate5m) by (resource,  subresource, verb, scope, le))
     record: apiserver:apiserver_request_latency:histogram_quantile
     labels:
       quantile: "0.90"
   - expr: |
-      histogram_quantile(0.5, sum(rate(apiserver_request_sli_duration_seconds_bucket[5m])) by (resource,  subresource, verb, scope, le))
+      histogram_quantile(0.5, sum(apiserver:request_latency:rate5m) by (resource,  subresource, verb, scope, le))
     record: apiserver:apiserver_request_latency:histogram_quantile
     labels:
       quantile: "0.50"
@@ -86,17 +93,47 @@ groups:
 - name: apiserver.1m.rules
   rules:
   - expr: |
-      histogram_quantile(0.99, sum(rate(apiserver_request_sli_duration_seconds_bucket[1m])) by (resource,  subresource, verb, scope, le))
+      histogram_quantile(0.99, sum(rate(apiserver_request_duration_seconds_bucket[1m])) by (resource,  subresource, verb, scope, le))
     record: apiserver:apiserver_request_latency_1m:histogram_quantile
     labels:
       quantile: "0.99"
   - expr: |
-      histogram_quantile(0.9, sum(rate(apiserver_request_sli_duration_seconds_bucket[1m])) by (resource,  subresource, verb, scope, le))
+      histogram_quantile(0.9, sum(rate(apiserver_request_duration_seconds_bucket[1m])) by (resource,  subresource, verb, scope, le))
     record: apiserver:apiserver_request_latency_1m:histogram_quantile
     labels:
       quantile: "0.90"
   - expr: |
-      histogram_quantile(0.5, sum(rate(apiserver_request_sli_duration_seconds_bucket[1m])) by (resource,  subresource, verb, scope, le))
+      histogram_quantile(0.5, sum(rate(apiserver_request_duration_seconds_bucket[1m])) by (resource,  subresource, verb, scope, le))
     record: apiserver:apiserver_request_latency_1m:histogram_quantile
+    labels:
+      quantile: "0.50"
+  - expr: |
+      histogram_quantile(0.99, sum(rate(apiserver_request_slo_duration_seconds_bucket[1m])) by (resource,  subresource, verb, scope, le))
+    record: apiserver:apiserver_request_slo_latency_1m:histogram_quantile
+    labels:
+      quantile: "0.99"
+  - expr: |
+      histogram_quantile(0.9, sum(rate(apiserver_request_slo_duration_seconds_bucket[1m])) by (resource,  subresource, verb, scope, le))
+    record: apiserver:apiserver_request_slo_latency_1m:histogram_quantile
+    labels:
+      quantile: "0.90"
+  - expr: |
+      histogram_quantile(0.5, sum(rate(apiserver_request_slo_duration_seconds_bucket[1m])) by (resource,  subresource, verb, scope, le))
+    record: apiserver:apiserver_request_slo_latency_1m:histogram_quantile
+    labels:
+      quantile: "0.50"
+  - expr: |
+      histogram_quantile(0.99, sum(rate(apiserver_request_sli_duration_seconds_bucket[1m])) by (resource,  subresource, verb, scope, le))
+    record: apiserver:apiserver_request_sli_latency_1m:histogram_quantile
+    labels:
+      quantile: "0.99"
+  - expr: |
+      histogram_quantile(0.9, sum(rate(apiserver_request_sli_duration_seconds_bucket[1m])) by (resource,  subresource, verb, scope, le))
+    record: apiserver:apiserver_request_sli_latency_1m:histogram_quantile
+    labels:
+      quantile: "0.90"
+  - expr: |
+      histogram_quantile(0.5, sum(rate(apiserver_request_sli_duration_seconds_bucket[1m])) by (resource,  subresource, verb, scope, le))
+    record: apiserver:apiserver_request_sli_latency_1m:histogram_quantile
     labels:
       quantile: "0.50"

--- a/clusterloader2/pkg/measurement/common/testdata/api_responsiveness_prometheus/slo_pass.yaml
+++ b/clusterloader2/pkg/measurement/common/testdata/api_responsiveness_prometheus/slo_pass.yaml
@@ -1,46 +1,46 @@
 interval: 1m
 input_series:
-  - series: apiserver_request_duration_seconds_bucket{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="namespace",subresource="",verb="POST",version="v1",le="1"}
+  - series: apiserver_request_sli_duration_seconds_bucket{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="namespace",subresource="",verb="POST",version="v1",le="1"}
     values: 0 0 0 0 0 0 1 991 991 991 991
-  - series: apiserver_request_duration_seconds_bucket{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="namespace",subresource="",verb="POST",version="v1",le="5"}
+  - series: apiserver_request_sli_duration_seconds_bucket{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="namespace",subresource="",verb="POST",version="v1",le="5"}
     values: 0 0 0 0 0 0 1 1001 1001 1001 1001
-  - series: apiserver_request_duration_seconds_bucket{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="namespace",subresource="",verb="POST",version="v1",le="+Inf"}
+  - series: apiserver_request_sli_duration_seconds_bucket{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="namespace",subresource="",verb="POST",version="v1",le="+Inf"}
     values: 0 0 0 0 0 0 1 1001 1001 1001 1001
-  - series: apiserver_request_duration_seconds_count{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="namespace",subresource="",verb="POST",version="v1"}
+  - series: apiserver_request_sli_duration_seconds_count{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="namespace",subresource="",verb="POST",version="v1"}
     values: 0 0 0 0 0 0 1 1001 1001 1001 1001
     
-  - series: apiserver_request_duration_seconds_bucket{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="namespace",subresource="",verb="GET",version="v1",le="1"}
+  - series: apiserver_request_sli_duration_seconds_bucket{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="namespace",subresource="",verb="GET",version="v1",le="1"}
     values: 0 0 0 0 0 0 1 991 991 991 991
-  - series: apiserver_request_duration_seconds_bucket{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="namespace",subresource="",verb="GET",version="v1",le="5"}
+  - series: apiserver_request_sli_duration_seconds_bucket{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="namespace",subresource="",verb="GET",version="v1",le="5"}
     values: 0 0 0 0 0 0 1 1001 1001 1001 1001
-  - series: apiserver_request_duration_seconds_bucket{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="namespace",subresource="",verb="GET",version="v1",le="+Inf"}
+  - series: apiserver_request_sli_duration_seconds_bucket{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="namespace",subresource="",verb="GET",version="v1",le="+Inf"}
     values: 0 0 0 0 0 0 1 1001 1001 1001 1001
-  - series: apiserver_request_duration_seconds_count{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="namespace",subresource="",verb="GET",version="v1"}
+  - series: apiserver_request_sli_duration_seconds_count{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="namespace",subresource="",verb="GET",version="v1"}
     values: 0 0 0 0 0 0 1 1001 1001 1001 1001
 
-  - series: apiserver_request_duration_seconds_bucket{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="namespace",subresource="",verb="GET",version="v1",le="1"}
+  - series: apiserver_request_sli_duration_seconds_bucket{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="namespace",subresource="",verb="GET",version="v1",le="1"}
     values: 0 0 0 0 0 0 1 991 991 991 991
-  - series: apiserver_request_duration_seconds_bucket{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="namespace",subresource="",verb="GET",version="v1",le="5"}
+  - series: apiserver_request_sli_duration_seconds_bucket{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="namespace",subresource="",verb="GET",version="v1",le="5"}
     values: 0 0 0 0 0 0 1 1001 1001 1001 1001
-  - series: apiserver_request_duration_seconds_bucket{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="namespace",subresource="",verb="GET",version="v1",le="+Inf"}
+  - series: apiserver_request_sli_duration_seconds_bucket{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="namespace",subresource="",verb="GET",version="v1",le="+Inf"}
     values: 0 0 0 0 0 0 1 1001 1001 1001 1001
-  - series: apiserver_request_duration_seconds_count{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="namespace",subresource="",verb="GET",version="v1"}
+  - series: apiserver_request_sli_duration_seconds_count{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="namespace",subresource="",verb="GET",version="v1"}
     values: 0 0 0 0 0 0 1 1001 1001 1001 1001
 
-  - series: apiserver_request_duration_seconds_bucket{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="namespace",subresource="",verb="LIST",version="v1",le="1"}
+  - series: apiserver_request_sli_duration_seconds_bucket{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="namespace",subresource="",verb="LIST",version="v1",le="1"}
     values: 0 0 0 0 0 0 1 701 701 701 701 701
-  - series: apiserver_request_duration_seconds_bucket{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="namespace",subresource="",verb="LIST",version="v1",le="1.5"}
+  - series: apiserver_request_sli_duration_seconds_bucket{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="namespace",subresource="",verb="LIST",version="v1",le="1.5"}
     values: 0 0 0 0 0 0 1 1001 1001 1001 1001
-  - series: apiserver_request_duration_seconds_bucket{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="namespace",subresource="",verb="LIST",version="v1",le="+Inf"}
+  - series: apiserver_request_sli_duration_seconds_bucket{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="namespace",subresource="",verb="LIST",version="v1",le="+Inf"}
     values: 0 0 0 0 0 0 1 1001 1001 1001 1001
-  - series: apiserver_request_duration_seconds_count{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="namespace",subresource="",verb="GET",version="v1"}
+  - series: apiserver_request_sli_duration_seconds_count{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="namespace",subresource="",verb="GET",version="v1"}
     values: 0 0 0 0 0 0 1 1001 1001 1001 1001
 
-  - series: apiserver_request_duration_seconds_bucket{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="namespace",subresource="",verb="LIST",version="v1",le="5"}
+  - series: apiserver_request_sli_duration_seconds_bucket{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="namespace",subresource="",verb="LIST",version="v1",le="5"}
     values: 0 0 0 0 0 0 1 901 901 901 901 901
-  - series: apiserver_request_duration_seconds_bucket{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="namespace",subresource="",verb="LIST",version="v1",le="10"}
+  - series: apiserver_request_sli_duration_seconds_bucket{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="namespace",subresource="",verb="LIST",version="v1",le="10"}
     values: 0 0 0 0 0 0 1 1001 1001 1001 1001
-  - series: apiserver_request_duration_seconds_bucket{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="namespace",subresource="",verb="LIST",version="v1",le="+Inf"}
+  - series: apiserver_request_sli_duration_seconds_bucket{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="namespace",subresource="",verb="LIST",version="v1",le="+Inf"}
     values: 0 0 0 0 0 0 1 1001 1001 1001 1001
-  - series: apiserver_request_duration_seconds_count{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="namespace",subresource="",verb="GET",version="v1"}
+  - series: apiserver_request_sli_duration_seconds_count{component="apiserver",dry_run="",group="storage.k8s.io",resource="pod",scope="namespace",subresource="",verb="GET",version="v1"}
     values: 0 0 0 0 0 0 1 1001 1001 1001 1001

--- a/clusterloader2/pkg/measurement/interface.go
+++ b/clusterloader2/pkg/measurement/interface.go
@@ -22,6 +22,8 @@ import (
 	"k8s.io/perf-tests/clusterloader2/pkg/config"
 	"k8s.io/perf-tests/clusterloader2/pkg/framework"
 	"k8s.io/perf-tests/clusterloader2/pkg/provider"
+
+	"k8s.io/apimachinery/pkg/version"
 )
 
 // Config provides client and parameters required for the measurement execution.
@@ -40,6 +42,10 @@ type Config struct {
 	// Identifier identifies this instance of measurement.
 	Identifier    string
 	CloudProvider provider.Provider
+
+	// ClusterVersion contains the version of the cluster and is used to select
+	// available metrics.
+	ClusterVersion version.Info
 }
 
 // Measurement is an common interface for all measurements methods. It should be implemented by the user to

--- a/clusterloader2/pkg/measurement/manager.go
+++ b/clusterloader2/pkg/measurement/manager.go
@@ -17,6 +17,7 @@ limitations under the License.
 package measurement
 
 import (
+	"fmt"
 	"sync"
 
 	"k8s.io/perf-tests/clusterloader2/pkg/config"
@@ -70,6 +71,13 @@ func (mm *measurementManager) Execute(methodName string, identifier string, para
 		CloudProvider:       mm.clusterLoaderConfig.ClusterConfig.Provider,
 		ClusterLoaderConfig: mm.clusterLoaderConfig,
 	}
+
+	clusterVersion, err := mm.clusterFramework.GetDiscoveryClient().ServerVersion()
+	if err != nil {
+		return fmt.Errorf("failed to get cluster version")
+	}
+	config.ClusterVersion = *clusterVersion
+
 	summaries, err := measurementInstance.Execute(config)
 	mm.summaries = append(mm.summaries, summaries...)
 	return err

--- a/clusterloader2/pkg/measurement/util/metrics.go
+++ b/clusterloader2/pkg/measurement/util/metrics.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import "k8s.io/apimachinery/pkg/version"
+
+func GetApiserverSLI(clusterVersion version.Info) string {
+	if clusterVersion.Major == "1" && clusterVersion.Minor < "23" {
+		return "apiserver_request_duration_seconds"
+	}
+	if clusterVersion.Major == "1" && clusterVersion.Minor < "26" {
+		return "apiserver_request_slo_duration_seconds"
+	}
+	return "apiserver_request_sli_duration_seconds"
+}

--- a/clusterloader2/pkg/measurement/util/metrics.go
+++ b/clusterloader2/pkg/measurement/util/metrics.go
@@ -27,3 +27,13 @@ func GetApiserverSLI(clusterVersion version.Info) string {
 	}
 	return "apiserver_request_sli_duration_seconds"
 }
+
+func GetApiserverLatency(clusterVersion version.Info) string {
+	if clusterVersion.Major == "1" && clusterVersion.Minor < "23" {
+		return "apiserver:apiserver_request_latency_1m:histogram_quantile"
+	}
+	if clusterVersion.Major == "1" && clusterVersion.Minor < "26" {
+		return "apiserver:apiserver_request_slo_latency_1m:histogram_quantile"
+	}
+	return "apiserver:apiserver_request_sli_latency_1m:histogram_quantile"
+}

--- a/clusterloader2/pkg/prometheus/manifests/prometheus-rules.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/prometheus-rules.yaml
@@ -10,17 +10,17 @@ spec:
   - name: apiserver.rules
     rules:
     - expr: |
-        histogram_quantile(0.99, sum(rate(apiserver_request_duration_seconds_bucket[5m])) by (resource,  subresource, verb, scope, le))
+        histogram_quantile(0.99, sum(rate(apiserver_request_sli_duration_seconds_bucket[5m])) by (resource,  subresource, verb, scope, le))
       record: apiserver:apiserver_request_latency:histogram_quantile
       labels:
         quantile: "0.99"
     - expr: |
-        histogram_quantile(0.9, sum(rate(apiserver_request_duration_seconds_bucket[5m])) by (resource,  subresource, verb, scope, le))
+        histogram_quantile(0.9, sum(rate(apiserver_request_sli_duration_seconds_bucket[5m])) by (resource,  subresource, verb, scope, le))
       record: apiserver:apiserver_request_latency:histogram_quantile
       labels:
         quantile: "0.90"
     - expr: |
-        histogram_quantile(0.5, sum(rate(apiserver_request_duration_seconds_bucket[5m])) by (resource,  subresource, verb, scope, le))
+        histogram_quantile(0.5, sum(rate(apiserver_request_sli_duration_seconds_bucket[5m])) by (resource,  subresource, verb, scope, le))
       record: apiserver:apiserver_request_latency:histogram_quantile
       labels:
         quantile: "0.50"
@@ -91,17 +91,17 @@ spec:
   - name: apiserver.1m.rules
     rules:
     - expr: |
-        histogram_quantile(0.99, sum(rate(apiserver_request_duration_seconds_bucket[1m])) by (resource,  subresource, verb, scope, le))
+        histogram_quantile(0.99, sum(rate(apiserver_request_sli_duration_seconds_bucket[1m])) by (resource,  subresource, verb, scope, le))
       record: apiserver:apiserver_request_latency_1m:histogram_quantile
       labels:
         quantile: "0.99"
     - expr: |
-        histogram_quantile(0.9, sum(rate(apiserver_request_duration_seconds_bucket[1m])) by (resource,  subresource, verb, scope, le))
+        histogram_quantile(0.9, sum(rate(apiserver_request_sli_duration_seconds_bucket[1m])) by (resource,  subresource, verb, scope, le))
       record: apiserver:apiserver_request_latency_1m:histogram_quantile
       labels:
         quantile: "0.90"
     - expr: |
-        histogram_quantile(0.5, sum(rate(apiserver_request_duration_seconds_bucket[1m])) by (resource,  subresource, verb, scope, le))
+        histogram_quantile(0.5, sum(rate(apiserver_request_sli_duration_seconds_bucket[1m])) by (resource,  subresource, verb, scope, le))
       record: apiserver:apiserver_request_latency_1m:histogram_quantile
       labels:
         quantile: "0.50"

--- a/clusterloader2/pkg/prometheus/manifests/prometheus-rules.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/prometheus-rules.yaml
@@ -10,17 +10,24 @@ spec:
   - name: apiserver.rules
     rules:
     - expr: |
-        histogram_quantile(0.99, sum(rate(apiserver_request_sli_duration_seconds_bucket[5m])) by (resource,  subresource, verb, scope, le))
+        rate(apiserver_request_duration_seconds_bucket[5m]) and on (job) kubernetes_build_info{major="[0-1]",minor=~"^([0-9]|1[0-9]|2[0-2])$"}
+        or
+        rate(apiserver_request_slo_duration_seconds_bucket[5m]) and on (job) kubernetes_build_info{major="1",minor=~"^2[3-5]$"}
+        or
+        rate(apiserver_request_sli_duration_seconds_bucket[5m]) and on (job) kubernetes_build_info{major="1",minor=~"^(2[6-9]|[3-9][0-9])$"}
+      record: apiserver:request_latency:rate5m
+    - expr: |
+        histogram_quantile(0.99, sum(apiserver:request_latency:rate5m) by (resource,  subresource, verb, scope, le))
       record: apiserver:apiserver_request_latency:histogram_quantile
       labels:
         quantile: "0.99"
     - expr: |
-        histogram_quantile(0.9, sum(rate(apiserver_request_sli_duration_seconds_bucket[5m])) by (resource,  subresource, verb, scope, le))
+        histogram_quantile(0.9, sum(apiserver:request_latency:rate5m) by (resource,  subresource, verb, scope, le))
       record: apiserver:apiserver_request_latency:histogram_quantile
       labels:
         quantile: "0.90"
     - expr: |
-        histogram_quantile(0.5, sum(rate(apiserver_request_sli_duration_seconds_bucket[5m])) by (resource,  subresource, verb, scope, le))
+        histogram_quantile(0.5, sum(apiserver:request_latency:rate5m) by (resource,  subresource, verb, scope, le))
       record: apiserver:apiserver_request_latency:histogram_quantile
       labels:
         quantile: "0.50"
@@ -91,17 +98,47 @@ spec:
   - name: apiserver.1m.rules
     rules:
     - expr: |
-        histogram_quantile(0.99, sum(rate(apiserver_request_sli_duration_seconds_bucket[1m])) by (resource,  subresource, verb, scope, le))
+        histogram_quantile(0.99, sum(rate(apiserver_request_duration_seconds_bucket[1m])) by (resource,  subresource, verb, scope, le))
       record: apiserver:apiserver_request_latency_1m:histogram_quantile
       labels:
         quantile: "0.99"
     - expr: |
-        histogram_quantile(0.9, sum(rate(apiserver_request_sli_duration_seconds_bucket[1m])) by (resource,  subresource, verb, scope, le))
+        histogram_quantile(0.9, sum(rate(apiserver_request_duration_seconds_bucket[1m])) by (resource,  subresource, verb, scope, le))
       record: apiserver:apiserver_request_latency_1m:histogram_quantile
       labels:
         quantile: "0.90"
     - expr: |
-        histogram_quantile(0.5, sum(rate(apiserver_request_sli_duration_seconds_bucket[1m])) by (resource,  subresource, verb, scope, le))
+        histogram_quantile(0.5, sum(rate(apiserver_request_duration_seconds_bucket[1m])) by (resource,  subresource, verb, scope, le))
       record: apiserver:apiserver_request_latency_1m:histogram_quantile
+      labels:
+        quantile: "0.50"
+    - expr: |
+        histogram_quantile(0.99, sum(rate(apiserver_request_slo_duration_seconds_bucket[1m])) by (resource,  subresource, verb, scope, le))
+      record: apiserver:apiserver_request_slo_latency_1m:histogram_quantile
+      labels:
+        quantile: "0.99"
+    - expr: |
+        histogram_quantile(0.9, sum(rate(apiserver_request_slo_duration_seconds_bucket[1m])) by (resource,  subresource, verb, scope, le))
+      record: apiserver:apiserver_request_slo_latency_1m:histogram_quantile
+      labels:
+        quantile: "0.90"
+    - expr: |
+        histogram_quantile(0.5, sum(rate(apiserver_request_slo_duration_seconds_bucket[1m])) by (resource,  subresource, verb, scope, le))
+      record: apiserver:apiserver_request_slo_latency_1m:histogram_quantile
+      labels:
+        quantile: "0.50"
+    - expr: |
+        histogram_quantile(0.99, sum(rate(apiserver_request_sli_duration_seconds_bucket[1m])) by (resource,  subresource, verb, scope, le))
+      record: apiserver:apiserver_request_sli_latency_1m:histogram_quantile
+      labels:
+        quantile: "0.99"
+    - expr: |
+        histogram_quantile(0.9, sum(rate(apiserver_request_sli_duration_seconds_bucket[1m])) by (resource,  subresource, verb, scope, le))
+      record: apiserver:apiserver_request_sli_latency_1m:histogram_quantile
+      labels:
+        quantile: "0.90"
+    - expr: |
+        histogram_quantile(0.5, sum(rate(apiserver_request_sli_duration_seconds_bucket[1m])) by (resource,  subresource, verb, scope, le))
+      record: apiserver:apiserver_request_sli_latency_1m:histogram_quantile
       labels:
         quantile: "0.50"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

In Kubernetes 1.23.0 a new request latency metric more suitable for SLOs since it doesn't account for webhooks latency was introduced. Since this new metric is better suited to clusterloader2 than the general-purpose one, it would make sense to update the existing Prometheus rules.

Note that this implies moving from a STABLE metric to an ALPHA one, but considering that the new metric has been around for already 3 releases and that it has a real-life scenario attached to it, the metric is very unlikely to be removed in the future.

#### Special notes for your reviewer:

This metric has been renamed in Kubernetes 1.26 (https://github.com/kubernetes/kubernetes/pull/112679) which means that the queries will only work on clusters from 1.26 onward. Would that be problematic for the support policy of clusterloader2?

This PR will require the release of Kubernetes 1.26 as well as a new version of metrics-server based on the apiserver code post 1.26. For these reasons, I will put it on hold for now.
/hold

/cc @marseel 