### PR TITLE
Allow to optionally deploy kube-state-metrics scrapper on GKE clusters

### DIFF
--- a/clusterloader2/pkg/provider/gke.go
+++ b/clusterloader2/pkg/provider/gke.go
@@ -39,6 +39,7 @@ func NewGKEProvider(_ map[string]string) Provider {
 			SupportResourceUsageMetering:        true,
 			ShouldPrometheusScrapeApiserverOnly: true,
 			ShouldScrapeKubeProxy:               false,
+			SupportKubeStateMetrics:             true,
 		},
 	}
 }


### PR DESCRIPTION
I am running performance tests on GKE clusters and would like to measure several metrics provided by the `kube-state-metrics` scrapper (such as `kube_pod_info`).

I tested the change locally and verified that the scraper was successfully deployed if the `prometheus-scrape-kube-state-metrics` flag was enabled and I also could query the metrics in Prometheus.

Is there any particular reason why it's an option only for GCE for now?

