### PR TITLE
Fix case when there are no replicas

### DIFF
--- a/clusterloader2/pkg/test/simple_test_executor.go
+++ b/clusterloader2/pkg/test/simple_test_executor.go
@@ -220,6 +220,10 @@ func (ste *simpleExecutor) ExecutePhase(ctx Context, phase *api.Phase) *errors.E
 			return errors.NewErrorList(err)
 		}
 
+		if len(instancesStates) == 0 {
+			return nil
+		}
+
 		// Deleting objects with index greater or equal requested replicas per namespace number.
 		// Objects will be deleted in reversed order.
 		for replicaCounter := phase.ReplicasPerNamespace; replicaCounter < instancesStates[0].CurrentReplicaCount; replicaCounter++ {


### PR DESCRIPTION
/kind bug

Observed in https://github.com/kubernetes/perf-tests/pull/2208

if objectBundle is empty, the CL2 fails.

/hold to see if the presubmit in https://github.com/kubernetes/perf-tests/pull/2208 passes

/assign @tosi3k 