### PR TITLE
Set priorityclass in prometheus

### DIFF
--- a/clusterloader2/pkg/prometheus/manifests/0prometheus-priorityclass.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/0prometheus-priorityclass.yaml
@@ -1,0 +1,7 @@
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: prometheus-priorityclass
+value: 20000000
+globalDefault: false
+description: "High priority class to prevent preemption of prometheus."

--- a/clusterloader2/pkg/prometheus/manifests/grafana-deployment.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/grafana-deployment.yaml
@@ -62,6 +62,7 @@ spec:
         runAsNonRoot: true
         runAsUser: 65534
       serviceAccountName: grafana
+      priorityClassName: prometheus-priorityclass
       volumes:
       - emptyDir: {}
         name: grafana-storage

--- a/clusterloader2/pkg/prometheus/manifests/prometheus-prometheus.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/prometheus-prometheus.yaml
@@ -63,6 +63,7 @@ spec:
   serviceMonitorSelector: {}
   podMonitorNamespaceSelector: {}
   podMonitorSelector: {}
+  priorityClassName: prometheus-priorityclass
   version: v2.25.0
   retention: 7d
   {{if not $PROMETHEUS_TOLERATE_MASTER}}


### PR DESCRIPTION
The goal is to prevent eviction of prometheus when some pods with higher priority are created as part of the test.

/hold (for me to ensure in manual run that the goal is achieved)

/assign @tosi3k 