### PR TITLE
Improve error logging in exec service

### DIFF
--- a/clusterloader2/pkg/measurement/common/api_availability_measurement.go
+++ b/clusterloader2/pkg/measurement/common/api_availability_measurement.go
@@ -97,7 +97,7 @@ func (a *apiAvailabilityMeasurement) pollHost(hostIP string) (string, error) {
 	cmd := fmt.Sprintf("curl --connect-timeout %d -s -k -w \"%%{http_code}\" -o /dev/null https://%s:443/readyz", a.hostPollTimeoutSeconds, hostIP)
 	output, err := execservice.RunCommand(pod, cmd)
 	if err != nil {
-		return "", fmt.Errorf("problem with RunCommand(): %w", err)
+		return "", fmt.Errorf("problem with RunCommand(): output=%q, err=%w", output, err)
 	}
 	return output, nil
 }


### PR DESCRIPTION
The goal is to make simpler debugging error cases by printing why it failed.

/assign @tosi3k 