### PR TITLE
Avoid race in subsequent changes to the same controller

### DIFF
--- a/clusterloader2/pkg/measurement/common/wait_for_controlled_pods.go
+++ b/clusterloader2/pkg/measurement/common/wait_for_controlled_pods.go
@@ -615,10 +615,10 @@ func (w *waitForControlledPodsRunningMeasurement) waitForRuntimeObject(obj runti
 	o := newObjectChecker(key)
 	o.lock.Lock()
 	defer o.lock.Unlock()
+	ctx, cancel := context.WithCancel(ctx)
+	o.cancel = cancel
 	w.handlingGroup.Start(func() {
-		ctx, cancel := context.WithCancel(ctx)
 		defer cancel()
-		o.SetCancel(cancel)
 		if operationTimeout != time.Duration(0) {
 			ctx, cancel = context.WithTimeout(ctx, operationTimeout)
 			defer cancel()


### PR DESCRIPTION
/kind bug
#### What this PR does / why we need it:

One of the test runs has failed with

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x17b1e9a]
goroutine 79903 [running]:
k8s.io/perf-tests/clusterloader2/pkg/measurement/common.(*objectChecker).Stop(0x1aa49a0)
	/home/prow/go/src/k8s.io/perf-tests/clusterloader2/pkg/measurement/common/wait_for_controlled_pods.go:713 +0x7a
k8s.io/perf-tests/clusterloader2/pkg/measurement/util/checker.Map.Add(...)
	/home/prow/go/src/k8s.io/perf-tests/clusterloader2/pkg/measurement/util/checker/checker_map.go:43
k8s.io/perf-tests/clusterloader2/pkg/measurement/common.(*waitForControlledPodsRunningMeasurement).handleObjectLocked(0xc03c6c9ba0, {0x0, 0x0}, {0x20edda0, 0xc081055010})
	/home/prow/go/src/k8s.io/perf-tests/clusterloader2/pkg/measurement/common/wait_for_controlled_pods.go:493 +0x1f6
k8s.io/perf-tests/clusterloader2/pkg/measurement/common.(*waitForControlledPodsRunningMeasurement).handleObject(0xc03c6c9ba0, {0x0, 0x0}, {0x1c5b1e0, 0xc081055010})
	/home/prow/go/src/k8s.io/perf-tests/clusterloader2/pkg/measurement/common/wait_for_controlled_pods.go:453 +0x5b5
k8s.io/perf-tests/clusterloader2/pkg/measurement/common.(*waitForControlledPodsRunningMeasurement).start.func1.1()
	/home/prow/go/src/k8s.io/perf-tests/clusterloader2/pkg/measurement/common/wait_for_controlled_pods.go:279 +0x2d
k8s.io/perf-tests/clusterloader2/pkg/measurement/util/workerqueue.(*WorkerQueue).worker(0xc02447dba0)
	/home/prow/go/src/k8s.io/perf-tests/clusterloader2/pkg/measurement/util/workerqueue/workerqueue.go:65 +0x31
k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
	/home/prow/go/pkg/mod/k8s.io/apimachinery@v0.22.15/pkg/util/wait/wait.go:73 +0x5a
created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start
	/home/prow/go/pkg/mod/k8s.io/apimachinery@v0.22.15/pkg/util/wait/wait.go:71 +0x88
```

This has failed on o.cancel = nil in 
https://github.com/kubernetes/perf-tests/blob/19927c1a477eaebeb004387972def1db75142c10/clusterloader2/pkg/measurement/common/wait_for_controlled_pods.go#L710-L713


The cancel is being set in 
https://github.com/kubernetes/perf-tests/blob/83e45df022caa7507aa84f5b8af85db2af153c6e/clusterloader2/pkg/measurement/common/wait_for_controlled_pods.go#L615-L621

The problem is that the setting it happens asynchronously (in the separate goroutine) and when the function finishes there is potential race between calling o.cancel and o.SetCancel.

If the object is being changed between o.SetCancel is called, then the attempt to replace it (and Stop previous instance) will fail as here.

The idea for fix is to:
* make invariant that when the waitForRuntimeObject finishes (so before it's pushed to checkerMap) it has o.cancel set.
* context.WithCancel requires calling cancel as soon as the code finishes to clean resources, so let's keep it where it was (in the async goroutine).

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:


/assign @tosi3k 
