### PR TITLE
Add timeout to exec command used for polling single master health

### DIFF
--- a/clusterloader2/pkg/execservice/exec_service.go
+++ b/clusterloader2/pkg/execservice/exec_service.go
@@ -134,10 +134,10 @@ func TearDownExecService(f *framework.Framework) error {
 	return nil
 }
 
-// RunCommand executes given command on a pod in cluster.
-func RunCommand(pod *corev1.Pod, cmd string) (string, error) {
+// RunCommand executes given command on a pod in cluster. Context is passed to the exec command.
+func RunCommand(ctx context.Context, pod *corev1.Pod, cmd string) (string, error) {
 	var stdout, stderr bytes.Buffer
-	c := exec.Command("kubectl", "exec", fmt.Sprintf("--namespace=%v", pod.Namespace), pod.Name, "--", "/bin/sh", "-x", "-c", cmd)
+	c := exec.CommandContext(ctx, "kubectl", "exec", fmt.Sprintf("--namespace=%v", pod.Namespace), pod.Name, "--", "/bin/sh", "-x", "-c", cmd)
 	c.Stdout, c.Stderr = &stdout, &stderr
 	if err := c.Run(); err != nil {
 		return stderr.String(), err

--- a/clusterloader2/pkg/measurement/common/service_creation_latency.go
+++ b/clusterloader2/pkg/measurement/common/service_creation_latency.go
@@ -380,7 +380,7 @@ func (p *pingChecker) run() {
 			for _, ip := range ips {
 				address := net.JoinHostPort(ip, fmt.Sprint(port))
 				command := fmt.Sprintf("curl %s", address)
-				_, err = execservice.RunCommand(pod, command)
+				_, err = execservice.RunCommand(context.TODO(), pod, command)
 				if err != nil {
 					break
 				}


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

With the current approach the whole operation of polling single master health via exec command can get stuck for a latency of respective POST call, which in case of overloaded cluster can take O(minutes) .

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

