### PR TITLE
cl2: Enable scraping mutex profiles for etcd

### DIFF
--- a/clusterloader2/pkg/measurement/common/bundle/test_metrics.go
+++ b/clusterloader2/pkg/measurement/common/bundle/test_metrics.go
@@ -60,6 +60,9 @@ func createTestMetricsMeasurement() measurement.Measurement {
 	if metrics.etcdBlockProfile, err = measurement.CreateMeasurement("BlockProfile"); err != nil {
 		klog.Errorf("%v: etcdBlockProfile creation error: %v", metrics, err)
 	}
+	if metrics.etcdMutexProfile, err = measurement.CreateMeasurement("MutexProfile"); err != nil {
+		klog.Errorf("%v: etcdMutexProfile creation error: %v", metrics, err)
+	}
 	if metrics.apiserverCPUProfile, err = measurement.CreateMeasurement("CPUProfile"); err != nil {
 		klog.Errorf("%v: apiserverCPUProfile creation error: %v", metrics, err)
 	}
@@ -104,6 +107,7 @@ type testMetrics struct {
 	etcdCPUProfile                 measurement.Measurement
 	etcdMemoryProfile              measurement.Measurement
 	etcdBlockProfile               measurement.Measurement
+	etcdMutexProfile               measurement.Measurement
 	apiserverCPUProfile            measurement.Measurement
 	apiserverMemoryProfile         measurement.Measurement
 	apiserverBlockProfile          measurement.Measurement
@@ -183,6 +187,8 @@ func (t *testMetrics) Execute(config *measurement.Config) ([]measurement.Summary
 		appendResults(&summaries, errList, summary, executeError(t.etcdMemoryProfile.String(), action, err))
 		summary, err = execute(t.etcdBlockProfile, etcdStartConfig)
 		appendResults(&summaries, errList, summary, executeError(t.etcdBlockProfile.String(), action, err))
+		summary, err = execute(t.etcdMutexProfile, etcdStartConfig)
+		appendResults(&summaries, errList, summary, executeError(t.etcdMutexProfile.String(), action, err))
 		summary, err = execute(t.apiserverCPUProfile, kubeApiserverStartConfig)
 		appendResults(&summaries, errList, summary, executeError(t.apiserverCPUProfile.String(), action, err))
 		summary, err = execute(t.apiserverMemoryProfile, kubeApiserverStartConfig)
@@ -220,6 +226,8 @@ func (t *testMetrics) Execute(config *measurement.Config) ([]measurement.Summary
 		appendResults(&summaries, errList, summary, executeError(t.etcdMemoryProfile.String(), action, err))
 		summary, err = execute(t.etcdBlockProfile, etcdGatherConfig)
 		appendResults(&summaries, errList, summary, executeError(t.etcdBlockProfile.String(), action, err))
+		summary, err = execute(t.etcdMutexProfile, etcdGatherConfig)
+		appendResults(&summaries, errList, summary, executeError(t.etcdMutexProfile.String(), action, err))
 		summary, err = execute(t.apiserverCPUProfile, kubeApiserverGatherConfig)
 		appendResults(&summaries, errList, summary, executeError(t.apiserverCPUProfile.String(), action, err))
 		summary, err = execute(t.apiserverMemoryProfile, kubeApiserverGatherConfig)
@@ -262,6 +270,7 @@ func (t *testMetrics) Dispose() {
 	t.etcdCPUProfile.Dispose()
 	t.etcdMemoryProfile.Dispose()
 	t.etcdBlockProfile.Dispose()
+	t.etcdMutexProfile.Dispose()
 	t.apiserverCPUProfile.Dispose()
 	t.apiserverMemoryProfile.Dispose()
 	t.apiserverBlockProfile.Dispose()

--- a/clusterloader2/pkg/measurement/common/profile.go
+++ b/clusterloader2/pkg/measurement/common/profile.go
@@ -39,6 +39,7 @@ const (
 	cpuProfileName    = "CPUProfile"
 	memoryProfileName = "MemoryProfile"
 	blockProfileName  = "BlockProfile"
+	mutexProfileName  = "MutexProfile"
 )
 
 func init() {
@@ -50,6 +51,9 @@ func init() {
 	}
 	if err := measurement.Register(blockProfileName, createProfileMeasurementFactory(blockProfileName, "block")); err != nil {
 		klog.Fatalf("Cannot register %s: %v", blockProfileName, err)
+	}
+	if err := measurement.Register(mutexProfileName, createProfileMeasurementFactory(mutexProfileName, "mutex")); err != nil {
+		klog.Fatalf("Cannot register %s: %v", mutexProfileName, err)
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Follow up from https://github.com/kubernetes/perf-tests/pull/2215#discussion_r1048399738

Allow mutex profiles to be exported for etcd.
All control plane components expose block profiles. None except etcd expose mutex profiles, this commit enables scraping mutex profiles for etcd.

#### Which issue(s) this PR fixes:
NA

#### Special notes for your reviewer:
NA

/assign @marseel 