### PR TITLE
Fix netperf docker image build failure

### DIFF
--- a/network/benchmarks/netperf/Dockerfile
+++ b/network/benchmarks/netperf/Dockerfile
@@ -31,7 +31,7 @@ COPY go.mod go.mod
 
 RUN go build -o nptests
 
-FROM debian:jessie
+FROM debian:bullseye
 ENV LD_LIBRARY_PATH=/usr/local/lib
 
 MAINTAINER Girish Kalele <gkalele@google.com>
@@ -54,7 +54,7 @@ RUN cd iperf-3.1 && ./configure --prefix=/usr/local --bindir /usr/local/bin && m
 
 # Download and build netperf from sources
 RUN curl -LO https://github.com/HewlettPackard/netperf/archive/netperf-2.7.0.tar.gz && tar -xzf netperf-2.7.0.tar.gz && mv netperf-netperf-2.7.0/ netperf-2.7.0
-RUN cd netperf-2.7.0 && ./configure --prefix=/usr/local --bindir /usr/local/bin && make && make install
+RUN cd netperf-2.7.0 && ./configure --prefix=/usr/local --bindir /usr/local/bin && make CFLAGS=-fcommon && make install
 
 COPY --from=builder /workspace/nptests /usr/bin/
 


### PR DESCRIPTION
#### What this PR does / why we need it:
##### What
- Update netperf container base from `debian:jessie` to `debian:bullseye`
- Add `CFLAGS=-fcommon` to build of netperf binary

##### Why
- The default image `sirot/netperf-latest` used by the netperf test crashes when given the `-testFrom` and `-testTo` parameters. These parameters cannot be turned off, but are implicitly set when omitted by user; introduced by kubernetes/perf-tests#2144.
- `debian:jessie` container on docker hub is ~2 years old: apt repo keys are expired, thus preventing dependency installation and container build
- After upgrade to `debian:bullseye`, with a newer compiler, netperf needs `-fcommon` flag for building (as workaround); see HewlettPackard/netperf#46

##### Relevance/Value
Updating the container is necessary to run the tests at all, fixing a regression introduced by the additionally passed parameters from kubernetes/perf-tests#2144

#### Which issue(s) this PR fixes:
```
NONE
```

#### Special notes for your reviewer:
```
NONE
```

#### What type of PR is this?
/kind bug
/kind regression
