### PR TITLE
WaitForPods: print timeout debugging data only if we are really seeing timeout.

### DIFF
--- a/clusterloader2/pkg/measurement/common/wait_for_controlled_pods.go
+++ b/clusterloader2/pkg/measurement/common/wait_for_controlled_pods.go
@@ -650,7 +650,7 @@ func (w *waitForControlledPodsRunningMeasurement) waitForRuntimeObject(obj runti
 			o.err = fmt.Errorf("%s: %v", key, err)
 			o.failedPods = failedPods
 
-			hasTimedOut := ctx.Err() != nil
+			hasTimedOut := ctx.Err() == context.DeadlineExceeded
 			if hasTimedOut {
 				if isDeleted {
 					o.status = deleteTimeout


### PR DESCRIPTION
e.g. now it happens that if we update controller (e.g. job, deployment) we wait on, we see time out error as new observed revision of the controller cancels context used by WaitForPods to start a new one, for new revision.

While it doesn't break anything, it is quite misleading.

/assign @tosi3k 