### PR TITLE
Add a way to customize namespace deletion timeout

### DIFF
--- a/clusterloader2/api/default.go
+++ b/clusterloader2/api/default.go
@@ -19,6 +19,7 @@ package api
 import (
 	"fmt"
 
+	"k8s.io/perf-tests/clusterloader2/pkg/framework/client"
 	"k8s.io/perf-tests/clusterloader2/pkg/util"
 )
 
@@ -55,5 +56,10 @@ func (ns *NamespaceConfig) SetDefaults() {
 	defaultEnableExistingNS := false
 	if ns.EnableExistingNamespaces == nil {
 		ns.EnableExistingNamespaces = &defaultEnableExistingNS
+	}
+
+	defaultDeleteNamespaceTimeout := Duration(client.DefaultNamespaceDeletionTimeout)
+	if ns.DeleteNamespaceTimeout == nil {
+		ns.DeleteNamespaceTimeout = &defaultDeleteNamespaceTimeout
 	}
 }

--- a/clusterloader2/api/types.go
+++ b/clusterloader2/api/types.go
@@ -144,6 +144,9 @@ type NamespaceConfig struct {
 	DeleteAutomanagedNamespaces *bool `json:"deleteAutomanagedNamespaces,omitempty"`
 	// EnableExistingNamespaces enables to use pre-created namespaces in a test.
 	EnableExistingNamespaces *bool `json:"enableExistingNamespaces,omitempty"`
+	// DeleteNamespaceTimeout controls a timeout for waiting until automanaged namespaces are deleted.
+	// Defaults to 10m, if not set.
+	DeleteNamespaceTimeout *Duration `json:"deleteNamespaceTimeout,omitempty"`
 }
 
 // NamespaceRange specifies the range of namespaces [Min, Max].

--- a/clusterloader2/pkg/execservice/exec_service.go
+++ b/clusterloader2/pkg/execservice/exec_service.go
@@ -128,7 +128,7 @@ func TearDownExecService(f *framework.Framework) error {
 	if err := client.DeleteNamespace(f.GetClientSets().GetClient(), execDeploymentNamespace); err != nil {
 		return fmt.Errorf("deleting %s namespace error: %v", execDeploymentNamespace, err)
 	}
-	if err := client.WaitForDeleteNamespace(f.GetClientSets().GetClient(), execDeploymentNamespace); err != nil {
+	if err := client.WaitForDeleteNamespace(f.GetClientSets().GetClient(), execDeploymentNamespace, client.DefaultNamespaceDeletionTimeout); err != nil {
 		return err
 	}
 	return nil

--- a/clusterloader2/pkg/framework/client/objects.go
+++ b/clusterloader2/pkg/framework/client/objects.go
@@ -45,7 +45,7 @@ const (
 	retryBackoffSteps           = 6
 
 	// Parameters for namespace deletion operations.
-	defaultNamespaceDeletionTimeout  = 10 * time.Minute
+	DefaultNamespaceDeletionTimeout  = 10 * time.Minute
 	defaultNamespaceDeletionInterval = 5 * time.Second
 
 	// String const defined in https://go.googlesource.com/net/+/749bd193bc2bcebc5f1a048da8af0392cfb2fa5d/http2/transport.go#1041
@@ -229,7 +229,7 @@ func ListNamespaces(c clientset.Interface) ([]apiv1.Namespace, error) {
 }
 
 // WaitForDeleteNamespace waits untils namespace is terminated.
-func WaitForDeleteNamespace(c clientset.Interface, namespace string) error {
+func WaitForDeleteNamespace(c clientset.Interface, namespace string, timeout time.Duration) error {
 	retryWaitFunc := func() (bool, error) {
 		_, err := c.CoreV1().Namespaces().Get(context.TODO(), namespace, metav1.GetOptions{})
 		if err != nil {
@@ -242,7 +242,7 @@ func WaitForDeleteNamespace(c clientset.Interface, namespace string) error {
 		}
 		return false, nil
 	}
-	return wait.PollImmediate(defaultNamespaceDeletionInterval, defaultNamespaceDeletionTimeout, retryWaitFunc)
+	return wait.PollImmediate(defaultNamespaceDeletionInterval, timeout, retryWaitFunc)
 }
 
 // ListEvents retrieves events for the object with the given name.

--- a/clusterloader2/pkg/imagepreload/imagepreload.go
+++ b/clusterloader2/pkg/imagepreload/imagepreload.go
@@ -158,7 +158,7 @@ func (c *controller) PreloadImages() error {
 	if err := client.DeleteNamespace(kclient, namespace); err != nil {
 		return err
 	}
-	if err := client.WaitForDeleteNamespace(kclient, namespace); err != nil {
+	if err := client.WaitForDeleteNamespace(kclient, namespace, client.DefaultNamespaceDeletionTimeout); err != nil {
 		return err
 	}
 	return nil

--- a/clusterloader2/pkg/measurement/common/network/network_performance_measurement.go
+++ b/clusterloader2/pkg/measurement/common/network/network_performance_measurement.go
@@ -217,7 +217,7 @@ func (npm *networkPerformanceMeasurement) cleanupCluster() {
 	if err := client.DeleteNamespace(npm.k8sClient, netperfNamespace); err != nil {
 		klog.Errorf("Failed to delete namespace: %v", err)
 	}
-	if err := client.WaitForDeleteNamespace(npm.k8sClient, netperfNamespace); err != nil {
+	if err := client.WaitForDeleteNamespace(npm.k8sClient, netperfNamespace, client.DefaultNamespaceDeletionTimeout); err != nil {
 		klog.Errorf("Waiting for namespace deletion failed: %v", err)
 	}
 }

--- a/clusterloader2/pkg/measurement/common/probes/probes.go
+++ b/clusterloader2/pkg/measurement/common/probes/probes.go
@@ -153,7 +153,7 @@ func (p *probesMeasurement) Dispose() {
 	if err := client.DeleteNamespace(k8sClient, probesNamespace); err != nil {
 		klog.Errorf("error while deleting %s namespace: %v", probesNamespace, err)
 	}
-	if err := client.WaitForDeleteNamespace(k8sClient, probesNamespace); err != nil {
+	if err := client.WaitForDeleteNamespace(k8sClient, probesNamespace, client.DefaultNamespaceDeletionTimeout); err != nil {
 		klog.Errorf("error while waiting for %s namespace to be deleted: %v", probesNamespace, err)
 	}
 }

--- a/clusterloader2/pkg/prometheus/prometheus.go
+++ b/clusterloader2/pkg/prometheus/prometheus.go
@@ -331,7 +331,7 @@ func (pc *Controller) TearDownPrometheusStack() error {
 	if err := client.DeleteNamespace(k8sClient, namespace); err != nil {
 		return err
 	}
-	if err := client.WaitForDeleteNamespace(k8sClient, namespace); err != nil {
+	if err := client.WaitForDeleteNamespace(k8sClient, namespace, client.DefaultNamespaceDeletionTimeout); err != nil {
 		return err
 	}
 	return nil

--- a/clusterloader2/pkg/test/simple_test_executor.go
+++ b/clusterloader2/pkg/test/simple_test_executor.go
@@ -115,7 +115,7 @@ func (ste *simpleExecutor) prepareTestNamespaces(ctx Context, conf *api.Config) 
 	var deleteStaleNS = *conf.Namespace.DeleteStaleNamespaces
 	if len(staleNamespaces) > 0 && deleteStaleNS {
 		klog.Warning("stale automanaged namespaces found")
-		if errList := ctx.GetClusterFramework().DeleteNamespaces(staleNamespaces); !errList.IsEmpty() {
+		if errList := ctx.GetClusterFramework().DeleteNamespaces(staleNamespaces, conf.Namespace.DeleteNamespaceTimeout.ToTimeDuration()); !errList.IsEmpty() {
 			klog.Errorf("stale automanaged namespaces cleanup error: %s", errList.String())
 		}
 	}
@@ -389,7 +389,7 @@ func cleanupResources(ctx Context, conf *api.Config) {
 	cleanupStartTime := time.Now()
 	ctx.GetManager().Dispose()
 	if *conf.Namespace.DeleteAutomanagedNamespaces {
-		if errList := ctx.GetClusterFramework().DeleteAutomanagedNamespaces(); !errList.IsEmpty() {
+		if errList := ctx.GetClusterFramework().DeleteAutomanagedNamespaces(conf.Namespace.DeleteNamespaceTimeout.ToTimeDuration()); !errList.IsEmpty() {
 			klog.Errorf("Resource cleanup error: %v", errList.String())
 			return
 		}

--- a/clusterloader2/testing/huge-service/config.yaml
+++ b/clusterloader2/testing/huge-service/config.yaml
@@ -2,10 +2,12 @@
 {{$HUGE_SERVICE_HEADLESS := DefaultParam .CL2_HUGE_SERVICE_HEADLESS false}}
 {{$HUGE_SERVICE_ENDPOINTS := DefaultParam .CL2_HUGE_SERVICE_ENDPOINTS 1000}}
 {{$STATEFULSET_ENDPOINTS := DefaultParam .CL2_STATEFULSET_ENDPOINTS 100}}
+{{$DELETE_NAMESPACE_TIMEOUT := DefaultParam .CL2_DELETE_NAMESPACE_TIMEOUT "10m"}}
 
 name: huge-service
 namespace:
   number: 1
+  deleteNamespaceTimeout: {{$DELETE_NAMESPACE_TIMEOUT}}
 tuningSets:
 - name: Sequence
   parallelismLimitedLoad:


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
#### What this PR does / why we need it:

This PR makes it possible to customize namespace deletion timeout, as it's not possible that all tests everywhere can fit in 10m.

This PR also uses the possibility to customize it in huge service which in some cases takes more than 10m to cleanup (it's short and creates tons of events).

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

/assign @Argh4k 
