### PR TITLE
Use registry.k8s.io in slo-monitor Makefile

### DIFF
--- a/slo-monitor/Makefile
+++ b/slo-monitor/Makefile
@@ -14,8 +14,8 @@
 
 PACKAGE = k8s.io/perf-tests/slo-monitor
 TAG = 0.15.3
-# Image should be pulled from k8s.gcr.io, which will auto-detect
-# region (us, eu, asia, ...) and pull from the closest.
+# Image should be pulled from registry.k8s.io, which will auto-detect
+# region/cloud provider and pull from the closest.
 REPOSITORY?=registry.k8s.io
 # Images should be pushed to staging-k8s.gcr.io.
 PUSH_REPOSITORY?=staging-k8s.gcr.io

--- a/slo-monitor/Makefile
+++ b/slo-monitor/Makefile
@@ -16,7 +16,7 @@ PACKAGE = k8s.io/perf-tests/slo-monitor
 TAG = 0.15.3
 # Image should be pulled from k8s.gcr.io, which will auto-detect
 # region (us, eu, asia, ...) and pull from the closest.
-REPOSITORY?=k8s.gcr.io
+REPOSITORY?=registry.k8s.io
 # Images should be pushed to staging-k8s.gcr.io.
 PUSH_REPOSITORY?=staging-k8s.gcr.io
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Reference issue: #2231, https://github.com/kubernetes/k8s.io/issues/4738