### PR TITLE
Update `pause` container image version. 

### DIFF
--- a/clusterloader2/docs/GETTING_STARTED.md
+++ b/clusterloader2/docs/GETTING_STARTED.md
@@ -228,7 +228,7 @@ spec:
         group: test-pod
     spec:
       containers:
-      - image: registry.k8s.io/pause:3.1
+      - image: registry.k8s.io/pause:3.9
         name: {{.Name}}
 ```
 ## Execute test

--- a/clusterloader2/testing/density/deployment.yaml
+++ b/clusterloader2/testing/density/deployment.yaml
@@ -16,7 +16,7 @@ spec:
         group: {{.Group}}
     spec:
       containers:
-      - image: registry.k8s.io/pause:3.1
+      - image: registry.k8s.io/pause:3.9
         imagePullPolicy: IfNotPresent
         name: {{.Name}}
         ports:

--- a/clusterloader2/testing/density/scheduler/custom-scheduler-metrics/deployment-custom-schd-sample.yaml
+++ b/clusterloader2/testing/density/scheduler/custom-scheduler-metrics/deployment-custom-schd-sample.yaml
@@ -16,5 +16,5 @@ spec:
     spec:
       schedulerName: default-scheduler
       containers:
-      - image: registry.k8s.io/pause:3.1
+      - image: registry.k8s.io/pause:3.9
         name: {{.Name}}

--- a/clusterloader2/testing/density/scheduler/pod-affinity/deployment.yaml
+++ b/clusterloader2/testing/density/scheduler/pod-affinity/deployment.yaml
@@ -25,7 +25,7 @@ spec:
               topologyKey: "kubernetes.io/hostname"
             weight: 1
       containers:
-      - image: registry.k8s.io/pause:3.1
+      - image: registry.k8s.io/pause:3.9
         imagePullPolicy: IfNotPresent
         name: {{.Name}}
         ports:

--- a/clusterloader2/testing/density/scheduler/pod-anti-affinity/deployment.yaml
+++ b/clusterloader2/testing/density/scheduler/pod-anti-affinity/deployment.yaml
@@ -25,7 +25,7 @@ spec:
               topologyKey: "kubernetes.io/hostname"
             weight: 1
       containers:
-      - image: registry.k8s.io/pause:3.1
+      - image: registry.k8s.io/pause:3.9
         imagePullPolicy: IfNotPresent
         name: {{.Name}}
         ports:

--- a/clusterloader2/testing/density/scheduler/pod-topology-spread/deployment.yaml
+++ b/clusterloader2/testing/density/scheduler/pod-topology-spread/deployment.yaml
@@ -27,7 +27,7 @@ spec:
           matchLabels:
             group: {{.Group}}
       containers:
-      - image: registry.k8s.io/pause:3.1
+      - image: registry.k8s.io/pause:3.9
         imagePullPolicy: IfNotPresent
         name: {{.Name}}
         ports:

--- a/clusterloader2/testing/experimental/storage/pod-startup/volume-types/configmap/deployment_with_configmap.yaml
+++ b/clusterloader2/testing/experimental/storage/pod-startup/volume-types/configmap/deployment_with_configmap.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - name: {{.Name}}
-        image: registry.k8s.io/pause:3.1
+        image: registry.k8s.io/pause:3.9
         imagePullPolicy: IfNotPresent
         volumeMounts:
         {{ range $volumeIndex := Loop .VolumesPerPod }}

--- a/clusterloader2/testing/experimental/storage/pod-startup/volume-types/downwardapi/deployment_with_downwardapi.yaml
+++ b/clusterloader2/testing/experimental/storage/pod-startup/volume-types/downwardapi/deployment_with_downwardapi.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - name: {{.Name}}
-        image: registry.k8s.io/pause:3.1
+        image: registry.k8s.io/pause:3.9
         imagePullPolicy: IfNotPresent
         volumeMounts:
         {{ range $volumeIndex := Loop .VolumesPerPod }}

--- a/clusterloader2/testing/experimental/storage/pod-startup/volume-types/emptydir/deployment_with_emptydir.yaml
+++ b/clusterloader2/testing/experimental/storage/pod-startup/volume-types/emptydir/deployment_with_emptydir.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - name: {{.Name}}
-        image: registry.k8s.io/pause:3.1
+        image: registry.k8s.io/pause:3.9
         imagePullPolicy: IfNotPresent
         volumeMounts:
         {{ range $volumeIndex := Loop .VolumesPerPod }}

--- a/clusterloader2/testing/experimental/storage/pod-startup/volume-types/genericephemeralinline/deployment_with_inline.yaml
+++ b/clusterloader2/testing/experimental/storage/pod-startup/volume-types/genericephemeralinline/deployment_with_inline.yaml
@@ -24,7 +24,7 @@ spec:
     spec:
       containers:
       - name: {{.Name}}
-        image: registry.k8s.io/pause:3.1
+        image: registry.k8s.io/pause:3.9
         imagePullPolicy: IfNotPresent
         volumeMounts:
         {{ range $volumeIndex := Loop .VolumesPerPod }}

--- a/clusterloader2/testing/experimental/storage/pod-startup/volume-types/persistentvolume/deployment_with_pvc.yaml
+++ b/clusterloader2/testing/experimental/storage/pod-startup/volume-types/persistentvolume/deployment_with_pvc.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - name: {{.Name}}
-        image: registry.k8s.io/pause:3.1
+        image: registry.k8s.io/pause:3.9
         imagePullPolicy: IfNotPresent
         volumeMounts:
         {{ range $volumeIndex := Loop .VolumesPerPod }}

--- a/clusterloader2/testing/experimental/storage/pod-startup/volume-types/secret/deployment_with_secret.yaml
+++ b/clusterloader2/testing/experimental/storage/pod-startup/volume-types/secret/deployment_with_secret.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - name: {{.Name}}
-        image: registry.k8s.io/pause:3.1
+        image: registry.k8s.io/pause:3.9
         imagePullPolicy: IfNotPresent
         volumeMounts:
         {{ range $volumeIndex := Loop .VolumesPerPod }}

--- a/clusterloader2/testing/load/config.yaml
+++ b/clusterloader2/testing/load/config.yaml
@@ -73,7 +73,7 @@
 {{$EXEC_TIMEOUT := DefaultParam .CL2_EXEC_TIMEOUT "3600s"}}
 {{$SLEEP_AFTER_EXEC_DURATION := DefaultParam .CL2_SLEEP_AFTER_EXEC_DURATION "0s"}}
 
-{{$latencyPodImage := DefaultParam .CL2_LATENCY_POD_IMAGE "registry.k8s.io/pause:3.1"}}
+{{$latencyPodImage := DefaultParam .CL2_LATENCY_POD_IMAGE "registry.k8s.io/pause:3.9"}}
 {{$defaultQps := DefaultParam .CL2_DEFAULT_QPS (IfThenElse (le .Nodes 500) 10 100)}}
 
 name: load

--- a/clusterloader2/testing/load/daemonset.yaml
+++ b/clusterloader2/testing/load/daemonset.yaml
@@ -1,5 +1,5 @@
 {{$HostNetworkMode := DefaultParam .CL2_USE_HOST_NETWORK_PODS false}}
-{{$Image := DefaultParam .Image "registry.k8s.io/pause:3.1"}}
+{{$Image := DefaultParam .Image "registry.k8s.io/pause:3.9"}}
 {{$Env := DefaultParam .Env ""}}
 {{$DaemonSetSurge := DefaultParam .CL2_DS_SURGE (MaxInt 10 (DivideInt .Nodes 20))}} # 5% of nodes, but not less than 10
 {{$RUN_ON_ARM_NODES := DefaultParam .CL2_RUN_ON_ARM_NODES false}}

--- a/clusterloader2/testing/load/deployment.yaml
+++ b/clusterloader2/testing/load/deployment.yaml
@@ -55,7 +55,7 @@ spec:
           ./dnsperfgo -duration 60s -idle-duration 10s -inputfile /var/configmap/all-queries -qps {{$dnsQPSPerClient}};
         name: {{.Name}}-dnsperf
 {{else}}
-      - image: registry.k8s.io/pause:3.1
+      - image: registry.k8s.io/pause:3.9
         name: {{.Name}}
 {{end}}
         resources:

--- a/clusterloader2/testing/load/job.yaml
+++ b/clusterloader2/testing/load/job.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
       - name: {{.Name}}
         # TODO(#799): We should test the "run-to-completion" workflow and hence don't use pause pods.
-        image: registry.k8s.io/pause:3.1
+        image: registry.k8s.io/pause:3.9
         resources:
           # Keep the CpuRequest/MemoryRequest request equal percentage of 1-core, 4GB node.
           # For now we're setting it to 0.5%.

--- a/clusterloader2/testing/load/modules/reconcile-objects.yaml
+++ b/clusterloader2/testing/load/modules/reconcile-objects.yaml
@@ -13,7 +13,7 @@
 {{$operationTimeout := .operationTimeout}}
 
 # DaemonSets
-{{$daemonSetImage := DefaultParam .daemonSetImage "registry.k8s.io/pause:3.0"}}
+{{$daemonSetImage := DefaultParam .daemonSetImage "registry.k8s.io/pause:3.9"}}
 {{$daemonSetReplicas := .daemonSetReplicas}}
 {{$daemonSetEnv := .daemonSetEnv}}
 

--- a/clusterloader2/testing/load/simple-deployment.yaml
+++ b/clusterloader2/testing/load/simple-deployment.yaml
@@ -4,7 +4,7 @@
 {{$CpuRequest := DefaultParam .CpuRequest "5m"}}
 {{$EnvVar := DefaultParam .EnvVar "a"}}
 {{$MemoryRequest := DefaultParam .MemoryRequest "20M"}}
-{{$Image := DefaultParam .Image "registry.k8s.io/pause:3.1"}}
+{{$Image := DefaultParam .Image "registry.k8s.io/pause:3.9"}}
 {{$RUN_ON_ARM_NODES := DefaultParam .CL2_RUN_ON_ARM_NODES false}}
 
 apiVersion: apps/v1

--- a/clusterloader2/testing/load/statefulset.yaml
+++ b/clusterloader2/testing/load/statefulset.yaml
@@ -25,7 +25,7 @@ spec:
       hostNetwork: {{$HostNetworkMode}}
       containers:
       - name: {{.Name}}
-        image: registry.k8s.io/pause:3.1
+        image: registry.k8s.io/pause:3.9
         ports:
           - containerPort: 80
             name: web

--- a/clusterloader2/testing/node-throughput/config.yaml
+++ b/clusterloader2/testing/node-throughput/config.yaml
@@ -4,7 +4,7 @@
 #Constants
 {{$POD_COUNT := DefaultParam .POD_COUNT 100}}
 {{$POD_THROUGHPUT := DefaultParam .POD_THROUGHPUT 5}}
-{{$CONTAINER_IMAGE := DefaultParam .CONTAINER_IMAGE "registry.k8s.io/pause:3.1"}}
+{{$CONTAINER_IMAGE := DefaultParam .CONTAINER_IMAGE "registry.k8s.io/pause:3.9"}}
 {{$POD_STARTUP_LATENCY_THRESHOLD := DefaultParam .POD_STARTUP_LATENCY_THRESHOLD "5s"}}
 {{$OPERATION_TIMEOUT := DefaultParam .OPERATION_TIMEOUT "15m"}}
 

--- a/clusterloader2/testing/windows-tests/config.yaml
+++ b/clusterloader2/testing/windows-tests/config.yaml
@@ -4,7 +4,7 @@
 #Constants
 {{$POD_COUNT := DefaultParam .CL2_POD_COUNT 80}}
 {{$POD_THROUGHPUT := DefaultParam .CL2_POD_THROUGHPUT 0.03}}
-{{$CONTAINER_IMAGE := DefaultParam .CL2_CONTAINER_IMAGE "registry.k8s.io/pause:3.4.1"}}
+{{$CONTAINER_IMAGE := DefaultParam .CL2_CONTAINER_IMAGE "registry.k8s.io/pause:3.9"}}
 {{$POD_STARTUP_LATENCY_THRESHOLD := DefaultParam .CL2_POD_STARTUP_LATENCY_THRESHOLD "60m"}}
 {{$OPERATION_TIMEOUT := DefaultParam .CL2_OPERATION_TIMEOUT "90m"}}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What this PR does / why we need it:
This PR contains the changes to use the more recent `pause:3.9` container image for deployments. 

