### PR TITLE
Scrape k8s apiserver only for aws provider

### DIFF
--- a/clusterloader2/pkg/provider/aws.go
+++ b/clusterloader2/pkg/provider/aws.go
@@ -29,14 +29,15 @@ type AWSProvider struct {
 func NewAWSProvider(_ map[string]string) Provider {
 	return &AWSProvider{
 		features: Features{
-			SupportProbe:                        true,
-			SupportImagePreload:                 true,
-			SupportSSHToMaster:                  true,
+			ShouldPrometheusScrapeApiserverOnly: true,
+			ShouldScrapeKubeProxy:               true,
+			SupportAccessAPIServerPprofEndpoint: true,
 			SupportEnablePrometheusServer:       true,
 			SupportGrabMetricsFromKubelets:      true,
-			SupportAccessAPIServerPprofEndpoint: true,
+			SupportImagePreload:                 true,
+			SupportProbe:                        true,
 			SupportResourceUsageMetering:        true,
-			ShouldScrapeKubeProxy:               true,
+			SupportSSHToMaster:                  true,
 		},
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Scrape k8s apiserver only metrics for AWS provider (added `ShouldPrometheusScrapeApiserverOnly : true` + sorted other options)
CL2 was unable to scrape kcm metrics:
```
4/8 targets are ready, example not ready target: {map[endpoint:kube-controller-manager instance:192.168.149.39:10257 job:master namespace:monitoring service:master] down}
```
