### PR TITLE
perf-dash: add "benchmark" as name also for BenchmarkPerfScheduling

### DIFF
--- a/perfdash/config.go
+++ b/perfdash/config.go
@@ -514,11 +514,7 @@ var (
 				Parser:           parsePerfData,
 			}},
 			"BenchmarkPerfResults": []TestDescription{{
-				// Expected file prefix string is constructed as
-				// OutputFilePrefix+"_"+Name. Given we currently generate
-				// file prefixed with "BenchmarkPerfScheduling_" followed by a date,
-				// set the Name to an empty string.
-				Name:             "",
+				Name:             "bechmark",
 				OutputFilePrefix: "BenchmarkPerfScheduling",
 				Parser:           parsePerfData,
 			}},


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind failing-test

#### What this PR does / why we need it:

This is required because an empty name is no longer supported: the perf-dashboard is run with --allow-parsers-matching-all-tests=false which causes perfdash to skip current configuration for BenchmarkPerfResults as it does not have name set (https://github.com/kubernetes/perf-tests/blob/4674704f45e5d9785741b0399426cbfced37a648/perfdash/metrics-downloader.go#L165-L167).

#### Special notes for your reviewer:

The corresponding change for writing that file with "benchmark" is in https://github.com/kubernetes/kubernetes/pull/118164.