### PR TITLE
Fix BenchmarkPerfResults name. Release perfdash 2.46

### DIFF
--- a/perfdash/Makefile
+++ b/perfdash/Makefile
@@ -1,7 +1,7 @@
 all: push
 
 # See deployment.yaml for the version currently running-- bump this ahead before rebuilding!
-TAG?=2.45
+TAG?=2.46
 
 REPO?=gcr.io/k8s-staging-perf-tests
 

--- a/perfdash/config.go
+++ b/perfdash/config.go
@@ -514,7 +514,7 @@ var (
 				Parser:           parsePerfData,
 			}},
 			"BenchmarkPerfResults": []TestDescription{{
-				Name:             "bechmark",
+				Name:             "benchmark",
 				OutputFilePrefix: "BenchmarkPerfScheduling",
 				Parser:           parsePerfData,
 			}},

--- a/perfdash/deployment.yaml
+++ b/perfdash/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: perfdash
-        image: gcr.io/k8s-staging-perf-tests/perfdash:2.45
+        image: gcr.io/k8s-staging-perf-tests/perfdash:2.46
         command:
           - /perfdash
           -   --www=true


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
We need that to display BenchmarkPerfResults on perfdash

