### PR TITLE
perf-dash: fix "benchmark" as name also for BenchmarkPerfScheduling

### DIFF
--- a/perfdash/config.go
+++ b/perfdash/config.go
@@ -514,7 +514,7 @@ var (
 				Parser:           parsePerfData,
 			}},
 			"BenchmarkPerfResults": []TestDescription{{
-				Name:             "bechmark",
+				Name:             "benchmark",
 				OutputFilePrefix: "BenchmarkPerfScheduling",
 				Parser:           parsePerfData,
 			}},


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind failing-test

#### What this PR does / why we need it:

The previous PR had a
typo (https://github.com/kubernetes/perf-tests/pull/2266).
