### PR TITLE
clusterloader2: Use immediate poll for prom health checks

### DIFF
--- a/clusterloader2/pkg/prometheus/prometheus.go
+++ b/clusterloader2/pkg/prometheus/prometheus.go
@@ -437,7 +437,7 @@ func (pc *Controller) runNodeExporter() error {
 
 func (pc *Controller) waitForPrometheusToBeHealthy() error {
 	klog.V(2).Info("Waiting for Prometheus stack to become healthy...")
-	return wait.Poll(
+	return wait.PollImmediate(
 		checkPrometheusReadyInterval,
 		pc.readyTimeout,
 		pc.isPrometheusReady)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This commit changes `poll.Wait` to `poll.WaitImmediate` in the logic that is used to wait for Prometheus to be ready. Before this commit, cl2 would always wait 30 seconds before checking if Prometheus is healthy, as this is the default interval used to wait between unsuccessful checks. By using `WaitImmediate`, this initial 30s is skipped, which speeds up consecutive runs where Prometheus is already deployed and ready.

