### PR TITLE
Bump dnsperfgo to 1.4.0

### DIFF
--- a/dns/dnsperfgo/Makefile
+++ b/dns/dnsperfgo/Makefile
@@ -1,6 +1,6 @@
 REGISTRY ?= gcr.io/k8s-staging-perf-tests
 IMAGE_NAME = dnsperfgo
-VERSION ?= v1.3.0
+VERSION ?= v1.4.0
 
 all: push
 


### PR DESCRIPTION
Release dnsperfgo `1.4.0` to include the change to use EndpointSlices instead of Endpoints https://github.com/kubernetes/perf-tests/pull/2284