### PR TITLE
CL2 load test bump dnsperfgo image to 1.4.0

### DIFF
--- a/clusterloader2/testing/load/deployment.yaml
+++ b/clusterloader2/testing/load/deployment.yaml
@@ -34,7 +34,7 @@ spec:
       containers:
 {{if .EnableDNSTests}}
 {{if $USE_ADVANCED_DNSTEST}}
-      - image: gcr.io/k8s-staging-perf-tests/dnsperfgo:v1.3.0
+      - image: gcr.io/k8s-staging-perf-tests/dnsperfgo:v1.4.0
         ports:
         - containerPort: 9153
           name: dnsperfmetrics


### PR DESCRIPTION
New dnsperfgo image is released `1.4.0` to use EndpointSlices instead of Endpoints, effectively supporting over 1k endpoints behind a single service https://github.com/kubernetes/perf-tests/pull/2285