### PR TITLE
chore: remove refs to deprecated io/ioutil

### DIFF
--- a/dns/dnsperfgo/main.go
+++ b/dns/dnsperfgo/main.go
@@ -19,8 +19,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"log"
 	"net"
 	"net/http"
@@ -30,6 +28,8 @@ import (
 	"sync"
 	"syscall"
 	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"golang.org/x/net/context"
 	clientset "k8s.io/client-go/kubernetes"
@@ -82,7 +82,7 @@ func main() {
 func hostnamesFromConfig(config *Config) []string {
 	var hostnamesArr []string
 	if config.hostnameFile != "" {
-		contents, err := ioutil.ReadFile(config.hostnameFile)
+		contents, err := os.ReadFile(config.hostnameFile)
 		if err != nil {
 			log.Fatalf("Failed to read input file %q, err - %v, Exiting.", config.hostnameFile, err)
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
"io/ioutil" has been deprecated since Go 1.19: As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code. See the specific function documentation for details.  (SA1019)
#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

