### PR TITLE
Include control plane node role when checking for control plane node

### DIFF
--- a/clusterloader2/pkg/measurement/common/scheduler_latency.go
+++ b/clusterloader2/pkg/measurement/common/scheduler_latency.go
@@ -100,7 +100,7 @@ func (s *schedulerLatencyMeasurement) Execute(config *measurement.Config) ([]mea
 
 	var masterRegistered = false
 	for _, node := range nodes.Items {
-		if util.LegacyIsMasterNode(&node) {
+		if util.LegacyIsMasterNode(&node) || util.IsControlPlaneNode(&node) {
 			masterRegistered = true
 		}
 	}

--- a/clusterloader2/pkg/measurement/util/gatherers/container_resource_gatherer.go
+++ b/clusterloader2/pkg/measurement/util/gatherers/container_resource_gatherer.go
@@ -115,7 +115,7 @@ func NewResourceUsageGatherer(c clientset.Interface, host string, port int, prov
 
 		masterNodes := sets.NewString()
 		for _, node := range nodeList.Items {
-			if pkgutil.LegacyIsMasterNode(&node) {
+			if pkgutil.LegacyIsMasterNode(&node) || pkgutil.IsControlPlaneNode(&node) {
 				masterNodes.Insert(node.Name)
 			}
 		}

--- a/clusterloader2/pkg/prometheus/prometheus.go
+++ b/clusterloader2/pkg/prometheus/prometheus.go
@@ -415,7 +415,7 @@ func (pc *Controller) runNodeExporter() error {
 	numMasters := 0
 	for _, node := range nodes {
 		node := node
-		if util.LegacyIsMasterNode(&node) {
+		if util.LegacyIsMasterNode(&node) || util.IsControlPlaneNode(&node) {
 			numMasters++
 			g.Go(func() error {
 				f, err := pc.manifestsFS().Open(nodeExporterPod)

--- a/clusterloader2/pkg/provider/gce.go
+++ b/clusterloader2/pkg/provider/gce.go
@@ -83,7 +83,7 @@ func (p *GCEProvider) Metadata(c clientset.Interface) (map[string]string, error)
 
 	var masterInstanceIDs []string
 	for _, node := range nodes {
-		if util.LegacyIsMasterNode(&node) {
+		if util.LegacyIsMasterNode(&node) || util.IsControlPlaneNode(&node) {
 			zone, ok := node.Labels["topology.kubernetes.io/zone"]
 			if !ok {
 				// Fallback to old label to make it work for old k8s versions.

--- a/clusterloader2/pkg/util/cluster_test.go
+++ b/clusterloader2/pkg/util/cluster_test.go
@@ -17,10 +17,11 @@ limitations under the License.
 package util
 
 import (
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"testing"
 )
 
 func TestLegacyIsMasterNode(t *testing.T) {
@@ -48,6 +49,38 @@ func TestLegacyIsMasterNode(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Labels: tc.Labels},
 		}
 		result := LegacyIsMasterNode(node)
+		assert.Equal(t, tc.expect, result)
+	}
+}
+
+func TestIsControlPlaneNode(t *testing.T) {
+	testcases := map[string]struct {
+		Name   string
+		Labels map[string]string
+		expect bool
+	}{
+		"node with controlplane node-role key": {
+			Labels: map[string]string{keyControlPlaneNodeLabel: ""},
+			expect: true,
+		},
+		"node with controlplane node-role key and value as true": {
+			Labels: map[string]string{keyControlPlaneNodeLabel: "true"},
+			expect: true,
+		},
+		"node with controlplane node-role key and value as false": {
+			Labels: map[string]string{keyControlPlaneNodeLabel: "false"},
+			expect: true,
+		},
+		"node without controlplane node-role": {
+			Labels: map[string]string{},
+			expect: false,
+		},
+	}
+	for _, tc := range testcases {
+		node := &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{Labels: tc.Labels},
+		}
+		result := IsControlPlaneNode(node)
 		assert.Equal(t, tc.expect, result)
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Adds check control plane instance in clusterloader with label key as `node-role.kubernetes.io/control-plane`

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
https://github.com/kubernetes/test-infra/issues/29139
Test failing as part of this PR-
https://github.com/kubernetes/kops/pull/15538

#### Special notes for your reviewer:

