### PR TITLE
Update golang compiler for golang tip job

### DIFF
--- a/golang/Makefile
+++ b/golang/Makefile
@@ -15,7 +15,7 @@
 .PHONY: build-go build push
 
 export GCS_BUCKET?=k8s-infra-scale-golang-builds
-export GO_COMPILER_PKG?=go1.18.5.linux-amd64.tar.gz
+export GO_COMPILER_PKG?=go1.20.6.linux-amd64.tar.gz
 export GO_COMPILER_URL?=https://dl.google.com/go/$(GO_COMPILER_PKG)
 export ROOT_DIR?=/home/prow/go/src
 


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
After https://go.googlesource.com/go/+/82ee946d7acd93cad27f748efb9c3131ae69668e it is required to use at least 1.20 to build golang from source.

#### Which issue(s) this PR fixes:
https://testgrid.k8s.io/sig-scalability-golang#build-and-push-k8s-at-golang-tip

#### Special notes for your reviewer:

