### PR TITLE
issue:2287: find maximum number of informers that doesn't impact latency.

### DIFF
--- a/clusterloader2/testing/watch-list/job.yaml
+++ b/clusterloader2/testing/watch-list/job.yaml
@@ -22,5 +22,5 @@ spec:
               cpu: "6"
           command: [ "watch-list" ]
           # TODO(p0lyn0mial): bring back 16 informers
-          args: [ "--alsologtostderr=true", "--v=4", "--timeout={{.Duration}}", "--count=8", "--namespace=watch-list-1", "--enableWatchListFeature={{.EnableWatchListFeature}}"]
+          args: [ "--alsologtostderr=true", "--v=4", "--timeout={{.Duration}}", "--count=6", "--namespace=watch-list-1", "--enableWatchListFeature={{.EnableWatchListFeature}}"]
       restartPolicy: Never


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
After https://github.com/kubernetes/perf-tests/pull/2305 the latency increased to `30s`. 
With https://github.com/kubernetes/perf-tests/pull/2303 it was around `1s`.

Between `1s` and `30s` the CPU usage didn't significantly increase.
Everything indicates that the egress is being throttled.

According to my calculations we should be below the egress limit (2 GB/s) with `6` or `5` informers.
This PR set the value of the informers to `6`.

Once we find our sweet spot I'm going to add a metric that will measure the latency for streaming.
Then we update the value of informers to initial value of `16` and compare the latencies one more time.

xref: https://github.com/kubernetes/perf-tests/issues/2287

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

