### PR TITLE
Add new measurement PodPeriodicCommand

### DIFF
--- a/clusterloader2/README.md
+++ b/clusterloader2/README.md
@@ -127,6 +127,11 @@ This measurement gathers the memory profile provided by pprof for a given compon
 - **MetricsForE2E** \
 The measurement gathers metrics from kube-apiserver, controller manager,
 scheduler and optionally all kubelets.
+- **PodPeriodicCommand** \
+This measurement continually runs commands on an interval in pods targeted
+with a label selector. The output from each command is collected, allowing for
+information to be polled throughout the duration of the measurement, such as
+CPU and memory profiles.
 - **PodStartupLatency** \
 This measurement verifies if [pod startup SLO] is satisfied.
 - **ResourceUsageSummary** \

--- a/clusterloader2/pkg/measurement/common/pod_command.go
+++ b/clusterloader2/pkg/measurement/common/pod_command.go
@@ -1,0 +1,716 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/remotecommand"
+	"k8s.io/client-go/util/exec"
+	"k8s.io/klog/v2"
+	"k8s.io/perf-tests/clusterloader2/pkg/measurement"
+	"k8s.io/perf-tests/clusterloader2/pkg/measurement/util/informer"
+	"k8s.io/perf-tests/clusterloader2/pkg/util"
+)
+
+const (
+	podPeriodicCommandMeasurementName = "PodPeriodicCommand"
+)
+
+type podPeriodicCommandMeasurementCommandParams struct {
+	// Name is an identifier for the command.
+	Name string
+	// Command is the actual Command to execute in a pod.
+	Command []string
+	// Timeout is the maximum amount of time the command will have to finish.
+	Timeout time.Duration
+}
+
+type podPeriodicCommandMeasurementParams struct {
+	// LabelSelector is used to select applicable pods to run commands on.
+	LabelSelector *labels.Selector
+	// Interval is the time between sequential command executions.
+	Interval time.Duration
+	// Container is the name of the Container to run the command in.
+	Container string
+	// Limit is the maximum number of pods that will have the commands executed in on every interval.
+	Limit int
+	// FailOnCommandError controls if the measurement will fail if a command has a non-zero RC during the life of the measurement.
+	FailOnCommandError bool
+	// FailOnExecError controls if the measurement will fail if an error occurs while trying to execute a command.
+	// For example, this would include any error returned from the k8s client-go library.
+	FailOnExecError bool
+	// FailOnTimeout controls if the measurement will fail if a command times out.
+	FailOnTimeout bool
+	// Commands is the list of Commands that will be executed in each pod on each interval.
+	Commands []*podPeriodicCommandMeasurementCommandParams
+}
+
+func newPodPeriodCommandMeasurementParams(
+	params map[string]interface{},
+) (p *podPeriodicCommandMeasurementParams, err error) {
+	p = &podPeriodicCommandMeasurementParams{}
+
+	p.LabelSelector, err = util.GetLabelSelector(params, "labelSelector")
+	if err != nil {
+		return
+	}
+	p.Interval, err = util.GetDuration(params, "interval")
+	if err != nil {
+		return
+	}
+
+	p.Container, err = util.GetString(params, "container")
+	if err != nil {
+		return
+	}
+
+	p.Limit, err = util.GetInt(params, "limit")
+	if err != nil {
+		return
+	}
+
+	p.FailOnCommandError, err = util.GetBool(params, "failOnCommandError")
+	if err != nil {
+		return
+	}
+
+	p.FailOnExecError, err = util.GetBool(params, "failOnExecError")
+	if err != nil {
+		return
+	}
+
+	p.FailOnTimeout, err = util.GetBool(params, "failOnTimeout")
+	if err != nil {
+		return
+	}
+
+	var commandMaps []map[string]interface{}
+	commandMaps, err = util.GetMapArray(params, "commands")
+	if err != nil {
+		return
+	}
+
+	p.Commands = []*podPeriodicCommandMeasurementCommandParams{}
+	for _, commandMap := range commandMaps {
+		c := &podPeriodicCommandMeasurementCommandParams{}
+
+		c.Name, err = util.GetString(commandMap, "name")
+		if err != nil {
+			return
+		}
+
+		c.Command, err = util.GetStringArray(commandMap, "command")
+		if err != nil {
+			return
+		}
+
+		c.Timeout, err = util.GetDuration(commandMap, "timeout")
+		if err != nil {
+			return
+		}
+
+		p.Commands = append(p.Commands, c)
+	}
+
+	return p, nil
+}
+
+type runCommandResult struct {
+	// stdout is the saved stdout from the command. Will be stored as its own measurement summary.
+	stdout string
+	// stderr is the saved stderr from the command. Will be stored as its own measurement summary.
+	stderr string
+	// ExitCode is the RC from the command. Defaults to zero and will not be set if the command times
+	// out or fails to run.
+	ExitCode int `json:"exitCode"`
+	// Name is the name of the command that was run, set in the config.
+	Name string `json:"name"`
+	// Command is the actual command which was executed.
+	Command []string `json:"command"`
+	// Timeout is the configured timeout duration.
+	Timeout string `json:"timeout"`
+	// HitTimeout is set to true if the command did not finish before the timeout.
+	HitTimeout bool `json:"hitTimeout"`
+	// StartTime is the time the command began executing. Isn't super precise.
+	StartTime time.Time `json:"startTime"`
+	// EndTime is the time the command finished executing. Isn't super precise.
+	EndTime time.Time `json:"endTime"`
+	// ExecError is set to any go error raised while executing the command.
+	ExecError string `json:"execError"`
+}
+
+type runAllCommandsResult struct {
+	Pod       string              `json:"pod"`
+	Namespace string              `json:"namespace"`
+	Container string              `json:"container"`
+	Commands  []*runCommandResult `json:"commands"`
+}
+
+type stats struct {
+	// Execs is the total number of times a command was executed in a pod.
+	Execs int `json:"execs"`
+	// ExecErrors is the total number of errors that were observed, not including errors from the executed commands.
+	// For example, this includes any errors that are returned by the k8s client-go library.
+	ExecErrors int `json:"execErrors"`
+	// Timeouts is the number of commands which hit a timeout.
+	Timeouts int `json:"timeouts"`
+	// NonZeroRCs is the total number of non-zero return codes that were collected from the commands executed.
+	NonZeroRCs int `json:"nonZeroRCs"`
+	// Measurements is the total number of measurements gathered.
+	Measurements int `json:"measurements"`
+	// Ticks is the total number of intervals that were executed.
+	Ticks int `json:"ticks"`
+	// TicksNoPods is the total number of intervals that were skipped because no applicable pods could be found.
+	TicksNoPods int `json:"ticksNoPods"`
+}
+
+// podPeriodicCommandMeasurement can be used to continually run commands within pods at an interval.
+//
+// It works by performing the following on each tick:
+//
+//  1. Creating a list of pods, with maximum size `params.Limit`, which will execute the configured commands.
+//     Pods are selected using `params.LabelSelector`, must contain `params.Container`, and must be in a running
+//     state. If no applicable pods are available, then no step is performed for the tick.
+//  2. For each pod, spin a goroutine which will run all configured commands in the pod.
+//  3. For each command, spin a goroutine to handle running the command.
+//  4. If the command returns non-zero, this will be reflected in the associated measurement.
+//  5. If a go error occurred while trying to execute the command, this will be reflected in the associated measurement.
+//
+// The following measurements are produced during the gather step:
+//
+//  1. One summary measurement, which includes information on all executed commands, such as if the command
+//     took longer than `params.Timeout`, the command's RC, and the pod the command was executed on.
+//  2. One measurement for each command's non-empty stdout and stderr.
+//  3. One measurement containing statistics, such as the number of commands executed, the number of errors observed,
+//     and the number of non-zero RCs.
+//
+// The measurement fails in the following scenarios:
+//
+//  1. `params.FailOnCommandError` is set to true and a command has a non-zero RC.
+//  2. `params.FailOnExecError` is set to true and an error occurs while trying to execute a command.
+//  3. `params.FailOnTimeout` is set to true and a command takes longer than its configured timeout to execute.
+type podPeriodicCommandMeasurement struct {
+	clientset  kubernetes.Interface
+	restConfig *rest.Config
+	params     *podPeriodicCommandMeasurementParams
+	isRunning  bool
+	// skipGather signals if the gather step should be skipped, mainly used to bail if param parsing failed.
+	skipGather bool
+	// stopCh is closed when stop() is called.
+	stopCh chan struct{}
+	// doneCh is closed after stopCh is closed and all in progress commands have finished.
+	doneCh   chan struct{}
+	results  []*runAllCommandsResult
+	informer cache.SharedInformer
+	stats    *stats
+	// statsLock needs to be held to modify and read the stats field.
+	statsLock *sync.Mutex
+}
+
+// isApplicablePod checks if a pod is a viable candidate for running a command on.
+func (p *podPeriodicCommandMeasurement) isApplicablePod(pod *v1.Pod) bool {
+	if pod.Status.Phase != v1.PodRunning {
+		return false
+	}
+
+	hasContainer := false
+	for _, c := range pod.Spec.Containers {
+		if c.Name == p.params.Container {
+			hasContainer = true
+
+			break
+		}
+	}
+
+	if !hasContainer {
+		return false
+	}
+
+	for _, c := range pod.Status.Conditions {
+		if c.Type == v1.PodReady && c.Status == v1.ConditionTrue {
+			return true
+		}
+	}
+
+	return false
+}
+
+// getMaxNPods gets at most N pods from the internal informer's store.
+// The informer uses a ThreadSafeStore, which stores objects in a map. When List is called, the map is
+// iterated over using range, which ensures a random order.
+func (p *podPeriodicCommandMeasurement) getMaxNPods(n int) []*v1.Pod {
+	store := p.informer.GetStore()
+	pods := []*v1.Pod{}
+
+	podList := store.List()
+	if len(podList) == 0 {
+		return pods
+	}
+
+	for _, podInterface := range podList {
+		pod := podInterface.(*v1.Pod)
+		if !p.isApplicablePod(pod) {
+			continue
+		}
+
+		pods = append(pods, pod)
+
+		if len(pods) >= n {
+			return pods
+		}
+	}
+
+	return pods
+}
+
+// runCommandInPod runs a specific given command in the specific given pod.
+func (p *podPeriodicCommandMeasurement) runCommandInPod(
+	pod *v1.Pod, params *podPeriodicCommandMeasurementCommandParams,
+) *runCommandResult {
+	klog.V(4).Infof(
+		"%s: running named command %s in pod %s/%s",
+		podPeriodicCommandMeasurementName, params.Name, pod.Namespace, pod.Name,
+	)
+
+	p.statsLock.Lock()
+	p.stats.Execs++
+	p.statsLock.Unlock()
+
+	result := &runCommandResult{
+		Name:       params.Name,
+		Command:    params.Command,
+		Timeout:    params.Timeout.String(),
+		ExitCode:   0,
+		HitTimeout: false,
+	}
+
+	req := p.clientset.CoreV1().RESTClient().
+		Post().
+		Namespace(pod.Namespace).
+		Resource("pods").
+		Name(pod.Name).
+		SubResource("exec").
+		VersionedParams(&v1.PodExecOptions{
+			Container: p.params.Container,
+			Command:   params.Command,
+			Stdin:     false,
+			Stdout:    true,
+			Stderr:    true,
+			TTY:       false,
+		}, scheme.ParameterCodec)
+
+	executor, err := remotecommand.NewSPDYExecutor(p.restConfig, "POST", req.URL())
+	if err != nil {
+		result.ExecError = err.Error()
+
+		return result
+	}
+
+	stdoutBuf := &bytes.Buffer{}
+	stderrBuf := &bytes.Buffer{}
+	// Holds error returned from executor.Stream.
+	execErrChan := make(chan error, 1)
+
+	// The logic used here to start the executor and the timeout timer isn't super precise, but
+	// it is good enough for this use case. It is ok that the timeout timer is started after the
+	// executor, since we still guarantee that the timeout is at least the configured value.
+	result.StartTime = time.Now()
+
+	go func() {
+		err := executor.Stream(remotecommand.StreamOptions{
+			Stdout: stdoutBuf,
+			Stderr: stderrBuf,
+		})
+		execErrChan <- err
+	}()
+
+	// Two different cases: (1) if the command returns before the timeout, and (2) if the timeout
+	// triggers before the command is done.
+	// The value result.EndTime is set in both cases.
+	// If the timeout triggers, then the command isn't actually cancelled. This logic isn't available until
+	// client-go version 0.26 (see Executor.StreamWithContext).
+	select {
+	case err = <-execErrChan:
+		result.EndTime = time.Now()
+
+		if err == nil {
+			break
+		}
+
+		switch e := err.(type) {
+		case exec.CodeExitError:
+			result.ExitCode = e.ExitStatus()
+
+			p.statsLock.Lock()
+			p.stats.NonZeroRCs++
+			p.statsLock.Unlock()
+
+			klog.V(2).Infof(
+				"%s: warning: non-zero exit code %d for named command %s in pod %s/%s",
+				podPeriodicCommandMeasurementName, result.ExitCode, params.Name, pod.Namespace, pod.Name,
+			)
+		default:
+			result.ExecError = err.Error()
+			return result
+		}
+	case <-time.After(params.Timeout):
+		result.EndTime = time.Now()
+		result.HitTimeout = true
+
+		p.statsLock.Lock()
+		p.stats.Timeouts++
+		p.statsLock.Unlock()
+
+		klog.V(2).Infof(
+			"%s: warning: hit timeout of %s for named command %s in pod %s/%s",
+			podPeriodicCommandMeasurementName, params.Timeout.String(), params.Name, pod.Namespace, pod.Name,
+		)
+	}
+
+	klog.V(4).Infof(
+		"%s: finished running named command %s in pod %s/%s",
+		podPeriodicCommandMeasurementName, params.Name, pod.Namespace, pod.Name,
+	)
+
+	result.stdout = stdoutBuf.String()
+	result.stderr = stderrBuf.String()
+
+	return result
+}
+
+// runAllCommandsInPod runs all of the configured commands in the given specific pod.
+func (p *podPeriodicCommandMeasurement) runAllCommandsInPod(pod *v1.Pod) *runAllCommandsResult {
+	wg := &sync.WaitGroup{}
+	commandResultCh := make(chan *runCommandResult, len(p.params.Commands))
+
+	getRunCommandFunc := func(c *podPeriodicCommandMeasurementCommandParams) func() {
+		return func() {
+			defer wg.Done()
+
+			if c := p.runCommandInPod(pod, c); c != nil {
+				if c.ExecError != "" {
+					p.statsLock.Lock()
+					p.stats.ExecErrors++
+					p.statsLock.Unlock()
+
+					klog.V(2).Infof(
+						"%s: error while running named command %s on pod %s/%s: %v",
+						podPeriodicCommandMeasurementName, c.Name, pod.Namespace, pod.Name, c.ExecError,
+					)
+				}
+
+				commandResultCh <- c
+			}
+		}
+	}
+
+	klog.V(4).Infof(
+		"%s: running commands on pod %s/%s", podPeriodicCommandMeasurementName, pod.Namespace, pod.Name,
+	)
+
+	for _, command := range p.params.Commands {
+		wg.Add(1)
+
+		go getRunCommandFunc(command)()
+	}
+
+	wg.Wait()
+	close(commandResultCh)
+
+	klog.V(4).Infof(
+		"%s: finished running commands on pod %s/%s", podPeriodicCommandMeasurementName, pod.Namespace, pod.Name,
+	)
+
+	results := &runAllCommandsResult{
+		Pod:       pod.Name,
+		Namespace: pod.Namespace,
+		Container: p.params.Container,
+		Commands:  []*runCommandResult{},
+	}
+
+	for c := range commandResultCh {
+		results.Commands = append(results.Commands, c)
+	}
+
+	klog.V(8).Infof("%s: %#v", podPeriodicCommandMeasurementName, results)
+
+	return results
+}
+
+// commandWorker runs the configured commands in applicable pods on the configured interval.
+func (p *podPeriodicCommandMeasurement) commandWorker() {
+	ticker := time.NewTicker(p.params.Interval)
+	defer func() {
+		ticker.Stop()
+		// Close doneCh to signal the worker has exited.
+		close(p.doneCh)
+	}()
+
+	doTick := func() {
+		p.statsLock.Lock()
+		p.stats.Ticks++
+		p.statsLock.Unlock()
+
+		targetPods := p.getMaxNPods(p.params.Limit)
+		if len(targetPods) == 0 {
+			klog.V(2).Infof("%s: warning: no pods available to run commands on", podPeriodicCommandMeasurementName)
+
+			p.statsLock.Lock()
+			p.stats.TicksNoPods++
+			p.statsLock.Unlock()
+
+			return
+		}
+
+		wg := &sync.WaitGroup{}
+		resultsChan := make(chan *runAllCommandsResult, len(targetPods))
+
+		for _, pod := range targetPods {
+			wg.Add(1)
+			go func(targetPod *v1.Pod) {
+				defer wg.Done()
+				resultsChan <- p.runAllCommandsInPod(targetPod)
+			}(pod)
+		}
+
+		wg.Wait()
+		close(resultsChan)
+
+		for r := range resultsChan {
+			p.results = append(p.results, r)
+		}
+	}
+
+	// Do an initial tick
+	doTick()
+	for {
+		select {
+		case <-p.stopCh:
+			return
+		case <-ticker.C:
+			doTick()
+		}
+	}
+}
+
+func (p *podPeriodicCommandMeasurement) start(
+	clientset kubernetes.Interface, restConfig *rest.Config, params *podPeriodicCommandMeasurementParams,
+) error {
+	if p.isRunning {
+		return fmt.Errorf("%s: measurement already running", podPeriodicCommandMeasurementName)
+	}
+
+	klog.V(2).Infof("%s: starting pod periodic command measurement...", podPeriodicCommandMeasurementName)
+
+	p.clientset = clientset
+	p.restConfig = restConfig
+	p.params = params
+	p.isRunning = true
+	p.skipGather = false
+	p.stopCh = make(chan struct{})
+	p.doneCh = make(chan struct{})
+	p.results = []*runAllCommandsResult{}
+	p.stats = &stats{}
+	p.statsLock = &sync.Mutex{}
+
+	labelSelectorString := (*params.LabelSelector).String()
+	p.informer = informer.NewInformer(
+		&cache.ListWatch{
+			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+				options.LabelSelector = labelSelectorString
+				return clientset.CoreV1().Pods("").List(context.TODO(), options)
+			},
+			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+				options.LabelSelector = labelSelectorString
+				return clientset.CoreV1().Pods("").Watch(context.TODO(), options)
+			},
+		},
+		// Use the informer's internal cache to handle listing pods, no need to handle events.
+		func(_, _ interface{}) {},
+	)
+
+	if err := informer.StartAndSync(p.informer, p.stopCh, informerSyncTimeout); err != nil {
+		return err
+	}
+
+	go p.commandWorker()
+
+	return nil
+}
+
+func (p *podPeriodicCommandMeasurement) stop() {
+	if p.isRunning {
+		p.isRunning = false
+		close(p.stopCh)
+		// Wait for the commandWorker function to stop.
+		<-p.doneCh
+	}
+}
+
+func (p *podPeriodicCommandMeasurement) gather() ([]measurement.Summary, error) {
+	p.stop()
+
+	klog.V(2).Infof("%s: gathered %d command results", podPeriodicCommandMeasurementName, len(p.results))
+
+	// Create summary for all results.
+	content, err := util.PrettyPrintJSON(p.results)
+	if err != nil {
+		// Ignore p.params.FailOnError here, since this is fatal.
+		return nil, fmt.Errorf("unable to convert results to JSON: %w", err)
+	}
+
+	measurements := []measurement.Summary{
+		measurement.CreateSummary(podPeriodicCommandMeasurementName, "json", content),
+	}
+
+	// Hold error to be returned to signal that the measurement failed, or nil.
+	// Should only be non-nil if one of the FailOnXYZ params is set.
+	var resultErr error
+
+	// Create individual results for stdout and stderr.
+	// Saving these as a value in a json document can lead to weird issues in reading the data
+	// properly, especially if the data is binary, such as for profiling results.
+	// Additionally, check for any errors or timeouts that may have occurred.
+	for _, r := range p.results {
+		getSummaryName := func(c *runCommandResult, suffix string) string {
+			return strings.Join(
+				[]string{
+					podPeriodicCommandMeasurementName, c.StartTime.Format(time.RFC3339), r.Namespace, r.Pod, c.Name, suffix,
+				}, "-",
+			)
+		}
+
+		for _, c := range r.Commands {
+			if c.stdout != "" {
+				measurements = append(measurements, measurement.CreateSummary(getSummaryName(c, "stdout"), "txt", c.stdout))
+			}
+			if c.stderr != "" {
+				measurements = append(measurements, measurement.CreateSummary(getSummaryName(c, "stderr"), "txt", c.stderr))
+			}
+
+			// If the result error has already been set, we don't need to set it again.
+			if resultErr != nil {
+				continue
+			}
+
+			if p.params.FailOnCommandError && c.ExitCode != 0 {
+				resultErr = fmt.Errorf(
+					"unexpected non-zero RC while executing command %s in pod %s/%s: got RC %d",
+					c.Name, r.Namespace, r.Pod, c.ExitCode,
+				)
+				continue
+			}
+
+			if p.params.FailOnExecError && c.ExecError != "" {
+				resultErr = fmt.Errorf(
+					"unexpected error while executing command %s in pod %s/%s: %s", c.Name, r.Namespace, r.Pod, c.ExecError,
+				)
+				continue
+			}
+
+			if p.params.FailOnTimeout && c.HitTimeout {
+				resultErr = fmt.Errorf(
+					"hit timeout of %s while executing command %s in pod %s/%s",
+					c.Timeout, c.Name, r.Namespace, r.Pod,
+				)
+			}
+		}
+	}
+
+	// Create summary for stats.
+	p.stats.Measurements = len(measurements) + 1 // Adding another measurement for the stats.
+	content, err = util.PrettyPrintJSON(p.stats)
+	if err != nil {
+		// Ignore p.params.FailOnError here, since this is fatal.
+		return nil, fmt.Errorf("unable to convert stats to JSON: %w", err)
+	}
+
+	measurements = append(
+		measurements,
+		measurement.CreateSummary(
+			strings.Join([]string{podPeriodicCommandMeasurementName, "stats"}, "-"), "json", content,
+		),
+	)
+
+	// resultErr can only be set if one of the FailOnXYZ params is set.
+	if resultErr != nil {
+		return measurements, resultErr
+	}
+
+	return measurements, nil
+}
+
+func (*podPeriodicCommandMeasurement) String() string {
+	return podPeriodicCommandMeasurementName
+}
+
+func (p *podPeriodicCommandMeasurement) Execute(config *measurement.Config) ([]measurement.Summary, error) {
+	action, err := util.GetString(config.Params, "action")
+	if err != nil {
+		return nil, err
+	}
+
+	switch action {
+	case "start":
+		params, err := newPodPeriodCommandMeasurementParams(config.Params)
+		if err != nil {
+			p.skipGather = true
+			return nil, err
+		}
+
+		return nil, p.start(
+			config.ClusterFramework.GetClientSets().GetClient(), config.ClusterFramework.GetRestClient(), params,
+		)
+	case "gather":
+		if p.skipGather {
+			return nil, nil
+		}
+
+		return p.gather()
+	default:
+		return nil, fmt.Errorf("unknown action %s", action)
+	}
+}
+
+func (p *podPeriodicCommandMeasurement) Dispose() {
+	p.stop()
+}
+
+func createPodPeriodicCommandMeasurement() measurement.Measurement {
+	return &podPeriodicCommandMeasurement{}
+}
+
+func init() {
+	if err := measurement.Register(podPeriodicCommandMeasurementName, createPodPeriodicCommandMeasurement); err != nil {
+		klog.Fatalf("Cannot register %s: %v", podPeriodicCommandMeasurementName, err)
+	}
+}

--- a/clusterloader2/pkg/util/util.go
+++ b/clusterloader2/pkg/util/util.go
@@ -23,6 +23,8 @@ import (
 	"math/rand"
 	"strconv"
 	"time"
+
+	"k8s.io/apimachinery/pkg/labels"
 )
 
 // ErrKeyNotFound is returned when key doesn't exists in a map.
@@ -93,6 +95,11 @@ func GetStringArray(dict map[string]interface{}, key string) ([]string, error) {
 	return getStringArray(dict, key)
 }
 
+// GetLabelSelector tries to return value from map parsed as labels.Selector type. If value doesn't exist, error is returned.
+func GetLabelSelector(dict map[string]interface{}, key string) (*labels.Selector, error) {
+	return getLabelSelector(dict, key)
+}
+
 // GetStringOrDefault tries to return value from map cast to string type. If value doesn't exist default value is used.
 func GetStringOrDefault(dict map[string]interface{}, key string, defaultValue string) (string, error) {
 	value, err := getString(dict, key)
@@ -136,6 +143,20 @@ func GetBoolOrDefault(dict map[string]interface{}, key string, defaultValue bool
 		return defaultValue, nil
 	}
 	return value, err
+}
+
+func getLabelSelector(dict map[string]interface{}, key string) (*labels.Selector, error) {
+	value, err := getString(dict, key)
+	if err != nil {
+		return nil, err
+	}
+
+	selector, err := labels.Parse(value)
+	if err != nil {
+		return nil, err
+	}
+
+	return &selector, nil
 }
 
 func getMap(dict map[string]interface{}, key string) (map[string]interface{}, error) {

--- a/clusterloader2/pkg/util/util_test.go
+++ b/clusterloader2/pkg/util/util_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/labels"
 )
 
 type test struct {
@@ -95,6 +96,43 @@ func TestToStruct(t *testing.T) {
 			}
 			if !tt.wantErr {
 				assert.Equal(t, tt.want, tt.in)
+			}
+		})
+	}
+}
+
+func TestGetLabelSelector(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   interface{}
+		matches labels.Labels
+		wantErr bool
+	}{
+		{
+			name:    "error with non-string value",
+			value:   1,
+			wantErr: true,
+		},
+		{
+			name:    "error with bad label selector value",
+			value:   "?i am a bad label selector?",
+			wantErr: true,
+		},
+		{
+			name:    "no error with good label selector value",
+			value:   "app=test",
+			matches: labels.Set{"app": "test"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			l, err := GetLabelSelector(map[string]interface{}{"key": tt.value}, "key")
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetLabelSelector() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !tt.wantErr {
+				assert.Equal(t, true, (*l).Matches(tt.matches))
 			}
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This commit adds a new measurement named PodPeriodicCommand, which allows users to run commands within pods on a periodic basis, saving the output for later use. For instance, this can be used to scrape pprofs from a select set of pods. Here is an example configuration:

```yaml
name: testppc
namespace:
  number: 1
steps:
- name: Start PodPeriodicCommand
  measurements:
  - identifier: PodPeriodicCommand
    method: PodPeriodicCommand
    params:
      action: start
      labelSelector: k8s-app=cilium
      interval: 30s
      container: cilium-agent
      limit: 1
      failOnError: true
      commands:
      - name: AllocsProfile
        command:
        - curl
        - -s
        - -k
        - http://localhost:6060/debug/pprof/allocs?seconds=30
        timeout: 35s
      - name: Example Timeout
        command:
        - sleep
        - 10
        timeout: 1s
- name: Sleep for two minutes
  measurements:
  - Identifier: ExecCommand
    Method: Exec
    Params:
      timeout: 121s
      command:
      - sleep
      - 120
- name: Gather PodPeriodicCommand
  measurements:
  - identifier: PodPeriodicCommand
    method: PodPeriodicCommand
    params:
      action: gather
```

Running `go tool pprof -http :8080 *AllocsProfile*` in the results directory will open up a new browser tab containing a view of the allocs profiles collected during the two minute run.

Example stats summary using the above config:

```json
{
  "execs": 10,
  "nonZeroRCs": 0,
  "errors": 0,
  "timeouts": 5,
  "measurements": 7,
  "ticks": 5,
  "ticksNoPods": 0
}
```

Example report summary using the above config:

```json
[
  {
    "pod": "cilium-hplhd",
    "namespace": "kube-system",
    "container": "cilium-agent",
    "commands": [
      {
        "exitCode": 0,
        "name": "Example Timeout",
        "command": [
          "sleep",
          "10"
        ],
        "timeout": "1s",
        "hitTimeout": true,
        "startTime": "2023-09-01T12:36:48.762289489-06:00",
        "endTime": "2023-09-01T12:36:49.762788275-06:00"
      },
      {
        "exitCode": 0,
        "name": "AllocsProfile",
        "command": [
          "curl",
          "-s",
          "-k",
          "http://localhost:6060/debug/pprof/allocs?seconds=30"
        ],
        "timeout": "35s",
        "hitTimeout": false,
        "startTime": "2023-09-01T12:36:48.762298737-06:00",
        "endTime": "2023-09-01T12:37:19.079579364-06:00"
      }
    ]
  },
  {
    "pod": "cilium-hplhd",
    "namespace": "kube-system",
    "container": "cilium-agent",
    "commands": [
      {
        "exitCode": 0,
        "name": "Example Timeout",
        "command": [
          "sleep",
          "10"
        ],
        "timeout": "1s",
        "hitTimeout": true,
        "startTime": "2023-09-01T12:37:19.080434913-06:00",
        "endTime": "2023-09-01T12:37:20.081270277-06:00"
      },
      {
        "exitCode": 0,
        "name": "AllocsProfile",
        "command": [
          "curl",
          "-s",
          "-k",
          "http://localhost:6060/debug/pprof/allocs?seconds=30"
        ],
        "timeout": "35s",
        "hitTimeout": false,
        "startTime": "2023-09-01T12:37:19.080752313-06:00",
        "endTime": "2023-09-01T12:37:49.391037823-06:00"
      }
    ]
  },
  {
    "pod": "cilium-hplhd",
    "namespace": "kube-system",
    "container": "cilium-agent",
    "commands": [
      {
        "exitCode": 0,
        "name": "Example Timeout",
        "command": [
          "sleep",
          "10"
        ],
        "timeout": "1s",
        "hitTimeout": true,
        "startTime": "2023-09-01T12:37:49.392397474-06:00",
        "endTime": "2023-09-01T12:37:50.392593022-06:00"
      },
      {
        "exitCode": 0,
        "name": "AllocsProfile",
        "command": [
          "curl",
          "-s",
          "-k",
          "http://localhost:6060/debug/pprof/allocs?seconds=30"
        ],
        "timeout": "35s",
        "hitTimeout": false,
        "startTime": "2023-09-01T12:37:49.392824859-06:00",
        "endTime": "2023-09-01T12:38:19.748587964-06:00"
      }
    ]
  },
  {
    "pod": "cilium-hplhd",
    "namespace": "kube-system",
    "container": "cilium-agent",
    "commands": [
      {
        "exitCode": 0,
        "name": "Example Timeout",
        "command": [
          "sleep",
          "10"
        ],
        "timeout": "1s",
        "hitTimeout": true,
        "startTime": "2023-09-01T12:38:19.749415287-06:00",
        "endTime": "2023-09-01T12:38:20.749768968-06:00"
      },
      {
        "exitCode": 0,
        "name": "AllocsProfile",
        "command": [
          "curl",
          "-s",
          "-k",
          "http://localhost:6060/debug/pprof/allocs?seconds=30"
        ],
        "timeout": "35s",
        "hitTimeout": false,
        "startTime": "2023-09-01T12:38:19.749570704-06:00",
        "endTime": "2023-09-01T12:38:50.576227327-06:00"
      }
    ]
  },
  {
    "pod": "cilium-swbdc",
    "namespace": "kube-system",
    "container": "cilium-agent",
    "commands": [
      {
        "exitCode": 0,
        "name": "Example Timeout",
        "command": [
          "sleep",
          "10"
        ],
        "timeout": "1s",
        "hitTimeout": true,
        "startTime": "2023-09-01T12:38:50.577293404-06:00",
        "endTime": "2023-09-01T12:38:51.577569606-06:00"
      },
      {
        "exitCode": 0,
        "name": "AllocsProfile",
        "command": [
          "curl",
          "-s",
          "-k",
          "http://localhost:6060/debug/pprof/allocs?seconds=30"
        ],
        "timeout": "35s",
        "hitTimeout": false,
        "startTime": "2023-09-01T12:38:50.577536494-06:00",
        "endTime": "2023-09-01T12:39:21.794034396-06:00"
      }
    ]
  }
]
``` 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes: #2262

#### Special notes for your reviewer:

Finishing this work went a bit stale due to some changing priorities, but an initial implementation was used to collect data for the following PRs:

* https://github.com/cilium/cilium/pull/26238
* https://github.com/cilium/cilium/pull/26327
