### PR TITLE
Add Responsiveness and RequestCount to node-throughput tests in perfdash

### DIFF
--- a/perfdash/config.go
+++ b/perfdash/config.go
@@ -567,6 +567,16 @@ var (
 					Parser:           parsePerfData,
 				},
 			},
+			"Responsiveness_PrometheusSimple": []TestDescription{{
+				Name:             "node-throughput",
+				OutputFilePrefix: "APIResponsivenessPrometheus_simple",
+				Parser:           parsePerfData,
+			}},
+			"RequestCount_PrometheusSimple": []TestDescription{{
+				Name:             "node-throughput",
+				OutputFilePrefix: "APIResponsivenessPrometheus_simple",
+				Parser:           parseRequestCountData,
+			}},
 		},
 	}
 	windowsDescriptions = TestDescriptions{


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
The current node-throughput test export Prometheus Simple metrics, but perfdash is ignoring them: https://github.com/kubernetes/perf-tests/blob/b4bc889e1e6537cba3d83025b3d85274790fa7ba/clusterloader2/testing/node-throughput/config.yaml#L21
This PR adds support to perfdash to display Prometheus Simple metrics.
