### PR TITLE
feat: Add support for specifying a list of existing namespaces

### DIFF
--- a/clusterloader2/api/types.go
+++ b/clusterloader2/api/types.go
@@ -94,10 +94,17 @@ type Module struct {
 // In a given namespace range (or cluster scope if no range is specified)
 // it defines the number and the configuration of managed objects.
 type Phase struct {
-	// NamespaceRange defines the set of namespaces in which objects
+	// NamespaceRange defines the range of generated namespaces in which objects
 	// should be reconciled.
 	// If null, objects are assumed to be cluster scoped.
+	// Note: Only one of NamespaceList and NamespaceRange should be set
 	NamespaceRange *NamespaceRange `json:"namespaceRange"`
+	// NamespaceList defines a list of namespaces in which objects
+	// should be reconciled. This is used for resources that should be forced
+	// into specific namespaces.
+	// If null, assumed to use NamespaceRange.
+	// Note: Only one of NamespaceList and NamespaceRange should be set
+	NamespaceList []string `json:"namespaceList"`
 	// ReplicasPerNamespace is a number of instances of a given object
 	// to exist in each of referenced namespaces.
 	ReplicasPerNamespace int32 `json:"replicasPerNamespace"`

--- a/clusterloader2/api/validation.go
+++ b/clusterloader2/api/validation.go
@@ -139,6 +139,10 @@ func validateTuningSetInPhase(s *Step, ts []*TuningSet, fldPath *field.Path) fie
 
 func (v *ConfigValidator) validatePhase(p *Phase, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
+
+	if p.NamespaceList != nil && p.NamespaceRange != nil {
+		allErrs = append(allErrs, field.Forbidden(fldPath, "must specify at most 1 of namespaceList and namespaceRange"))
+	}
 	if p.NamespaceRange != nil {
 		allErrs = append(allErrs, v.validateNamespaceRange(p.NamespaceRange, fldPath.Child("namespaceRange"))...)
 	}

--- a/clusterloader2/api/validation_test.go
+++ b/clusterloader2/api/validation_test.go
@@ -224,9 +224,37 @@ func TestVerifyPhase(t *testing.T) {
 			expected: true,
 		},
 		{
+			name: "namespaceList specifies namespace",
+			input: Phase{
+				ReplicasPerNamespace: 10,
+				NamespaceList:        []string{"ns1"},
+			},
+			expected: true,
+		},
+		{
+			name: "namespaceRange specifies namespace",
+			input: Phase{
+				ReplicasPerNamespace: 10,
+				NamespaceRange: &NamespaceRange{
+					Min: 1,
+					Max: 1,
+				},
+			},
+			expected: true,
+		},
+		{
 			name: "negative replicas",
 			input: Phase{
 				ReplicasPerNamespace: -10,
+			},
+			expected: false,
+		},
+		{
+			name: "namespaceList and namespaceRange both specify namespace",
+			input: Phase{
+				ReplicasPerNamespace: 10,
+				NamespaceList:        []string{"ns1"},
+				NamespaceRange:       &NamespaceRange{},
 			},
 			expected: false,
 		},

--- a/clusterloader2/pkg/test/simple_test_executor.go
+++ b/clusterloader2/pkg/test/simple_test_executor.go
@@ -180,7 +180,10 @@ func (ste *simpleExecutor) ExecuteStep(ctx Context, step *api.Step) *errors.Erro
 // ExecutePhase executes single test phase based on provided phase configuration.
 func (ste *simpleExecutor) ExecutePhase(ctx Context, phase *api.Phase) *errors.ErrorList {
 	errList := errors.NewErrorList()
-	nsList := createNamespacesList(ctx, phase.NamespaceRange)
+	nsList := phase.NamespaceList
+	if nsList == nil {
+		nsList = createNamespacesList(ctx, phase.NamespaceRange)
+	}
 	tuningSet, err := ctx.GetFactory().CreateTuningSet(phase.TuningSet)
 	if err != nil {
 		return errors.NewErrorList(fmt.Errorf("tuning set creation error: %v", err))


### PR DESCRIPTION

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR allows users to specify a list of pre-existing namespaces rather than using the generated ones. It is important in scenarios where certain resources are restricted to only be deployed in specific namespaces. 

#### Which issue(s) this PR fixes:

Fixes #2392

#### Special notes for your reviewer:
