### PR TITLE
Add option to dns performance test to install additional YAMLs

### DIFF
--- a/clusterloader2/pkg/config/template_functions.go
+++ b/clusterloader2/pkg/config/template_functions.go
@@ -46,6 +46,7 @@ func GetFuncs(fsys fs.FS) template.FuncMap {
 		"DefaultParam":     defaultParam,
 		"DivideFloat":      divideFloat,
 		"DivideInt":        divideInt,
+		"ExpandEnv":        expandEnv,
 		"IfThenElse":       ifThenElse,
 		"IncludeFile":      includeFile,
 		"IncludeEmbedFile": includeEmbedFile(fsys),
@@ -257,6 +258,14 @@ func includeEmbedFile(fsys fs.FS) func(file interface{}) (string, error) {
 		}
 		return string(data), nil
 	}
+}
+
+func expandEnv(param interface{}) string {
+	paramStr, ok := param.(string)
+	if !ok {
+		panic("expandEnv parameter is not a string")
+	}
+	return os.ExpandEnv(paramStr)
 }
 
 // yamlQuote quotes yaml string aligning each output lin by tabsInt.

--- a/clusterloader2/pkg/framework/framework.go
+++ b/clusterloader2/pkg/framework/framework.go
@@ -274,7 +274,6 @@ func (f *Framework) GetObject(gvk schema.GroupVersionKind, namespace string, nam
 func (f *Framework) ApplyTemplatedManifests(fsys fs.FS, manifestGlob string, templateMapping map[string]interface{}, options ...*client.APICallOptions) error {
 	// TODO(mm4tt): Consider using the out-of-the-box "kubectl create -f".
 	klog.Infof("Applying templates for %q", manifestGlob)
-
 	templateProvider := config.NewTemplateProvider(fsys)
 	manifests, err := fs.Glob(fsys, manifestGlob)
 	if err != nil {
@@ -306,7 +305,43 @@ func (f *Framework) ApplyTemplatedManifests(fsys fs.FS, manifestGlob string, tem
 				return fmt.Errorf("error while applying (%s): %v", manifest, err)
 			}
 		}
+	}
+	return nil
+}
 
+func (f *Framework) DeleteTemplatedManifests(fsys fs.FS, manifestGlob string, templateMapping map[string]interface{}, options ...*client.APICallOptions) error {
+	klog.Infof("Deleting templates for %q", manifestGlob)
+	templateProvider := config.NewTemplateProvider(fsys)
+	manifests, err := fs.Glob(fsys, manifestGlob)
+	if err != nil {
+		return err
+	}
+	if manifests == nil {
+		klog.Warningf("There is no matching file for pattern %v.\n", manifestGlob)
+	}
+	for _, manifest := range manifests {
+		klog.V(1).Infof("Deleting %s\n", manifest)
+		obj, err := templateProvider.TemplateToObject(manifest, templateMapping)
+		if err != nil {
+			if err == config.ErrorEmptyFile {
+				klog.Warningf("Skipping empty manifest %s", manifest)
+				continue
+			}
+			return fmt.Errorf("TemplateToObject error: %+v", err)
+		}
+		objList := []unstructured.Unstructured{*obj}
+		if obj.IsList() {
+			list, err := obj.ToList()
+			if err != nil {
+				return err
+			}
+			objList = list.Items
+		}
+		for _, item := range objList {
+			if err := f.DeleteObject(item.GroupVersionKind(), item.GetNamespace(), item.GetName(), options...); err != nil {
+				return fmt.Errorf("error while applying (%s): %v", manifest, err)
+			}
+		}
 	}
 	return nil
 }

--- a/clusterloader2/pkg/measurement/common/dns/manifests/dns-client.yaml
+++ b/clusterloader2/pkg/measurement/common/dns/manifests/dns-client.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: dnsperfgo
+  name: {{.ClientDeploymentName}}
   namespace: {{.Namespace}}
 spec:
   replicas: {{.PodReplicas}}
@@ -40,6 +40,20 @@ spec:
             memory: 10M
       serviceAccountName: {{.ServiceAccountName}}
       terminationGracePeriodSeconds: 1
+      # Add a pod anti-affinity with itself to spread out Pods across the
+      # cluster
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                  - key: dns-test
+                    operator: In
+                    values:
+                    - dnsperfgo
+                topologyKey: "kubernetes.io/hostname"
       # Add not-ready/unreachable tolerations for 15 minutes so that node
       # failure doesn't trigger pod deletion.
       tolerations:

--- a/clusterloader2/testing/load/modules/dns-k8s-hostnames.yaml
+++ b/clusterloader2/testing/load/modules/dns-k8s-hostnames.yaml
@@ -8,6 +8,7 @@
 {{$dnsClientPods := AddInt 5 (MultiplyInt $dnsClientPodsFactor (DivideInt .Nodes 100))}}
 {{$qpsPerClient := DefaultParam .CL2_DNS_K8S_HOSTNAMES_PER_CLIENT_QPS 10}}
 {{$testDurationMinutes := DefaultParam .CL2_DNS_K8S_HOSTNAMES_TEST_MINUTES 10}}
+{{$additionalManifestFilePath := ExpandEnv (DefaultParam .CL2_DNSTEST_ADDITIONAL_MANIFEST "")}}
 
 {{if and $ENABLE_DNSTESTS $USE_ADVANCED_DNSTEST}}
 steps:
@@ -19,6 +20,7 @@ steps:
       podReplicas: {{$dnsClientPods}}
       qpsPerClient: {{$qpsPerClient}}
       testDurationMinutes: {{$testDurationMinutes}}
+      additionalManifestFilePath: {{$additionalManifestFilePath}}
 
 - name: Wait 1m for DNS test to complete
   measurements:


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Provides the capability to apply additional manifests before starting a DNS performance test. This can be used to install other features that might need to be scaled tested (e.g. egress gateways, network policies, etc.)