### PR TITLE
Move netperf image to k8s-staging-perf-tests

### DIFF
--- a/network/benchmarks/netperf/Makefile
+++ b/network/benchmarks/netperf/Makefile
@@ -14,7 +14,8 @@
 
 all: docker push launch runtests
 
-DOCKERREPO       := girishkalele/netperf-latest
+REGISTRY ?= gcr.io/k8s-staging-perf-tests/netperf
+VERSION ?= v0.0.1
 
 docker: launch
 	mkdir -p Dockerbuild/nptest && \
@@ -22,10 +23,12 @@ docker: launch
     cp -f nptest/nptest.go Dockerbuild/nptest/ && \
     cp -f go.mod Dockerbuild/ && \
     cp -f go.sum Dockerbuild/ && \
-	docker build -t $(DOCKERREPO) Dockerbuild/
+	docker build -t $(REGISTRY):$(VERSION) Dockerbuild/
 
 push: docker
-	gcloud docker push $(DOCKERREPO)
+	docker tag $(REGISTRY):$(VERSION) $(REGISTRY):latest
+	docker push $(REGISTRY):$(VERSION)
+	docker push $(REGISTRY):latest
 
 clean:
 	@rm -f Dockerbuild/*

--- a/network/benchmarks/netperf/README.md
+++ b/network/benchmarks/netperf/README.md
@@ -105,7 +105,7 @@ Command line parameters to the launch.go can switch the test mode to incorporate
   -iterations int
         Number of iterations to run (default 1)
   -image string
-        Docker image used to run the network tests (default "girishkalele/netperf-latest")
+        Docker image used to run the network tests (default "gcr.io/k8s-staging-perf-tests/netperf")
 
  $ go run ./launch.go --hostnetworking --iterations 1
 

--- a/network/benchmarks/netperf/launch.go
+++ b/network/benchmarks/netperf/launch.go
@@ -74,7 +74,7 @@ func init() {
 	flag.IntVar(&iterations, "iterations", 1,
 		"Number of iterations to run")
 	flag.StringVar(&tag, "tag", runUUID, "CSV file suffix")
-	flag.StringVar(&netperfImage, "image", "sirot/netperf-latest", "Docker image used to run the network tests")
+	flag.StringVar(&netperfImage, "image", "gcr.io/k8s-staging-perf-tests/netperf", "Docker image used to run the network tests")
 	flag.StringVar(&testNamespace, "namespace", "netperf", "Test namespace to run netperf pods")
 	defaultKubeConfig := fmt.Sprintf("%s/.kube/config", os.Getenv("HOME"))
 	flag.StringVar(&kubeConfig, "kubeConfig", defaultKubeConfig,


### PR DESCRIPTION
Move netperf image to k8s-staging-perf-tests.
I've already pushed the image to this image repository.

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it: