### PR TITLE
[CL2] Follow up to safetext migration

### DIFF
--- a/clusterloader2/pkg/prometheus/manifests/0prometheus-operator-deployment.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/0prometheus-operator-deployment.yaml
@@ -60,7 +60,7 @@ spec:
       {{end}}
       nodeSelector:
         kubernetes.io/os: linux
-{{if not (eq $PROMETHEUS_NODE_SELECTOR "")}}        {{$PROMETHEUS_NODE_SELECTOR}}{{end}}
+        {{StructuralData $PROMETHEUS_NODE_SELECTOR}}
       securityContext:
         runAsNonRoot: true
         runAsUser: 65534

--- a/clusterloader2/pkg/prometheus/manifests/prometheus-prometheus.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/prometheus-prometheus.yaml
@@ -22,7 +22,7 @@ spec:
   baseImage: gcr.io/k8s-testimages/quay.io/prometheus/prometheus
   nodeSelector:
     kubernetes.io/os: linux
-{{if not (eq $PROMETHEUS_NODE_SELECTOR "")}}    {{$PROMETHEUS_NODE_SELECTOR}}{{end}}
+    {{StructuralData $PROMETHEUS_NODE_SELECTOR}}
   replicas: 1
   resources:
     requests:


### PR DESCRIPTION
Adding StructuralData as some data parsing was broken, only visible when PROMETHEUS_NODE_SELECTOR env was set

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Using CL2_PROMETHEUS_NODE_SELECTOR no longer breaks Prometheus.

#### Which issue(s) this PR fixes:

Fix #2464

Follow up to #2421 to cover use case of CL2_PROMETHEUS_NODE_SELECTOR

/assign @mborsz 
FYI @hakuna-matatah 