### PR TITLE
Bump slo-monitor to 0.15.7

### DIFF
--- a/slo-monitor/Makefile
+++ b/slo-monitor/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 PACKAGE = k8s.io/perf-tests/slo-monitor
-TAG = 0.15.6
+TAG = 0.15.7
 # Image should be pulled from registry.k8s.io, which will auto-detect
 # region/cloud provider and pull from the closest.
 REPOSITORY?=registry.k8s.io


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

To fix CVE-2023-45285 and CVE-2023-39326

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

