### PR TITLE
Fix time of pulling image error in slo-monitor

### DIFF
--- a/slo-monitor/src/monitors/pod_monitor.go
+++ b/slo-monitor/src/monitors/pod_monitor.go
@@ -290,7 +290,7 @@ func (pm *PodStartupLatencyDataMonitor) handlePulledImageEvent(key string, e *v1
 
 	ok := false
 	data := PodStartupMilestones{}
-	if data, ok = pm.PodStartupData[key]; ok {
+	if data, ok = pm.PodStartupData[key]; !ok {
 		data.startedPulling = time.Unix(0, 0)
 		data.needPulled = -1
 	}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Recording the time of pulling image correctly.
Slo-monitor logs before fixing:
`pod_monitor.go:324] Observed Pod default/netshoot creation: created 2024-01-22 02:27:21 +0000 UTC, pulling: 1970-01-01 00:00:00 +0000 UTC, pulled: 2024-01-22 02:27:26 +0000 UTC, running: 2024-01-22 02:27:28.157849816 +0000 UTC m=+1186.391220756`
After fixing:
`pod_monitor.go:324] Observed Pod default/netshoot creation: created 2024-01-22 02:35:25 +0000 UTC, pulling: 2024-01-22 02:35:27 +0000 UTC, pulled: 2024-01-22 02:35:30 +0000 UTC, running: 2024-01-22 02:35:32.056450406 +0000 UTC m=+91.324739178`

#### Which issue(s) this PR fixes:
Fixes #2525


