### PR TITLE
add simple HPA scale test

### DIFF
--- a/clusterloader2/cmd/clusterloader.go
+++ b/clusterloader2/cmd/clusterloader.go
@@ -76,6 +76,7 @@ func initClusterFlags() {
 	flags.StringEnvVar(&clusterLoaderConfig.ClusterConfig.EtcdCertificatePath, "etcd-certificate", "ETCD_CERTIFICATE", "/etc/srv/kubernetes/pki/etcd-apiserver-server.crt", "Path to the etcd certificate on the master machine")
 	flags.StringEnvVar(&clusterLoaderConfig.ClusterConfig.EtcdKeyPath, "etcd-key", "ETCD_KEY", "/etc/srv/kubernetes/pki/etcd-apiserver-server.key", "Path to the etcd key on the master machine")
 	flags.IntEnvVar(&clusterLoaderConfig.ClusterConfig.EtcdInsecurePort, "etcd-insecure-port", "ETCD_INSECURE_PORT", 2382, "Inscure http port")
+	flags.IntEnvVar(&clusterLoaderConfig.ClusterConfig.KCMPort, "KCM-port", "KCM_PORT", ports.KubeControllerManagerPort, "Port of the kube-controller-manager")
 	flags.BoolEnvVar(&clusterLoaderConfig.ClusterConfig.DeleteStaleNamespaces, "delete-stale-namespaces", "DELETE_STALE_NAMESPACES", false, "DEPRECATED: Whether to delete all stale namespaces before the test execution.")
 	err := flags.MarkDeprecated("delete-stale-namespaces", "specify deleteStaleNamespaces in testconfig file instead.")
 	if err != nil {

--- a/clusterloader2/pkg/config/cluster.go
+++ b/clusterloader2/pkg/config/cluster.go
@@ -56,6 +56,7 @@ type ClusterConfig struct {
 	KubeletPort                   int
 	K8SClientsNumber              int
 	SkipClusterVerification       bool
+	KCMPort                       int
 }
 
 // ExecServiceConfig represents all flags used by service config.

--- a/clusterloader2/pkg/measurement/common/kcm_metrics.go
+++ b/clusterloader2/pkg/measurement/common/kcm_metrics.go
@@ -1,0 +1,223 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"fmt"
+	"math"
+	"time"
+
+	"github.com/prometheus/common/model"
+	"k8s.io/klog/v2"
+	"k8s.io/perf-tests/clusterloader2/pkg/errors"
+	"k8s.io/perf-tests/clusterloader2/pkg/measurement"
+	measurementutil "k8s.io/perf-tests/clusterloader2/pkg/measurement/util"
+	"k8s.io/perf-tests/clusterloader2/pkg/provider"
+	"k8s.io/perf-tests/clusterloader2/pkg/util"
+)
+
+const (
+	kcmWorkQueueDepthMetricName    = "KCMWorkQueueDepthMetrics"
+	kcmWorkQueueDepthMetricVersion = "v1"
+	hpaResource                    = "horizontalpodautoscaler"
+)
+
+func init() {
+	if err := measurement.Register(kcmWorkQueueDepthMetricName, createKCMWorkQueueDepthMeasurement); err != nil {
+		klog.Fatalf("Cannot register %s: %v", kcmWorkQueueDepthMetricName, err)
+	}
+}
+
+func createKCMWorkQueueDepthMeasurement() measurement.Measurement {
+	return &kcmWorkQueueDepthMeasurement{
+		depthMetrics: map[string]float64{},
+		stopCh:       make(chan struct{}),
+	}
+}
+
+type kcmWorkQueueDepthMeasurement struct {
+	// depthMetrics is the minimum workqueue depth for each resouce in the leader.
+	depthMetrics      map[string]float64
+	hpaAllowedBacklog *float64
+
+	isRunning bool
+	stopCh    chan struct{}
+}
+
+func (m *kcmWorkQueueDepthMeasurement) Execute(config *measurement.Config) ([]measurement.Summary, error) {
+	provider := config.ClusterFramework.GetClusterConfig().Provider
+	hosts := config.ClusterFramework.GetClusterConfig().MasterIPs
+	SSHToMasterSupported := provider.Features().SupportSSHToMaster
+
+	action, err := util.GetString(config.Params, "action")
+	if err != nil {
+		return nil, err
+	}
+
+	kcmPort := config.ClusterFramework.GetClusterConfig().KCMPort
+	switch action {
+	case "start":
+		klog.V(2).Infof("%s: starting kcm metrics collecting...", m)
+		if !SSHToMasterSupported {
+			klog.Warningf("ssh to master node is not supported for provider: %v", provider.Name())
+			return nil, nil
+		}
+		m.start(provider, hosts, kcmPort)
+		return nil, nil
+	case "gather":
+		m.Dispose()
+		hpaAllowedBacklog, err := util.GetFloat64OrDefault(config.Params, "hpaAllowedBacklog", -1)
+		if err != nil {
+			return nil, err
+		}
+		if hpaAllowedBacklog >= 0 {
+			m.hpaAllowedBacklog = &hpaAllowedBacklog
+		}
+		summary, err := m.createSummary()
+		return []measurement.Summary{summary}, err
+	default:
+		return nil, fmt.Errorf("unknown action %v", action)
+	}
+}
+
+// Dispose cleans up after the measurement.
+func (m *kcmWorkQueueDepthMeasurement) Dispose() {
+	if m.isRunning {
+		m.isRunning = false
+		close(m.stopCh)
+	}
+}
+
+// String returns string representation of this measurement.
+func (m *kcmWorkQueueDepthMeasurement) String() string {
+	return kcmWorkQueueDepthMetricName
+}
+
+func (m *kcmWorkQueueDepthMeasurement) start(provider provider.Provider, hosts []string, port int) error {
+	if m.isRunning {
+		return fmt.Errorf("%s: measurement already running", m)
+	}
+	m.isRunning = true
+	klog.V(3).Infof("collecting KCM workqueue depth metrics from hosts: %v", hosts)
+	if len(hosts) == 0 {
+		return nil
+	}
+
+	// There's only one goroutine that collect metrics from all KCM instances.
+	go func() {
+		for {
+			select {
+			case <-time.After(time.Second):
+				metricsFromHosts := []map[string]float64{}
+				for _, host := range hosts {
+					workQueueDepthMetrics, err := m.getKCMWorkQueueDepth(host, provider, port)
+					if err != nil {
+						klog.Errorf("%s: failed to collect KCM workqueue depth: %v", m, err)
+						continue
+					}
+					metricsFromHosts = append(metricsFromHosts, workQueueDepthMetrics)
+				}
+				if len(metricsFromHosts) == 0 {
+					continue
+				}
+				// For one single data point in each KCM instance, we take the max,
+				// since the leader will have larger workqueue backlog.
+				result := metricsFromHosts[0]
+				for i := 1; i < len(metricsFromHosts); i++ {
+					result = getMaxOrMin(result, metricsFromHosts[i], true)
+				}
+				// We keep tracking the smallest value that we have seen.
+				m.depthMetrics = getMaxOrMin(m.depthMetrics, result, false)
+			case <-m.stopCh:
+				return
+			}
+		}
+	}()
+	return nil
+}
+
+func (m *kcmWorkQueueDepthMeasurement) createSummary() (measurement.Summary, error) {
+	perfData := &measurementutil.PerfData{
+		Version:   kcmWorkQueueDepthMetricVersion,
+		DataItems: []measurementutil.DataItem{},
+	}
+	for resource, value := range m.depthMetrics {
+		perfData.DataItems = append(perfData.DataItems, measurementutil.DataItem{
+			Data: map[string]float64{
+				"Min": value,
+			},
+			Labels: map[string]string{
+				"Resource": resource,
+			},
+		})
+	}
+	content, err := util.PrettyPrintJSON(perfData)
+	if err != nil {
+		return nil, err
+	}
+	if _, found := m.depthMetrics[hpaResource]; !found {
+		return nil, fmt.Errorf("can't find work queue depth metric for %v", hpaResource)
+	}
+	// If the min value is consistently larger than the allowed the workqueue backlog,
+	// it means the controller can't keep up with load for reconciliation.
+	if m.hpaAllowedBacklog != nil && m.depthMetrics[hpaResource] > *m.hpaAllowedBacklog {
+		err = errors.NewMetricViolationError(kcmWorkQueueDepthMetricName, fmt.Sprintf("HPA work queue backlog %v exceeds the allowed threshold %v", m.depthMetrics[hpaResource], *m.hpaAllowedBacklog))
+		klog.Errorf("%s: %v", m, err)
+	}
+	return measurement.CreateSummary(kcmWorkQueueDepthMetricName, "json", content), err
+}
+
+func (e *kcmWorkQueueDepthMeasurement) getKCMWorkQueueDepth(host string, provider provider.Provider, port int) (map[string]float64, error) {
+	cmd := fmt.Sprintf("curl -k https://localhost:%d/metrics", port)
+	samples, err := e.sshKCMMetrics(cmd, host, provider)
+	if err != nil {
+		return nil, err
+	}
+	workQueueDepth := map[string]float64{}
+	for _, sample := range samples {
+		if sample.Metric[model.MetricNameLabel] != "workqueue_depth" {
+			continue
+		}
+		resourceName, found := sample.Metric["name"]
+		if !found {
+			continue
+		}
+		workQueueDepth[string(resourceName)] = float64(sample.Value)
+	}
+	return workQueueDepth, nil
+}
+
+func (e *kcmWorkQueueDepthMeasurement) sshKCMMetrics(cmd, host string, provider provider.Provider) ([]*model.Sample, error) {
+	sshResult, err := measurementutil.SSH(cmd, host+":22", provider)
+	if err != nil {
+		return nil, fmt.Errorf("unexpected error (code: %d) in ssh connection to master: %#v", sshResult.Code, err)
+	} else if sshResult.Code != 0 {
+		return nil, fmt.Errorf("failed running command: %s on the host: %s, result: %+v", cmd, host, sshResult)
+	}
+	data := sshResult.Stdout
+	return measurementutil.ExtractMetricSamples(data)
+}
+
+func getMaxOrMin(existing, new map[string]float64, max bool) map[string]float64 {
+	for resource, value := range new {
+		if _, found := existing[resource]; !found {
+			existing[resource] = value
+		}
+		existing[resource] = math.Min(existing[resource], value)
+	}
+	return existing
+}

--- a/clusterloader2/pkg/util/util.go
+++ b/clusterloader2/pkg/util/util.go
@@ -304,14 +304,12 @@ func getBool(dict map[string]interface{}, key string) (bool, error) {
 // PrettyPrintJSON converts given data into formatted json.
 func PrettyPrintJSON(data interface{}) (string, error) {
 	output := &bytes.Buffer{}
-	if err := json.NewEncoder(output).Encode(data); err != nil {
-		return "", fmt.Errorf("building encoder error: %v", err)
+	enc := json.NewEncoder(output)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(data); err != nil {
+		return "", fmt.Errorf("error when encoding json: %v", err)
 	}
-	formatted := &bytes.Buffer{}
-	if err := json.Indent(formatted, output.Bytes(), "", "  "); err != nil {
-		return "", fmt.Errorf("indenting error: %v", err)
-	}
-	return formatted.String(), nil
+	return output.String(), nil
 }
 
 // CopyMap copies values from one map to the other.

--- a/clusterloader2/testing/hpa/README.md
+++ b/clusterloader2/testing/hpa/README.md
@@ -1,0 +1,18 @@
+## HPA controller load test
+
+Assumptions:
+- Cluster master noded are accessible via SSH.
+- The `/metrics` endpoint in the kube-controller-manager (KCM) can be accessed by anonymous users.
+  `--authorization-always-allow-paths` can be useful to achieve this.
+
+HPA load test perform the following steps:
+- Create replicasets, services, HPAs in a set of namespaces.
+  - The namespaces used here are managed by CL2.
+  - The number of HPAs in each namespace can be specified using `CL2_HPA_PER_NAMESPACE`.
+- Periodically measure the HPA controller workqueue depth in each KCM instance
+  - In each scrape, we use the max value among them since the leader will have more items in the workqueue.
+  - We keep tracking the smallest value over time.
+- Wait 2 minutes to allow HPA controller to reconcile HPA objects multiple rounds given the default reconciliation
+  interval for HPA controller is 15s.
+- Compare the minimum workqueue backlog with `CL2_KCM_HPA_ALLOWED_BACKLOG`. If exceeding, the test will fail.
+  If unspecified, the test will always pass. The metrics will output in json format.

--- a/clusterloader2/testing/hpa/config.yaml
+++ b/clusterloader2/testing/hpa/config.yaml
@@ -1,0 +1,60 @@
+{{$NODES_PER_NAMESPACE := DefaultParam .NODES_PER_NAMESPACE 1}}
+{{$NAMESPACES := DivideInt .Nodes $NODES_PER_NAMESPACE}}
+{{$NAMESPACE_NUMBER := MaxInt $NAMESPACES 1}}
+
+{{$HPA_NUMBER_PER_NAMESPACE := DefaultParam .CL2_HPA_PER_NAMESPACE 1000}}
+{{$KCM_HPA_ALLOWED_BACKLOG := DefaultParam .CL2_KCM_HPA_ALLOWED_BACKLOG -1}}
+
+name: HPA scale test
+namespace:
+  number: {{$NAMESPACE_NUMBER}}
+tuningSets:
+- name: Sequence
+  parallelismLimitedLoad:
+    parallelismLimit: 10
+steps:
+- name: Create replicasets, services and HPAs
+  phases:
+  - namespaceRange:
+      min: 1
+      max: {{$NAMESPACE_NUMBER}}
+    tuningSet: Sequence
+    replicasPerNamespace: 1
+    objectBundle:
+    - basename: app
+      objectTemplatePath: replicaset.yaml
+  - namespaceRange:
+      min: 1
+      max: {{$NAMESPACE_NUMBER}}
+    tuningSet: Sequence
+    replicasPerNamespace: 1
+    objectBundle:
+    - basename: app
+      objectTemplatePath: service.yaml
+  - namespaceRange:
+      min: 1
+      max: {{$NAMESPACE_NUMBER}}
+    tuningSet: Sequence
+    replicasPerNamespace: {{$HPA_NUMBER_PER_NAMESPACE}}
+    objectBundle:
+    - basename: app
+      objectTemplatePath: hpa.yaml
+- name: Starting to measure KCM work queue depth
+  measurements:
+  - Identifier: KCMWorkQueueDepthMetrics
+    Method: KCMWorkQueueDepthMetrics
+    Params:
+      action: start
+- name: Wait 2 minutes
+  measurements:
+    - Identifier: Wait
+      Method: Sleep
+      Params:
+        duration: 2m
+- name: Gathering KCM work queue depth
+  measurements:
+  - Identifier: KCMWorkQueueDepthMetrics
+    Method: KCMWorkQueueDepthMetrics
+    Params:
+      action: gather
+      hpaAllowedBacklog: {{$KCM_HPA_ALLOWED_BACKLOG}}

--- a/clusterloader2/testing/hpa/hpa.yaml
+++ b/clusterloader2/testing/hpa/hpa.yaml
@@ -1,0 +1,18 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{.Name}}
+spec:
+  minReplicas: 1
+  maxReplicas: 10
+  metrics:
+  - resource:
+      name: cpu
+      target:
+        averageUtilization: 50
+        type: Utilization
+    type: Resource
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: ReplicaSet
+    name: {{.Name}}

--- a/clusterloader2/testing/hpa/replicaset.yaml
+++ b/clusterloader2/testing/hpa/replicaset.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  name: {{.Name}}
+spec:
+  selector:
+    matchLabels:
+      name: {{.Name}}
+  template:
+    metadata:
+      labels:
+        name: {{.Name}}
+    spec:
+      containers:
+      - name: php-apache
+        image: registry.k8s.io/hpa-example
+        ports:
+        - containerPort: 80
+        resources:
+          limits:
+            cpu: 500m
+          requests:
+            cpu: 50m

--- a/clusterloader2/testing/hpa/service.yaml
+++ b/clusterloader2/testing/hpa/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{.Name}}
+  labels:
+    name: {{.Name}}
+spec:
+  ports:
+  - port: 80
+  selector:
+    name: {{.Name}}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR adds a simple scale test to test HPA controller to check if it can keep up with the load of reconcile all HPAs object within the reconciliation interval (default: 15s).

If a cluster has thousands of HPAs objects, it may not be able to reconcile them all every 15s. HPA controller's workqueue will consistently have backlog. This test can help catch it.

#### Which issue(s) this PR fixes:


#### Special notes for your reviewer:
It was previously discussed in SIG scalability call: https://docs.google.com/document/d/1hEpf25qifVWztaeZPFmjNiJvPo-5JX1z0LSvvVY5G2g/edit#heading=h.mh1dh917dnmi
