### PR TITLE
Add a dedicated SA for probes

### DIFF
--- a/clusterloader2/pkg/measurement/common/probes/manifests/dnsLookup/dns-prober-deployment.yaml
+++ b/clusterloader2/pkg/measurement/common/probes/manifests/dnsLookup/dns-prober-deployment.yaml
@@ -37,6 +37,7 @@ spec:
           volumeMounts:
             - name: logs-volume
               mountPath: /var/log
+      serviceAccountName: probes
       volumes:
         - name: logs-volume
           hostPath:

--- a/clusterloader2/pkg/measurement/common/probes/manifests/ping-client-deployment.yaml
+++ b/clusterloader2/pkg/measurement/common/probes/manifests/ping-client-deployment.yaml
@@ -35,6 +35,7 @@ spec:
           volumeMounts:
             - name: logs-volume
               mountPath: /var/log
+      serviceAccountName: probes
       volumes:
         - name: logs-volume
           hostPath:

--- a/clusterloader2/pkg/measurement/common/probes/manifests/ping-server-deployment.yaml
+++ b/clusterloader2/pkg/measurement/common/probes/manifests/ping-server-deployment.yaml
@@ -36,6 +36,7 @@ spec:
           volumeMounts:
             - name: logs-volume
               mountPath: /var/log
+      serviceAccountName: probes
       volumes:
         - name: logs-volume
           hostPath:

--- a/clusterloader2/pkg/measurement/common/probes/manifests/probes-serviceaccount.yaml
+++ b/clusterloader2/pkg/measurement/common/probes/manifests/probes-serviceaccount.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: probes
+  namespace: probes
+  


### PR DESCRIPTION
For being able to launch probes before a default SA is created.