### PR TITLE
Bump go compiler version to 1.22.0

### DIFF
--- a/golang/Makefile
+++ b/golang/Makefile
@@ -15,7 +15,7 @@
 .PHONY: build-go build push
 
 export GCS_BUCKET?=k8s-infra-scale-golang-builds
-export GO_COMPILER_PKG?=go1.21.3.linux-amd64.tar.gz
+export GO_COMPILER_PKG?=go1.22.0.linux-amd64.tar.gz
 export GO_COMPILER_URL?=https://dl.google.com/go/$(GO_COMPILER_PKG)
 export ROOT_DIR?=/home/prow/go/src
 


### PR DESCRIPTION
This is to (at least partially) fix https://testgrid.k8s.io/sig-scalability-golang#build-and-push-k8s-at-golang-tip.

https://github.com/kubernetes/test-infra/issues/31889 blocks the complete fix, however.

/assign @mborsz 