### PR TITLE
allow node problem detector restart 2 times

### DIFF
--- a/clusterloader2/testing/experiments/ignore_known_gce_container_restarts.yaml
+++ b/clusterloader2/testing/experiments/ignore_known_gce_container_restarts.yaml
@@ -10,6 +10,7 @@ RESTART_COUNT_THRESHOLD_OVERRIDES: |
   prometheus-to-sd-exporter: 2
   coredns: 2
   konnectivity-agent: 2
+  node-problem-detector: 2
 
   # Allow for a single restart of master components.
   # As long as tests are passing, a single restart shouldn't be a problem


### PR DESCRIPTION
https://testgrid.k8s.io/sig-release-master-informing#gce-master-scale-performance

Fixes https://github.com/kubernetes/kubernetes/issues/123328

https://perf-dash.k8s.io/#/?jobname=gce-5000Nodes&metriccategoryname=SystemPodMetrics&metricname=Load_SystemPodMetrics&RestartCount=RestartCount

Node Problem Detector restarted in recent runs. 


https://github.com/kubernetes/perf-tests/blob/ac4b33e7c3afe23b571be5c569fb968c8b88db7c/clusterloader2/testing/experiments/ignore_known_gce_container_restarts.yaml#L5-L16

It is not clear why the pod restart sometimes. Node Problem Detector is a daemonset and only 1 restarted may not indicts a big problem.

