### PR TITLE
add --break-system-packages for pip install

### DIFF
--- a/dns/run
+++ b/dns/run
@@ -25,7 +25,7 @@ outDir=${2:-"out"}
 nodeLocalIP=${4:-"169.254.20.10"}
 mkdir -p ${outDir}
 
-pip3 install numpy
+pip3 install --break-system-packages numpy
 
 case "$1" in
   kube-dns )


### PR DESCRIPTION
Similar with https://github.com/kubernetes/test-infra/pull/30695

Fixes https://github.com/kubernetes/perf-tests/issues/2597

https://storage.googleapis.com/kubernetes-jenkins/logs/ci-benchmark-nodelocal-dns-master/1762446829783355392/build-log.txt

```
2024/02/27 12:06:40 process.go:153: Running: /home/prow/go/src/k8s.io/perf-tests/run-e2e.sh node-local-dns /logs/artifacts/out /logs/artifacts 169.254.20.10
TOOL_NAME: node-local-dns
error: externally-managed-environment

× This environment is externally managed
╰─> To install Python packages system-wide, try apt install
    python3-xyz, where xyz is the package you are trying to
    install.
    
    If you wish to install a non-Debian-packaged Python package,
    create a virtual environment using python3 -m venv path/to/venv.
    Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
    sure you have python3-full installed.
    
    If you wish to install a non-Debian packaged Python application,
    it may be easiest to use pipx install xyz, which will manage a
    virtual environment for you. Make sure you have pipx installed.
    
    See /usr/share/doc/python3.11/README.venv for more information.

note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
hint: See PEP 668 for the detailed specification.

```

It makes below CIs failing.
https://testgrid.k8s.io/sig-scalability-benchmarks#node-local-dns
https://testgrid.k8s.io/sig-scalability-benchmarks#kube-dns