### PR TITLE
List pods/nodes from watchcache when creating a new ContainerResourceGatherer

### DIFF
--- a/clusterloader2/pkg/measurement/util/gatherers/container_resource_gatherer.go
+++ b/clusterloader2/pkg/measurement/util/gatherers/container_resource_gatherer.go
@@ -103,12 +103,13 @@ func NewResourceUsageGatherer(c clientset.Interface, host string, port int, prov
 			provider:                    provider,
 		})
 	} else {
-		pods, err := c.CoreV1().Pods(namespace).List(context.TODO(), metav1.ListOptions{})
+		listOptions := metav1.ListOptions{ResourceVersion: "0"}
+		pods, err := c.CoreV1().Pods(namespace).List(context.TODO(), listOptions)
 		if err != nil {
 			return nil, fmt.Errorf("listing pods error: %v", err)
 		}
 
-		nodeList, err := c.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
+		nodeList, err := c.CoreV1().Nodes().List(context.TODO(), listOptions)
 		if err != nil {
 			return nil, fmt.Errorf("listing nodes error: %v", err)
 		}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Setting empty ListOptions for the List calls essentially means we list the Pods/Nodes directly from etcd with no pagination at all. By listing from watchcache we would offload etcd.
