### PR TITLE
DNS propagation measurement in CL2

### DIFF
--- a/clusterloader2/go.mod
+++ b/clusterloader2/go.mod
@@ -40,6 +40,7 @@ require (
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/safetext v0.0.0-20230106111101-7156a760e523
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/montanaflynn/stats v0.7.1 // indirect
 	github.com/onsi/ginkgo v1.16.5
 	github.com/prometheus/client_model v0.6.0
 	github.com/prometheus/common v0.26.0

--- a/clusterloader2/go.sum
+++ b/clusterloader2/go.sum
@@ -708,6 +708,8 @@ github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjY
 github.com/mohae/deepcopy v0.0.0-20170603005431-491d3605edfb/go.mod h1:TaXosZuwdSHYgviHp1DAtfrULt5eUgsSMsZf+YrPgl8=
 github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00/go.mod h1:Pm3mSP3c5uWn86xMLZ5Sa7JB9GsEZySvHYXCTK4E9q4=
 github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
+github.com/montanaflynn/stats v0.7.1 h1:etflOAAHORrCC44V+aR6Ftzort912ZU+YLiSTuV8eaE=
+github.com/montanaflynn/stats v0.7.1/go.mod h1:etXPPgVO6n31NxCd9KQUMvCM+ve0ruNzt6R8Bnaayow=
 github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
 github.com/mrunalp/fileutils v0.5.0/go.mod h1:M1WthSahJixYnrXQl/DFQuteStB1weuxD2QJNHXfbSQ=
 github.com/mschoch/smat v0.0.0-20160514031455-90eadee771ae/go.mod h1:qAyveg+e4CE+eKJXWVjKXM4ck2QobLqTDytGJbLLhJg=

--- a/clusterloader2/pkg/measurement/common/probes/manifests/dnsPropagation/dns-propagation-prober-deployment.yaml
+++ b/clusterloader2/pkg/measurement/common/probes/manifests/dnsPropagation/dns-propagation-prober-deployment.yaml
@@ -1,0 +1,48 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: probes
+  name: dns-propagation-prober
+  labels:
+    probe: dns-propagation-prober
+spec:
+  selector:
+    matchLabels:
+      probe: dns-propagation-prober
+  replicas: {{.Replicas}}
+  template:
+    metadata:
+      labels:
+        probe: dns-propagation-prober
+    spec:
+      containers:
+        - name: prober
+          image: gcr.io/k8s-testimages/probes:v0.0.6
+          args:
+            - --metric-bind-address=0.0.0.0:8080
+            - --mode=dns-propagation
+            - --dns-propagation-probe-stateful-set={{.DNSPropagationProbeStatefulSet}}
+            - --dns-propagation-probe-service={{.DNSPropagationProbeService}}
+            - --dns-propagation-probe-namespace={{.DNSPropagationProbeNamespace}}
+            - --dns-propagation-probe-cluster-domain=cluster
+            - --dns-propagation-probe-suffix=local
+            - --dns-propagation-probe-interval=100ms
+            - --dns-propagation-probe-pod-count={{.DNSPropagationProbePodCount}}
+            - --dns-propagation-probe-sample-count={{.DNSPropagationProbeSampleCount}}
+            - --logtostderr=true
+            - --log_file=/var/log/cl2-dns-propagation.log
+          resources:
+            limits:
+              cpu: 100m
+              memory: 100Mi
+          ports:
+            - containerPort: 8080
+              name: metrics
+          volumeMounts:
+            - name: logs-volume
+              mountPath: /var/log
+      serviceAccountName: dns-propagation-prober
+      volumes:
+        - name: logs-volume
+          hostPath:
+            path: /var/log

--- a/clusterloader2/pkg/measurement/common/probes/manifests/dnsPropagation/dns-propagation-prober-rbac.yaml
+++ b/clusterloader2/pkg/measurement/common/probes/manifests/dnsPropagation/dns-propagation-prober-rbac.yaml
@@ -1,0 +1,36 @@
+apiVersion: v1
+kind: List
+items:
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRole
+  metadata:
+    name: dns-propagation-prober
+  rules:
+    - apiGroups:
+        - ""
+      resources:
+        - "services"
+        - "pods"
+        - "nodes"
+        - "namespaces"
+      verbs:
+        - get
+        - list
+        - watch
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRoleBinding
+  metadata:
+    name: dns-propagation-prober
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: dns-propagation-prober
+  subjects:
+    - kind: ServiceAccount
+      name: dns-propagation-prober
+      namespace: probes
+- apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    name: dns-propagation-prober
+    namespace: probes

--- a/clusterloader2/pkg/measurement/common/probes/manifests/dnsPropagation/dns-propagation-prober-service.yaml
+++ b/clusterloader2/pkg/measurement/common/probes/manifests/dnsPropagation/dns-propagation-prober-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: probes
+  name: dns-propagation-prober
+  labels:
+    probe: dns-propagation-prober
+spec:
+  ports:
+    - name: metrics
+      port: 8080
+  selector:
+    probe: dns-propagation-prober

--- a/clusterloader2/pkg/measurement/common/probes/manifests/dnsPropagation/dns-propagation-prober-serviceMonitor.yaml
+++ b/clusterloader2/pkg/measurement/common/probes/manifests/dnsPropagation/dns-propagation-prober-serviceMonitor.yaml
@@ -1,0 +1,15 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  namespace: probes
+  name: dns-propagation-prober
+spec:
+  endpoints:
+    - interval: 30s
+      port: metrics
+  namespaceSelector:
+    matchNames:
+      - probes
+  selector:
+    matchLabels:
+      probe: dns-propagation-prober

--- a/clusterloader2/pkg/measurement/common/probes/propagation_metric.go
+++ b/clusterloader2/pkg/measurement/common/probes/propagation_metric.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package probes
+
+import (
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/montanaflynn/stats"
+	"github.com/prometheus/common/model"
+	"k8s.io/klog/v2"
+	"k8s.io/perf-tests/clusterloader2/pkg/measurement"
+	measurementutil "k8s.io/perf-tests/clusterloader2/pkg/measurement/util"
+	"k8s.io/perf-tests/clusterloader2/pkg/util"
+)
+
+const (
+	defaultDNSPropagationProbeNamespaceIndex = 1
+	defaultDNSPropagationProbeSampleCount    = 10
+)
+
+// NewPropagationMetricPrometheus tries to parse latency data from results of Prometheus query from propagation probe.
+func NewPropagationMetricPrometheus(samples []*model.Sample) (*measurementutil.LatencyMetric, error) {
+	var latencyMetric measurementutil.LatencyMetric
+	values := []float64{}
+	for _, sample := range samples {
+		values = append(values, float64(sample.Value))
+	}
+	sort.Float64s(values)
+	p50, err := stats.Percentile(values, 50)
+	if err != nil {
+		return nil, err
+	}
+	p90, err := stats.Percentile(values, 90)
+	if err != nil {
+		return nil, err
+	}
+	p99, err := stats.Percentile(values, 99)
+	if err != nil {
+		return nil, err
+	}
+	latencyMetric.SetQuantile(0.5, time.Duration(p50*float64(time.Second)))
+	latencyMetric.SetQuantile(0.90, time.Duration(p90*float64(time.Second)))
+	latencyMetric.SetQuantile(0.99, time.Duration(p99*float64(time.Second)))
+	return &latencyMetric, nil
+}
+
+func InitializeTemplateMappingForDNSPropagationProbe(config *measurement.Config) (map[string]interface{}, error) {
+	DNSPropagationProbeService, err := util.GetStringOrDefault(config.Params, "DNSPropagationProbeService", "")
+	if err != nil {
+		return nil, err
+	}
+	DNSPropagationProbeStatefulSet, err := util.GetStringOrDefault(config.Params, "DNSPropagationProbeStatefulSet", "")
+	if err != nil {
+		return nil, err
+	}
+	DNSPropagationProbePodCount, err := util.GetIntOrDefault(config.Params, "DNSPropagationProbePodCount", 0)
+	if err != nil {
+		return nil, err
+	}
+	DNSPropagationProbeSampleCount, err := util.GetIntOrDefault(config.Params, "DNSPropagationProbeSampleCount", defaultDNSPropagationProbeSampleCount)
+	if err != nil {
+		return nil, err
+	}
+	// Reconstructing namespace name
+	DNSPropagationProbeNamespaceIndex, err := util.GetIntOrDefault(config.Params, "DNSPropagationProbeNamespaceIndex", defaultDNSPropagationProbeNamespaceIndex)
+	if err != nil {
+		return nil, err
+	}
+	namespacePrefix := config.ClusterFramework.GetAutomanagedNamespacePrefix()
+	DNSPropagationProbeNamespace := fmt.Sprintf("%s-%d", namespacePrefix, DNSPropagationProbeNamespaceIndex)
+	klog.V(2).Infof("DNS propagation namespace, GetAutomanagedNamespacePrefix= %s, DNSPropagationProbeNamespaceIndex=%d, DNSPropagationProbeNamespace=%s",
+		namespacePrefix, DNSPropagationProbeNamespaceIndex, DNSPropagationProbeNamespace)
+	return map[string]interface{}{
+		"DNSPropagationProbeNamespace":   DNSPropagationProbeNamespace,
+		"DNSPropagationProbeService":     DNSPropagationProbeService,
+		"DNSPropagationProbeStatefulSet": DNSPropagationProbeStatefulSet,
+		"DNSPropagationProbePodCount":    DNSPropagationProbePodCount,
+		"DNSPropagationProbeSampleCount": DNSPropagationProbeSampleCount,
+	}, nil
+}

--- a/clusterloader2/pkg/prometheus/manifests/prometheus-rules.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/prometheus-rules.yaml
@@ -63,6 +63,9 @@ spec:
       record: probes:dns_lookup_latency:histogram_quantile
       labels:
         quantile: "0.50"
+    - expr: |
+        sum(max_over_time(probes_dns_propagation_seconds[1h]))/sum(max_over_time(probes_dns_propagation_count[1h]))
+      record: probes:dns_propagation_average
   - name: kube-proxy.rules
     rules:
     - expr: |


### PR DESCRIPTION
Implementation of a DNS propagation measurement in CL2, using the DNS propagation prober.

Follow up on #2643

/kind feature