### PR TITLE
allows for the exec_service pod image to be pulled from a custom repo

### DIFF
--- a/clusterloader2/pkg/config/cluster.go
+++ b/clusterloader2/pkg/config/cluster.go
@@ -61,7 +61,8 @@ type ClusterConfig struct {
 // ExecServiceConfig represents all flags used by service config.
 type ExecServiceConfig struct {
 	// Determines if service config should be enabled.
-	Enable bool
+	Enable        bool
+	ImageRegistry string
 }
 
 // ModifierConfig represent all flags used by test modification

--- a/clusterloader2/pkg/execservice/exec_service.go
+++ b/clusterloader2/pkg/execservice/exec_service.go
@@ -67,10 +67,16 @@ func InitFlags(c *config.ExecServiceConfig) {
 		true,
 		"Whether to enable exec service that allows executing arbitrary commands from a pod running in the cluster.",
 	)
+	flags.StringVar(
+		&c.ImageRegistry,
+		"registry-k8s-repo",
+		"registry.k8s.io",
+		"FQDN of registry.k8s.io image repo",
+	)
 }
 
 // SetUpExecService creates exec pod.
-func SetUpExecService(f *framework.Framework, _ config.ExecServiceConfig) error {
+func SetUpExecService(f *framework.Framework, c config.ExecServiceConfig) error {
 	var err error
 	lock.Lock()
 	defer lock.Unlock()
@@ -82,6 +88,7 @@ func SetUpExecService(f *framework.Framework, _ config.ExecServiceConfig) error 
 	mapping["Name"] = execDeploymentName
 	mapping["Namespace"] = execDeploymentNamespace
 	mapping["Replicas"] = execPodReplicas
+	mapping["ImageRegistry"] = c.ImageRegistry
 	if err = client.CreateNamespace(f.GetClientSets().GetClient(), execDeploymentNamespace); err != nil {
 		return fmt.Errorf("namespace %s creation error: %v", execDeploymentNamespace, err)
 	}

--- a/clusterloader2/pkg/execservice/manifest/exec_deployment.yaml
+++ b/clusterloader2/pkg/execservice/manifest/exec_deployment.yaml
@@ -15,4 +15,4 @@ spec:
     spec:
       containers:
       - name: agnhost
-        image: registry.k8s.io/e2e-test-images/agnhost:2.32
+        image: {{.ImageRegistry}}/e2e-test-images/agnhost:2.32


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Some clusters may not be able to reach the upstream Kubernetes image repos, like registry.k8s.io, but can reach some internal mirror of these. This will allow to set a custom image repo for the exec_service that cluster loader uses to create the exec pods. You can supply the image repo via a clusterloader2 CLI flag `--registry-k8s-repo`

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # https://github.com/kubernetes/perf-tests/issues/2704

#### Special notes for your reviewer:

