### PR TITLE
use targetPort for monitoring network policies metrics

### DIFF
--- a/clusterloader2/pkg/prometheus/manifests/default/prometheus-podMonitorKubeNetworkPolicies.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/default/prometheus-podMonitorKubeNetworkPolicies.yaml
@@ -11,7 +11,8 @@ metadata:
 spec:
   podMetricsEndpoints:
     - interval: 10m
-      port: 9080
+      # see https://github.com/prometheus-operator/prometheus-operator/pull/3078
+      targetPort: 9080
   jobLabel: k8s-app
   selector:
     matchLabels:


### PR DESCRIPTION
I've found the scalability jobs were not running https://testgrid.k8s.io/sig-scalability-experiments#kube-network-policies

```
F0612 10:46:47.152411   17893 clusterloader.go:330] Error while setting up prometheus stack: error while applying (default/prometheus-podMonitorKubeNetworkPolicies.yaml): PodMonitor.monitoring.coreos.com "kube-network-policies-pods" is invalid: spec.podMetricsEndpoints[0].port: Invalid value: "integer": spec.podMetricsEndpoints[0].port in body must be of type string: "integer"
2024/06/12 10:46:47 process.go:155: Step '/home/prow/go/src/k8s.io/perf-tests/run-e2e.sh cluster-loader2 --experimental-gcp-snapshot-prometheus-disk=true --experimental-prometheus-disk-snapshot-name=ci-kubernetes-e2e-gci-gce-scalability-np-1800838655078567936 --experimental-prometheus-snapshot-to-report-dir=true --nodes=100 --prometheus-scrape-node-exporter --provider=gce --report-dir=/logs/artifacts --testconfig=testing/load/config.yaml --testconfig=testing/huge-service/config.yaml --testoverrides=./testing/experiments/use_simple_latency_query.yaml --testoverrides=./testing/prometheus/scrape-kube-network-policies.yaml' finished in 3m20.122697124s
```
It seems prometheus operator deprecated the targetPort field but didn't disable or remove it https://github.com/prometheus-operator/prometheus-operator/pull/3078

TargetPort allows to specify an integeer port, meanwhile port: only works for named ports.

/kind failing-test
/assign @jprzychodzen @dlapcevic 