### PR TITLE
prometheus: add optional path with additional manifests

### DIFF
--- a/clusterloader2/pkg/config/cluster.go
+++ b/clusterloader2/pkg/config/cluster.go
@@ -92,7 +92,6 @@ type PrometheusConfig struct {
 	ScrapeMastersWithPublicIPs bool
 	APIServerScrapePort        int
 	SnapshotProject            string
-	ManifestPath               string
 	AdditionalMonitorsPath     string
 	StorageClassProvisioner    string
 	StorageClassVolumeType     string

--- a/clusterloader2/pkg/config/cluster.go
+++ b/clusterloader2/pkg/config/cluster.go
@@ -93,6 +93,7 @@ type PrometheusConfig struct {
 	APIServerScrapePort        int
 	SnapshotProject            string
 	ManifestPath               string
+	AdditionalMonitorsPath     string
 	StorageClassProvisioner    string
 	StorageClassVolumeType     string
 	PVCStorageClass            string


### PR DESCRIPTION


#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

In the past, we added all service/pod monitors directly into manifests directory within cl2/prometheus. This is not really scalable solution if one wants to test other components. Let's add option to allow to specify additional monitors from different path.

#### Special notes for your reviewer:
Example use-case: https://github.com/marseel/perf-tests/commit/11075f78427c079801fb7b6ed53041dbad05a763
Example command:
```
CL2_PROMETHEUS_PVC_ENABLED=false go run ./cmd/clusterloader.go             -v=4             --testconfig=./testing/dns/config.yaml             --provider=kind             --enable-prometheus-server             --tear-down-prometheus-server=false             --nodes=2             --report-dir=./report                     --kubeconfig=$HOME/.kube/config --prometheus-additional-monitors-path=./testing/dns/manifests/ --prometheus-apiserver-scrape-port=6443
```
