### PR TITLE
Enable DNS propagation measurement for huge-service test

### DIFF
--- a/clusterloader2/testing/huge-service/config.yaml
+++ b/clusterloader2/testing/huge-service/config.yaml
@@ -17,6 +17,9 @@ steps:
     path: modules/measurements.yaml
     params:
       action: start
+      namespaceIdx: 1
+      serviceName: huge-service-statefulset-0
+      statefulsetEndpoints: {{$STATEFULSET_ENDPOINTS}}
 - module:
     path: modules/service.yaml
     params:
@@ -28,3 +31,6 @@ steps:
     path: modules/measurements.yaml
     params:
       action: gather
+      namespaceIdx: 1
+      serviceName: huge-service-statefulset-0
+      statefulsetEndpoints: {{$STATEFULSET_ENDPOINTS}}

--- a/clusterloader2/testing/huge-service/modules/measurements.yaml
+++ b/clusterloader2/testing/huge-service/modules/measurements.yaml
@@ -1,5 +1,8 @@
 # Valid actions: "start", "gather"
 {{$action := .action}}
+{{$statefulsetEndpoints := .statefulsetEndpoints}}
+{{$serviceName := .serviceName}}
+{{$namespaceIdx := .namespaceIdx}}
 
 {{$ALLOWED_SLOW_API_CALLS := DefaultParam .CL2_ALLOWED_SLOW_API_CALLS 0}}
 {{$HUGE_SERVICE_ALLOWED_SLOW_API_CALLS := DefaultParam .CL2_HUGE_SERVICE_ALLOWED_SLOW_API_CALLS 2}}
@@ -21,6 +24,13 @@
 {{$PROBE_MEASUREMENTS_PING_SLEEP_DURATION := DefaultParam .CL2_PROBE_MEASUREMENTS_PING_SLEEP_DURATION "1s"}}
 
 {{$allowedSlowCalls := AddInt $ALLOWED_SLOW_API_CALLS $HUGE_SERVICE_ALLOWED_SLOW_API_CALLS}}
+
+# DNS propagation configs, used to measure DNS propagation latency for statefulset in statefulset.yaml
+# Flag to enable/disable the DNS propagation measurement
+{{$ENABLE_DNS_PROPAGATION_MEASUREMENT := DefaultParam .CL2_ENABLE_DNS_PROPAGATION_MEASUREMENT false}}
+# Time threshold for the DNS propagation measurement
+{{$DNS_PROPAGATION_THRESHOLD := DefaultParam .CL2_DNS_PROPAGATION_THRESHOLD "10s"}}
+
 
 steps:
 - name: {{$action}}ing measurements
@@ -69,6 +79,19 @@ steps:
       enableViolations: true
       defaultAllowedRestarts: {{$ALLOWED_CONTAINER_RESTARTS}}
       customAllowedRestarts: {{YamlQuote $CUSTOM_ALLOWED_CONTAINER_RESTARTS 4}}
+{{end}}
+{{if $ENABLE_DNS_PROPAGATION_MEASUREMENT}}
+  - Identifier: DnsPropagation
+    Method: DnsPropagation
+    Params:
+      action: {{$action}}
+      DNSPropagationProbeStatefulSet: {{$serviceName}}
+      DNSPropagationProbeService: {{$serviceName}}
+      DNSPropagationProbeNamespaceIndex: {{$namespaceIdx}}
+      DNSPropagationProbePodCount: {{$statefulsetEndpoints}}
+      DNSPropagationProbeSampleCount: {{MinInt 25 (AddInt 15 (DivideInt $statefulsetEndpoints 1000))}}
+      replicasPerProbe: {{MinInt 10 (AddInt 2 (DivideInt .Nodes 100))}}
+      threshold: {{$DNS_PROPAGATION_THRESHOLD}}
 {{end}}
 - module:
     path: ../load/modules/dns-performance-metrics.yaml


### PR DESCRIPTION
Enabling DNS propagation measurement in huge-service test.
Measures the DNS propagation of the statefulset created in huge-service.

Required new env variable:
- `CL2_ENABLE_DNS_PROPAGATION_MEASUREMENT` should be set to true to enable the measurement

Optional new env variable:
- `CL2_DNS_PROPAGATION_THRESHOLD` time threshold for DNS propagation, defaults to 10s.

In addition, this measurement assumes huge-service is run with large statefulset enabled, hence the following existing vars will be needed as well 
- `CL2_ENABLE_LARGE_STATEFULSET` should be set to true to enable adding large statefulset
- `CL2_STATEFULSET_ENDPOINTS` indicates the size of the statefulset



/kind feature