### PR TITLE
Fix Kind pluralization.

### DIFF
--- a/clusterloader2/go.mod
+++ b/clusterloader2/go.mod
@@ -54,6 +54,7 @@ require (
 	k8s.io/client-go v0.22.15
 	k8s.io/component-base v0.22.15
 	k8s.io/component-helpers v0.22.15
+	k8s.io/gengo v0.0.0-20201214224949-b6c5ce23f027
 	k8s.io/klog/v2 v2.130.1
 	k8s.io/kubelet v0.22.15
 	k8s.io/kubernetes v1.22.15

--- a/clusterloader2/go.sum
+++ b/clusterloader2/go.sum
@@ -1565,6 +1565,7 @@ k8s.io/controller-manager v0.22.15/go.mod h1:hb2vGDlX6buMMeU4gl0LtLNFYw/8B701+o7
 k8s.io/cri-api v0.22.15/go.mod h1:uAw9CICQq20/1yB4ZnWT2TjJyMMROl4typFfWaURLwQ=
 k8s.io/csi-translation-lib v0.22.15/go.mod h1:JMnyIeTtwiiYrsYeBkba5tHvAYkPsnMj9BOdr/Kl13Y=
 k8s.io/gengo v0.0.0-20200413195148-3a45101e95ac/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
+k8s.io/gengo v0.0.0-20201214224949-b6c5ce23f027 h1:Uusb3oh8XcdzDF/ndlI4ToKTYVlkCSJP39SRY2mfRAw=
 k8s.io/gengo v0.0.0-20201214224949-b6c5ce23f027/go.mod h1:FiNAH4ZV3gBg2Kwh89tzAEV2be7d5xI0vBa/VySYy3E=
 k8s.io/klog v1.0.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
 k8s.io/klog/v2 v2.0.0/go.mod h1:PBfzABfn139FHAV07az/IF9Wp1bkk3vpT2XSJ76fSDE=

--- a/clusterloader2/pkg/framework/client/objects.go
+++ b/clusterloader2/pkg/framework/client/objects.go
@@ -289,7 +289,7 @@ func CreateObject(dynamicClient dynamic.Interface, namespace string, name string
 // PatchObject updates (using patch) object with given name, group, version and kind based on given object description.
 func PatchObject(dynamicClient dynamic.Interface, namespace string, name string, obj *unstructured.Unstructured, options ...*APICallOptions) error {
 	gvk := obj.GroupVersionKind()
-	gvr, _ := meta.UnsafeGuessKindToResource(gvk)
+	gvr_ := pluralResource(gvk)
 	obj.SetName(name)
 	updateFunc := func() error {
 		currentObj, err := dynamicClient.Resource(gvr).Namespace(namespace).Get(context.TODO(), name, metav1.GetOptions{})
@@ -308,7 +308,7 @@ func PatchObject(dynamicClient dynamic.Interface, namespace string, name string,
 
 // DeleteObject deletes object with given name, group, version and kind.
 func DeleteObject(dynamicClient dynamic.Interface, gvk schema.GroupVersionKind, namespace string, name string, options ...*APICallOptions) error {
-	gvr, _ := meta.UnsafeGuessKindToResource(gvk)
+	gvr := pluralResource(gvk)
 	deleteFunc := func() error {
 		// Delete operation removes object with all of the dependants.
 		policy := metav1.DeletePropagationBackground

--- a/clusterloader2/pkg/framework/client/objects.go
+++ b/clusterloader2/pkg/framework/client/objects.go
@@ -289,7 +289,7 @@ func CreateObject(dynamicClient dynamic.Interface, namespace string, name string
 // PatchObject updates (using patch) object with given name, group, version and kind based on given object description.
 func PatchObject(dynamicClient dynamic.Interface, namespace string, name string, obj *unstructured.Unstructured, options ...*APICallOptions) error {
 	gvk := obj.GroupVersionKind()
-	gvr_ := pluralResource(gvk)
+	gvr := pluralResource(gvk)
 	obj.SetName(name)
 	updateFunc := func() error {
 		currentObj, err := dynamicClient.Resource(gvr).Namespace(namespace).Get(context.TODO(), name, metav1.GetOptions{})

--- a/clusterloader2/pkg/framework/client/objects_test.go
+++ b/clusterloader2/pkg/framework/client/objects_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -120,6 +121,36 @@ func TestIsRetryableNetError(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := IsRetryableNetError(tt.err); got != tt.want {
 				t.Errorf("IsRetryableNetError() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestKindPluralization(t *testing.T) {
+	tests := []struct {
+		kind string
+		want string
+	}{
+		{
+			kind: "Endpoints.v1.core",
+			want: "endpoints.v1.core",
+		},
+		{
+			kind: "Gateway.v1beta1.gateway.networking.k8s.io",
+			want: "gateways.v1beta1.gateway.networking.k8s.io",
+		},
+		{
+			kind: "Deployment.v1.apps",
+			want: "deployments.v1.apps",
+		},
+	}
+	for _, tt := range tests {
+		name := fmt.Sprintf("Pluralization of '%s'", tt.kind)
+		t.Run(name, func(t *testing.T) {
+			gvk, _ := schema.ParseKindArg(tt.kind)
+			want, _ := schema.ParseResourceArg(tt.want)
+			if got := pluralResource(*gvk); !cmp.Equal(got, *want) {
+				t.Errorf("pluralResource(%+v) = %+v, want %+v", *gvk, got, *want)
 			}
 		})
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fixes a bug where tests using resources that are not properly pluralizes as described in https://github.com/kubernetes/client-go/issues/1082 systematically fail.

For example, any test creating a `Gateway` object will fail (as it's turned into 'gatewaies').
