### PR TITLE
CL2: Add isFatal param to WaitForPods and enable failing measurements

### DIFF
--- a/clusterloader2/pkg/errors/error_list.go
+++ b/clusterloader2/pkg/errors/error_list.go
@@ -18,6 +18,7 @@ package errors
 
 import (
 	"bytes"
+	"errors"
 	"sync"
 )
 
@@ -56,6 +57,19 @@ func (e *ErrorList) Concat(e2 *ErrorList) {
 	e.lock.Lock()
 	defer e.lock.Unlock()
 	e.errors = append(e.errors, e2.errors...)
+}
+
+// Has returns the first error in the list that is of the same
+// type as the provided error. Equality is checked using
+// `errors.Is`.
+func (e *ErrorList) Has(targetErr error) bool {
+	for _, err := range e.errors {
+		if errors.Is(err, targetErr) {
+			return true
+		}
+	}
+
+	return false
 }
 
 // String returns error list as a single string.

--- a/clusterloader2/pkg/errors/fatal_error.go
+++ b/clusterloader2/pkg/errors/fatal_error.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package errors
+
+import (
+	"errors"
+	"fmt"
+)
+
+var ErrCritical = errors.New("criticl error")
+
+// NewErrCritical wraps an error and marks it as fatal.
+func NewErrCritical(err error) error {
+	return fmt.Errorf("%w: %w", ErrCritical, err)
+}

--- a/clusterloader2/pkg/measurement/common/wait_for_pods.go
+++ b/clusterloader2/pkg/measurement/common/wait_for_pods.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"k8s.io/klog/v2"
+	"k8s.io/perf-tests/clusterloader2/pkg/errors"
 	"k8s.io/perf-tests/clusterloader2/pkg/measurement"
 	measurementutil "k8s.io/perf-tests/clusterloader2/pkg/measurement/util"
 	"k8s.io/perf-tests/clusterloader2/pkg/util"
@@ -29,6 +30,7 @@ import (
 const (
 	defaultWaitForPodsTimeout         = 60 * time.Second
 	defaultWaitForPodsInterval        = 5 * time.Second
+	defaultIsFatal                    = false
 	waitForRunningPodsMeasurementName = "WaitForRunningPods"
 )
 
@@ -61,6 +63,11 @@ func (w *waitForRunningPodsMeasurement) Execute(config *measurement.Config) ([]m
 		return nil, err
 	}
 
+	isFatal, err := util.GetBoolOrDefault(config.Params, "isFatal", defaultIsFatal)
+	if err != nil {
+		return nil, err
+	}
+
 	ctx, cancel := context.WithTimeout(context.TODO(), timeout)
 	defer cancel()
 	options := &measurementutil.WaitForPodOptions{
@@ -72,7 +79,12 @@ func (w *waitForRunningPodsMeasurement) Execute(config *measurement.Config) ([]m
 	if err != nil {
 		return nil, err
 	}
+
 	_, err = measurementutil.WaitForPods(ctx, podStore, options)
+	if err != nil && isFatal {
+		return nil, errors.NewErrCritical(err)
+	}
+
 	return nil, err
 }
 

--- a/clusterloader2/pkg/measurement/measurement_executor.go
+++ b/clusterloader2/pkg/measurement/measurement_executor.go
@@ -33,7 +33,7 @@ func Execute(mm Manager, m *api.Measurement) *errors.ErrorList {
 }
 
 func formatError(method, identifier string, err error) error {
-	return fmt.Errorf("measurement call %s - %s error: %v", method, identifier, err)
+	return fmt.Errorf("measurement call %s - %s error: %w", method, identifier, err)
 }
 
 func executeSingleMeasurement(mm Manager, m *api.Measurement) *errors.ErrorList {

--- a/clusterloader2/pkg/test/simple_test_executor.go
+++ b/clusterloader2/pkg/test/simple_test_executor.go
@@ -383,9 +383,8 @@ func createNamespacesList(ctx Context, namespaceRange *api.NamespaceRange) []str
 	return nsList
 }
 
-func isErrsCritical(*errors.ErrorList) bool {
-	// TODO: define critical errors
-	return false
+func isErrsCritical(errList *errors.ErrorList) bool {
+	return errList.Has(errors.ErrCritical)
 }
 
 func cleanupResources(ctx Context, conf *api.Config) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


/kind feature


#### What this PR does / why we need it:

This PR introduces a set of commits that enable measurements to fail during their `Execute` method. Errors that are returned during a measurement's `Execute` method are passed up the stack to the simple test executor, which then passes them through a function called `isErrsCritical`. This function can control if the entire test should bail, based on the criticalness of the errors passed to it. Right now, it's a no-op:

https://github.com/kubernetes/perf-tests/blob/e7bdd15c9122e55d7dc267768190addc8fdf7b9e/clusterloader2/pkg/test/simple_test_executor.go#L386-L389

This PR modifies the function to check if any of the errors in the given list are fatal. A measurement can mark an error as fatal if it returns an error wrapped by a newly added `FatalError` type.

This PR also modifies the `WaitForPods` measurement to utilize this functionality. A new param named `isFatal` can control if a test should bail if the `WaitForPods` measurement is unable to successfully determine that a set of required pods are running and ready. This can be helpful for tests that require some infrastructure within the cluster to run. For example:

```yaml
name: is-fatal-test
namespace:
  number: 1
tuningSets:
- name: Uniform1qps
  qpsLoad:
    qps: 1
steps:
- name: Create test pod
  phases:
  - namespaceRange:
      min: 1
      max: 1
    replicasPerNamespace: 1
    tuningSet: Uniform1qps
    objectBundle:
    - basename: my-test-pod
      objectTemplatePath: ./my-test-pod.yaml
- name: Wait for test pod
  measurements:
  - Identifier: WaitForRunningPods
    Method: WaitForRunningPods
    Params:
      labelSelector: name=my-test-pod
      desiredPodCount: 1
      timeout: 60s
      isFatal: true
- name: Sleep
  measurements:
  - Identifier: Sleep
    Method: Sleep
    Params:
      duration: 10s
```

In this config, the `Sleep` measurement will only be executed if the test pod has been successfully deployed.