### PR TITLE
Add workaround for errcheck linter warning

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,6 +2,9 @@ run:
   timeout: 10m
 
 linters-settings:
+  errcheck:
+    # Workaround for https://github.com/golangci/golangci-lint/issues/4733
+    ignore: ""
   golint:
     min-confidence: 0
   misspell:


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Updates the golangci-lint configuration to silence an errcheck linter warning.

#### Which issue(s) this PR fixes:

Fixes #2801

#### Special notes for your reviewer:

See golangci/golangci-lint#4733

