### PR TITLE
Add option to load perf dash metrics from local artifacts directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ clusterloader2/clusterloader
 
 # Vscode files
 .vscode
+*.code-workspace
 
 # GoLand files
 .idea

--- a/perfdash/.gitignore
+++ b/perfdash/.gitignore
@@ -1,1 +1,2 @@
 perfdash
+*.code-workspace

--- a/perfdash/Makefile
+++ b/perfdash/Makefile
@@ -5,12 +5,14 @@ TAG?=2.48
 
 REPO?=gcr.io/k8s-staging-perf-tests
 
-test: perfdash.go parser.go config.go metrics-downloader-helper.go metrics-downloader.go gcs_metrics_bucket.go s3_metrics_bucket.go
+.PHONY: test
+test: perfdash.go parser.go config.go metrics-downloader-helper.go metrics-downloader.go gcs_metrics_bucket.go s3_metrics_bucket.go local_metrics_dir.go
 	go test
 
 perfdash: test
 	go build -a -installsuffix cgo -ldflags '-w' -o perfdash
 
+.PHONY: run
 run: perfdash
 	./perfdash \
 		--www \
@@ -20,11 +22,14 @@ run: perfdash
 		--githubConfigDir=https://api.github.com/repos/kubernetes/perf-tests/contents/perfdash/test
 
 # Use buildkit to have "COPY --chmod=" support (availability of it in "regular" docker build depends on docker version).
+.PHONY: container
 container:
 	DOCKER_BUILDKIT=1 docker build --pull -t $(REPO)/perfdash:$(TAG) .
 
+.PHONY: push
 push: container
 	gcloud docker -s $(REPO) -- push $(REPO)/perfdash:$(TAG)
 
+.PHONY: clean
 clean:
 	rm -f perfdash

--- a/perfdash/local_metrics_dir.go
+++ b/perfdash/local_metrics_dir.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strconv"
+)
+
+// LocalMetricsDirectory prepares a client to fetch metrics data from a local directory.
+// This is meant to be used for testing and development to load results from the report-dir output of clusterloader2.
+type LocalMetricsDirectory struct {
+	dirPath string
+}
+
+const filePathSeparator = string(os.PathSeparator)
+
+// NewLocalMetricsDir creates a new LocalMetricsDirectory.
+func NewLocalMetricsDir(pathPrefix string) (MetricsBucket, error) {
+	absPath, err := filepath.Abs(pathPrefix)
+	if err != nil {
+		return nil, err
+	}
+
+	return &LocalMetricsDirectory{
+		dirPath: absPath,
+	}, nil
+}
+
+// GetBuildNumbers fetches the build numbers from a local artifacts directory.
+func (b *LocalMetricsDirectory) GetBuildNumbers(job string) ([]int, error) {
+	filePath := b.dirPath + filePathSeparator + job
+	files, err := os.ReadDir(filePath)
+	if err != nil {
+		return nil, err
+	}
+
+	var builds []int
+	for _, file := range files {
+		if file.IsDir() {
+			build, err := strconv.Atoi(file.Name())
+			if err != nil {
+				return nil, err
+			}
+
+			builds = append(builds, build)
+		}
+	}
+
+	return builds, nil
+}
+
+// ListFilesInBuild recursively fetches the files in the build from a local artifacts directory.
+// Note: artifacts are expected to be in dirPath such in the format of dirPath/job/buildNumber.
+// For example, it could be in artifacts/my-job/1234567890/aritfacts.
+func (b *LocalMetricsDirectory) ListFilesInBuild(job string, buildNumber int, prefix string) ([]string, error) {
+	filePath := joinStringsAndInts(b.dirPath, filePathSeparator, job, filePathSeparator, buildNumber, prefix)
+
+	files := []string{}
+	walkFn := func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() {
+			files = append(files, path)
+		}
+
+		return nil
+	}
+
+	err := filepath.WalkDir(filePath, walkFn)
+	if err != nil {
+		return nil, err
+	}
+
+	return files, nil
+}
+
+func (b *LocalMetricsDirectory) GetFilePrefix(job string, buildNumber int, prefix string) string {
+	p := joinStringsAndInts(b.dirPath, filePathSeparator, job, filePathSeparator, buildNumber, prefix)
+	return p
+}
+
+// ReadFile reads the file contents from a local artifacts directory.
+func (b *LocalMetricsDirectory) ReadFile(job string, buildNumber int, path string) ([]byte, error) {
+	filePath := joinStringsAndInts(b.dirPath, filePathSeparator, job, filePathSeparator, buildNumber, path)
+
+	return os.ReadFile(filePath)
+}

--- a/perfdash/metrics-downloader.go
+++ b/perfdash/metrics-downloader.go
@@ -121,6 +121,7 @@ func (a *artifactsCache) getMatchingFiles(job string, buildNumber int, prefix st
 	if !ok {
 		return nil, fmt.Errorf("couldn't get list of files from cache")
 	}
+
 	matchedFiles := []string{}
 	for _, file := range val {
 		if strings.HasPrefix(file, searchPrefix) {

--- a/perfdash/perfdash.go
+++ b/perfdash/perfdash.go
@@ -32,8 +32,9 @@ const (
 	errorDelay   = 10 * time.Second
 	maxBuilds    = 100
 
-	s3Mode  = "s3"
-	gcsMode = "gcs"
+	s3Mode       = "s3"
+	gcsMode      = "gcs"
+	localDirMode = "local"
 )
 
 var options = &DownloaderOptions{}
@@ -98,6 +99,8 @@ func run() error {
 		metricsBucket, err = NewGCSMetricsBucket(*logsBucket, *logsPath, *credentialPath, *useADC)
 	case s3Mode:
 		metricsBucket, err = NewS3MetricsBucket(*logsBucket, *logsPath, *awsRegion)
+	case localDirMode:
+		metricsBucket, err = NewLocalMetricsDir(*logsPath)
 	default:
 		return fmt.Errorf("unexpected mode: %s", options.Mode)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it: 
This adds an additional metrics bucket type called `local` which allows users to load perf dash metrics from a local directory, specifically the output from running `clusterloader2` with the `--reportdir` flag set. This is primarily used for development purposes so perf dash is usable with job data that is not hosted on prow.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

