### PR TITLE
Fix image parametrization in load config

### DIFF
--- a/clusterloader2/testing/load/deployment.yaml
+++ b/clusterloader2/testing/load/deployment.yaml
@@ -74,7 +74,7 @@ spec:
         ports:
         - containerPort: 80
   {{else}}
-      - image: {{.Image}}
+      - image: {{$Image}}
         name: {{.Name}}
   {{end}}
 {{end}}

--- a/clusterloader2/testing/load/job.yaml
+++ b/clusterloader2/testing/load/job.yaml
@@ -26,7 +26,7 @@ spec:
       containers:
       - name: {{.Name}}
         # TODO(#799): We should test the "run-to-completion" workflow and hence don't use pause pods.
-        image: {{.Image}}
+        image: {{$Image}}
         resources:
           # Keep the CpuRequest/MemoryRequest request equal percentage of 1-core, 4GB node.
           # For now we're setting it to 0.5%.

--- a/clusterloader2/testing/load/statefulset.yaml
+++ b/clusterloader2/testing/load/statefulset.yaml
@@ -26,7 +26,7 @@ spec:
       hostNetwork: {{$HostNetworkMode}}
       containers:
       - name: {{.Name}}
-        image: {{.Image}}
+        image: {{$Image}}
         ports:
           - containerPort: 80
             name: web


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

A previous change https://github.com/kubernetes/perf-tests/pull/2803 introduced a variable parametrizing the image with fallback to a default value, but instead used the variable that does not have a fallback. This can cause the tests to fail.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
None that I know of

#### Special notes for your reviewer:

