### PR TITLE
Label dependabot PRs as ok-to-test by default

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,115 +4,202 @@ updates:
   directory: /util-images/network/netperfbenchmark
   schedule:
     interval: weekly
+  labels:
+    - "ok-to-test"
+    - "kind/cleanup"
 - package-ecosystem: docker
   directory: /network/tools/network-policy-enforcement-latency/policy-creation-enforcement-latency
   schedule:
     interval: weekly
+  labels:
+    - "ok-to-test"
+    - "kind/cleanup"
 - package-ecosystem: docker
   directory: /util-images/request-benchmark
   schedule:
     interval: weekly
+  labels:
+    - "ok-to-test"
+    - "kind/cleanup"
 - package-ecosystem: docker
   directory: /util-images/access-tokens
   schedule:
     interval: weekly
+  labels:
+    - "ok-to-test"
+    - "kind/cleanup"
 - package-ecosystem: docker
   directory: /util-images/probes
   schedule:
     interval: weekly
+  labels:
+    - "ok-to-test"
+    - "kind/cleanup"
 - package-ecosystem: docker
   directory: /util-images/scratch
   schedule:
     interval: weekly
+  labels:
+    - "ok-to-test"
+    - "kind/cleanup"
 - package-ecosystem: docker
   directory: /network/tools/network-policy-enforcement-latency/pod-creation-reachability-latency
   schedule:
     interval: weekly
+  labels:
+    - "ok-to-test"
+    - "kind/cleanup"
 - package-ecosystem: docker
   directory: /util-images/watch-list
   schedule:
     interval: weekly
+  labels:
+    - "ok-to-test"
+    - "kind/cleanup"
 - package-ecosystem: docker
   directory: /dns/dnsperfgo
   schedule:
     interval: weekly
+  labels:
+    - "ok-to-test"
+    - "kind/cleanup"
 - package-ecosystem: docker
   directory: /dns/dnsperfgo/vendor/golang.org/x/net/http2
   schedule:
     interval: weekly
+  labels:
+    - "ok-to-test"
+    - "kind/cleanup"
 - package-ecosystem: docker
   directory: /dns/image
   schedule:
     interval: weekly
+  labels:
+    - "ok-to-test"
+    - "kind/cleanup"
 - package-ecosystem: docker
   directory: /perfdash
   schedule:
     interval: weekly
+  labels:
+    - "ok-to-test"
+    - "kind/cleanup"
 - package-ecosystem: docker
   directory: /slo-monitor
   schedule:
     interval: weekly
+  labels:
+    - "ok-to-test"
+    - "kind/cleanup"
 - package-ecosystem: docker
   directory: /util-images/sleep
   schedule:
     interval: weekly
+  labels:
+    - "ok-to-test"
+    - "kind/cleanup"
 - package-ecosystem: docker
   directory: /util-images/containerd
   schedule:
     interval: weekly
+  labels:
+    - "ok-to-test"
+    - "kind/cleanup"
 - package-ecosystem: docker
   directory: /network/benchmarks/netperf
   schedule:
     interval: weekly
+  labels:
+    - "ok-to-test"
+    - "kind/cleanup"
 - package-ecosystem: gomod
   directory: /util-images/network/netperfbenchmark
   schedule:
     interval: weekly
+  labels:
+    - "ok-to-test"
+    - "kind/cleanup"
 - package-ecosystem: gomod
   directory: /util-images/access-tokens
   schedule:
     interval: weekly
+  labels:
+    - "ok-to-test"
+    - "kind/cleanup"
 - package-ecosystem: gomod
   directory: /util-images/request-benchmark
   schedule:
     interval: weekly
+  labels:
+    - "ok-to-test"
+    - "kind/cleanup"
 - package-ecosystem: gomod
   directory: /util-images/probes
   schedule:
     interval: weekly
+  labels:
+    - "ok-to-test"
+    - "kind/cleanup"
 - package-ecosystem: gomod
   directory: /dns/jsonify
   schedule:
     interval: weekly
+  labels:
+    - "ok-to-test"
+    - "kind/cleanup"
 - package-ecosystem: gomod
   directory: /clusterloader2
   schedule:
     interval: weekly
+  labels:
+    - "ok-to-test"
+    - "kind/cleanup"
 - package-ecosystem: gomod
   directory: /dns/dnsperfgo
   schedule:
     interval: weekly
+  labels:
+    - "ok-to-test"
+    - "kind/cleanup"
 - package-ecosystem: gomod
   directory: /util-images/watch-list
   schedule:
     interval: weekly
+  labels:
+    - "ok-to-test"
+    - "kind/cleanup"
 - package-ecosystem: gomod
   directory: /perfdash
   schedule:
     interval: weekly
+  labels:
+    - "ok-to-test"
+    - "kind/cleanup"
 - package-ecosystem: gomod
   directory: /network/tools/network-policy-enforcement-latency
   schedule:
     interval: weekly
+  labels:
+    - "ok-to-test"
+    - "kind/cleanup"
 - package-ecosystem: gomod
   directory: /benchmark
   schedule:
     interval: weekly
+  labels:
+    - "ok-to-test"
+    - "kind/cleanup"
 - package-ecosystem: gomod
   directory: /slo-monitor
   schedule:
     interval: weekly
+  labels:
+    - "ok-to-test"
+    - "kind/cleanup"
 - package-ecosystem: gomod
   directory: /network/benchmarks/netperf
   schedule:
     interval: weekly
+  labels:
+    - "ok-to-test"
+    - "kind/cleanup"


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Updates the configuration so any PRs opened by dependabot have the `ok-to-test` and `kind/cleanup` labels by default. This has saved maintainers some time in Cluster API projects, maybe it would be useful here too.

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

Sorry for all the repetition. As best I can tell, there isn't a way to set labels globally in [dependabot.yml](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#labels).
