### PR TITLE
Bump version of go compiler that bootstraps golang tip test to 1.23.0

### DIFF
--- a/golang/Makefile
+++ b/golang/Makefile
@@ -15,7 +15,7 @@
 .PHONY: build-go build push
 
 export GCS_BUCKET?=k8s-infra-scale-golang-builds
-export GO_COMPILER_PKG?=go1.22.0.linux-amd64.tar.gz
+export GO_COMPILER_PKG?=go1.23.0.linux-amd64.tar.gz
 export GO_COMPILER_URL?=https://dl.google.com/go/$(GO_COMPILER_PKG)
 export ROOT_DIR?=/home/prow/go/src
 


### PR DESCRIPTION
This should fix https://testgrid.k8s.io/sig-scalability-golang#build-and-push-k8s-at-golang-tip .

Example failure: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-build-and-push-k8s-at-golang-tip/1833601955637760000

(FTR: the PR is based on https://github.com/kubernetes/perf-tests/pull/2542 )

/assign @mborsz