### PR TITLE
CL2: Add refreshInterval param to WaitForNodes and WaitForRunningPods measurements

### DIFF
--- a/clusterloader2/pkg/measurement/common/wait_for_nodes.go
+++ b/clusterloader2/pkg/measurement/common/wait_for_nodes.go
@@ -61,6 +61,12 @@ func (w *waitForNodesMeasurement) Execute(config *measurement.Config) ([]measure
 	if err != nil {
 		return nil, err
 	}
+
+	refreshInterval, err := util.GetDurationOrDefault(config.Params, "refreshInterval", defaultWaitForNodesInterval)
+	if err != nil {
+		return nil, err
+	}
+
 	stopCh := make(chan struct{})
 	time.AfterFunc(timeout, func() {
 		close(stopCh)
@@ -71,7 +77,7 @@ func (w *waitForNodesMeasurement) Execute(config *measurement.Config) ([]measure
 		MinDesiredNodeCount:  minNodeCount,
 		MaxDesiredNodeCount:  maxNodeCount,
 		CallerName:           w.String(),
-		WaitForNodesInterval: defaultWaitForNodesInterval,
+		WaitForNodesInterval: refreshInterval,
 	}
 	return nil, measurementutil.WaitForNodes(config.ClusterFramework.GetClientSets().GetClient(), stopCh, options)
 }

--- a/clusterloader2/pkg/measurement/common/wait_for_pods.go
+++ b/clusterloader2/pkg/measurement/common/wait_for_pods.go
@@ -60,13 +60,17 @@ func (w *waitForRunningPodsMeasurement) Execute(config *measurement.Config) ([]m
 	if err != nil {
 		return nil, err
 	}
+	refreshInterval, err := util.GetDurationOrDefault(config.Params, "refreshInterval", defaultWaitForPodsInterval)
+	if err != nil {
+		return nil, err
+	}
 
 	ctx, cancel := context.WithTimeout(context.TODO(), timeout)
 	defer cancel()
 	options := &measurementutil.WaitForPodOptions{
 		DesiredPodCount:     func() int { return desiredPodCount },
 		CallerName:          w.String(),
-		WaitForPodsInterval: defaultWaitForPodsInterval,
+		WaitForPodsInterval: refreshInterval,
 	}
 	podStore, err := measurementutil.NewPodStore(config.ClusterFramework.GetClientSets().GetClient(), selector)
 	if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR introduces a new param called `refreshInterval` to `WaitForNodes` and `WaitForRunningPods` measurements. The current value of refresh interval in both measurements are currently fixed. However, for test that includes a small number of nodes, 30 seconds for refreshing is too long, which can lead to inaccurate result (5 nodes that usually take 10 - 15 seconds to get ready almost always end up being reported as taking 30 seconds due to the fixed interval). At the same time, for test that includes a large number of pods and numbers, 5 seconds for pod's refresh interval might be too frequent.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

