### PR TITLE
Use `krel push` instead of the legacy push-build.sh

### DIFF
--- a/golang/push.sh
+++ b/golang/push.sh
@@ -17,5 +17,5 @@
 set -euxo pipefail
 
 # Push Kubernetes build to GCS.
-cd $ROOT_DIR/k8s.io/kubernetes
-../release/push-build.sh --nomock --ci --bucket=$GCS_BUCKET --private-bucket
+cd "$ROOT_DIR/k8s.io/release"
+go run ./cmd/krel push --repo-root "$ROOT_DIR/k8s.io/kubernetes" --nomock --ci --bucket="$GCS_BUCKET" --private-bucket


### PR DESCRIPTION


#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
The script has been deprecated for a while and we should stick to use krel only.

cc @kubernetes/release-managers 
#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:

Requires https://github.com/kubernetes/release/pull/3768

/hold