### PR TITLE
Update kube-state-metrics manifests to the latest release

### DIFF
--- a/clusterloader2/pkg/prometheus/manifests/exporters/kube-state-metrics/clusterRole.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/exporters/kube-state-metrics/clusterRole.yaml
@@ -2,8 +2,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
+    app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kube-state-metrics
-    app.kubernetes.io/version: 2.0.0-rc.0
+    app.kubernetes.io/version: 2.13.0
   name: kube-state-metrics
 rules:
 - apiGroups:
@@ -14,6 +15,7 @@ rules:
   - nodes
   - pods
   - services
+  - serviceaccounts
   - resourcequotas
   - replicationcontrollers
   - limitranges
@@ -76,6 +78,13 @@ rules:
   - list
   - watch
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - list
+  - watch
+- apiGroups:
   - storage.k8s.io
   resources:
   - storageclasses
@@ -95,6 +104,7 @@ rules:
   - networking.k8s.io
   resources:
   - networkpolicies
+  - ingressclasses
   - ingresses
   verbs:
   - list
@@ -103,6 +113,16 @@ rules:
   - coordination.k8s.io
   resources:
   - leases
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  - clusterroles
+  - rolebindings
+  - roles
   verbs:
   - list
   - watch

--- a/clusterloader2/pkg/prometheus/manifests/exporters/kube-state-metrics/clusterRoleBinding.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/exporters/kube-state-metrics/clusterRoleBinding.yaml
@@ -2,8 +2,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
+    app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kube-state-metrics
-    app.kubernetes.io/version: 2.0.0-rc.0
+    app.kubernetes.io/version: 2.13.0
   name: kube-state-metrics
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/clusterloader2/pkg/prometheus/manifests/exporters/kube-state-metrics/deployment.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/exporters/kube-state-metrics/deployment.yaml
@@ -2,8 +2,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
+    app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kube-state-metrics
-    app.kubernetes.io/version: 2.0.0-rc.0
+    app.kubernetes.io/version: 2.13.0
   name: kube-state-metrics
   namespace: kube-state-metrics-perf-test
 spec:
@@ -14,15 +15,17 @@ spec:
   template:
     metadata:
       labels:
+        app.kubernetes.io/component: exporter
         app.kubernetes.io/name: kube-state-metrics
-        app.kubernetes.io/version: 2.0.0-rc.0
+        app.kubernetes.io/version: 2.13.0
     spec:
+      automountServiceAccountToken: true
       containers:
-      - image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.0.0-rc.0
+      - image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.13.0
         livenessProbe:
           httpGet:
-            path: /healthz
-            port: 8080
+            path: /livez
+            port: http-metrics
           initialDelaySeconds: 5
           timeoutSeconds: 5
         name: kube-state-metrics
@@ -42,12 +45,20 @@ spec:
           name: telemetry
         readinessProbe:
           httpGet:
-            path: /
-            port: 8081
+            path: /readyz
+            port: telemetry
           initialDelaySeconds: 5
           timeoutSeconds: 5
         securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
           runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
       nodeSelector:
         kubernetes.io/os: linux
       serviceAccountName: kube-state-metrics

--- a/clusterloader2/pkg/prometheus/manifests/exporters/kube-state-metrics/service.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/exporters/kube-state-metrics/service.yaml
@@ -2,8 +2,9 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
+    app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kube-state-metrics
-    app.kubernetes.io/version: 2.0.0-rc.0
+    app.kubernetes.io/version: 2.13.0
   name: kube-state-metrics
   namespace: kube-state-metrics-perf-test
 spec:

--- a/clusterloader2/pkg/prometheus/manifests/exporters/kube-state-metrics/serviceAccount.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/exporters/kube-state-metrics/serviceAccount.yaml
@@ -1,8 +1,10 @@
 apiVersion: v1
+automountServiceAccountToken: false
 kind: ServiceAccount
 metadata:
   labels:
+    app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kube-state-metrics
-    app.kubernetes.io/version: 2.0.0-rc.0
+    app.kubernetes.io/version: 2.13.0
   name: kube-state-metrics
   namespace: kube-state-metrics-perf-test

--- a/clusterloader2/pkg/prometheus/manifests/exporters/kube-state-metrics/serviceMonitor.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/exporters/kube-state-metrics/serviceMonitor.yaml
@@ -3,7 +3,7 @@ kind: ServiceMonitor
 metadata:
   labels:
     app.kubernetes.io/name: kube-state-metrics
-    app.kubernetes.io/version: 2.0.0-rc.0
+    app.kubernetes.io/version: 2.13.0
   name: kube-state-metrics
   namespace: kube-state-metrics-perf-test
 spec:
@@ -18,4 +18,4 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: kube-state-metrics
-      app.kubernetes.io/version: 2.0.0-rc.0
+      app.kubernetes.io/version: 2.13.0


### PR DESCRIPTION
A PR was submitted to kube-state-metrics that should greatly improve performances and I'd like to update our perf tests to check it out.

Most of the manifests changes are copied from https://github.com/kubernetes/kube-state-metrics/tree/main/examples/standard