### PR TITLE
Change perf-dash logs bucket to kubernetes-ci-logs

### DIFF
--- a/perfdash/config.go
+++ b/perfdash/config.go
@@ -514,9 +514,10 @@ var (
 				Parser:           parsePerfData,
 			}},
 			"BenchmarkPerfResults": []TestDescription{{
-				Name:             "benchmark",
-				OutputFilePrefix: "BenchmarkPerfScheduling",
-				Parser:           parsePerfData,
+				Name:                        "benchmark",
+				OutputFilePrefix:            "BenchmarkPerfScheduling",
+				Parser:                      parsePerfData,
+				FetchMetricNameFromArtifact: true,
 			}},
 		},
 	}

--- a/perfdash/perfdash.go
+++ b/perfdash/perfdash.go
@@ -49,7 +49,7 @@ var (
 	globalConfig = make(map[string]string)
 
 	// Storage Service Bucket and Path flags
-	logsBucket = pflag.String("logsBucket", "kubernetes-jenkins", "Name of the data bucket")
+	logsBucket = pflag.String("logsBucket", "kubernetes-ci-logs", "Name of the data bucket")
 	logsPath   = pflag.String("logsPath", "logs", "Path to the logs inside the logs bucket")
 
 	// Google GCS Specific flags


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

Perf-dash should use `kubernetes-ci-logs` logs bucket, because perf jobs are not running in `kubernetes-jenkins` anymore. 
https://github.com/kubernetes/test-infra/issues/33381

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

