### PR TITLE
watchlist: decrease the number of informers to 6 to confirm no impact on latency

### DIFF
--- a/clusterloader2/testing/watch-list/config.yaml
+++ b/clusterloader2/testing/watch-list/config.yaml
@@ -42,7 +42,8 @@ steps:
         min: 1
         max: 1
         basename: watch-list
-      replicasPerNamespace: 2
+      # TODO(p0lyn0mial): bring back 2 replicas
+      replicasPerNamespace: 1
       tuningSet: Uniform10qps
       objectBundle:
         - basename: watch-list-secret

--- a/clusterloader2/testing/watch-list/job.yaml
+++ b/clusterloader2/testing/watch-list/job.yaml
@@ -21,5 +21,6 @@ spec:
               memory: "16Gi"
               cpu: "6"
           command: [ "watch-list" ]
-          args: [ "--alsologtostderr=true", "--v=4", "--timeout={{.Duration}}", "--count=16", "--namespace=watch-list-1", "--enableWatchListFeature={{.EnableWatchListFeature}}"]
+          # TODO(p0lyn0mial): bring back 16 informers
+          args: [ "--alsologtostderr=true", "--v=4", "--timeout={{.Duration}}", "--count=6", "--namespace=watch-list-1", "--enableWatchListFeature={{.EnableWatchListFeature}}"]
       restartPolicy: Never


### PR DESCRIPTION
`watchlist-off` [perf test](https://perf-dash.k8s.io/#/?jobname=watch-list-off&metriccategoryname=APIServer&metricname=LoadResponsiveness_PrometheusSimple&Resource=secrets&Scope=namespace&Subresource=&Verb=LIST) reports unexpectedly high LIST latency.

It looks like the main suspect is egress throughput. This PR reduces the amount of informers, which, in turn, reduces the amount of downloaded data, resulting in improved latency.