### PR TITLE
clusterloader2: Add missing templated var for prometheus apiserver port in master-ip service

### DIFF
--- a/clusterloader2/pkg/prometheus/manifests/master-ip/master-service.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/master-ip/master-service.yaml
@@ -1,5 +1,6 @@
 {{$PROMETHEUS_SCRAPE_NODE_EXPORTER := DefaultParam .PROMETHEUS_SCRAPE_NODE_EXPORTER false}}
 {{$PROMETHEUS_SCRAPE_APISERVER_ONLY := DefaultParam .PROMETHEUS_SCRAPE_APISERVER_ONLY false}}
+{{$PROMETHEUS_APISERVER_SCRAPE_PORT := DefaultParam .PROMETHEUS_APISERVER_SCRAPE_PORT 443}}
 
 # Service object for the kubelet running on master node.
 apiVersion: v1
@@ -14,7 +15,7 @@ spec:
   clusterIP: None
   ports:
     - name: apiserver
-      port: 443
+      port: {{$PROMETHEUS_APISERVER_SCRAPE_PORT}}
     {{if not $PROMETHEUS_SCRAPE_APISERVER_ONLY}}
     - name: etcd-2379
       port: 2379

--- a/clusterloader2/pkg/prometheus/manifests/master-ip/master-serviceMonitor.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/master-ip/master-serviceMonitor.yaml
@@ -62,4 +62,5 @@ spec:
     tlsConfig:
       insecureSkipVerify: true
   selector:
-    k8s-app: master
+    matchLabels:
+      k8s-app: master


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When using an alternative port for the API server, the master-ip service template is not using the `PROMETHEUS_APISERVER_SCRAPE_PORT` set by the `--prometheus-apiserver-scrape-port` flag and defaults to 443.

This PR mirrors the behaviour seen in `master-endpoints.yaml` into `master-service.yaml` and fixes the ` Waiting for Prometheus stack to become healthy...` step:

```
util.go:101] 7/9 targets are ready, example not ready target: {map[endpoint:apiserver instance:172.18.0.2:443 job:master namespace:monitoring service:master] down}
```

I've also noticed an error in the ServiceMonitor template where the label selector was missing `matchLabels:` and added a commit to fix.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

None
