### PR TITLE
Don't overwrite ResourceUsageSummary output for different namespaces

### DIFF
--- a/clusterloader2/pkg/measurement/common/resource_usage.go
+++ b/clusterloader2/pkg/measurement/common/resource_usage.go
@@ -69,14 +69,15 @@ func (e *resourceUsageMetricMeasurement) Execute(config *measurement.Config) ([]
 		return nil, err
 	}
 
+	namespace, err := util.GetStringOrDefault(config.Params, "namespace", "kube-system")
+	if err != nil {
+		return nil, err
+	}
+
 	switch action {
 	case "start":
 		provider := config.ClusterFramework.GetClusterConfig().Provider
 		host, err := util.GetStringOrDefault(config.Params, "host", config.ClusterFramework.GetClusterConfig().GetMasterIP())
-		if err != nil {
-			return nil, err
-		}
-		namespace, err := util.GetStringOrDefault(config.Params, "namespace", "kube-system")
 		if err != nil {
 			return nil, err
 		}
@@ -134,7 +135,8 @@ func (e *resourceUsageMetricMeasurement) Execute(config *measurement.Config) ([]
 		if err != nil {
 			return nil, err
 		}
-		resourceSummary := measurement.CreateSummary(resourceUsageMetricName, "json", content)
+		name := fmt.Sprintf("%s-%s", resourceUsageMetricName, namespace)
+		resourceSummary := measurement.CreateSummary(name, "json", content)
 		return []measurement.Summary{resourceSummary}, e.verifySummary(summary)
 
 	default:


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The `ResourceUsageSummary` measurement implementation does not take into account the namespace when creating output files, which can lead to files being overwritten if multiple measurements are used for different namespaces.

This PR adds the namespace to the output filename to avoid collisions.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

None
