### PR TITLE
clusterloader2: Avoid logging and awaiting waitgroup when chaosmonkey is disabled

### DIFF
--- a/clusterloader2/pkg/test/simple_test_executor.go
+++ b/clusterloader2/pkg/test/simple_test_executor.go
@@ -99,7 +99,10 @@ func (ste *simpleExecutor) ExecuteTest(ctx Context, conf *api.Config) *errors.Er
 			}
 		}
 	}
-	klog.V(2).Infof(ctx.GetChaosMonkey().Summary())
+	summary := ctx.GetChaosMonkey().Summary()
+	if summary != "" {
+		klog.V(2).Info(summary)
+	}
 	return errList
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Not really a bug but I noticed that the waitgroup returned from chaosMonkey.Init() is always non-nil and therefore we always log and await the waitgroup, which can be confusing when chaosmonkey nodekiller is disabled. I also updated to avoid emitting an empty log statement when the summary is empty.

```
I1219 14:48:15.653932   23514 simple_test_executor.go:80] Waiting for the chaos monkey subroutine to end...
I1219 14:48:15.653947   23514 simple_test_executor.go:82] Chaos monkey ended.
I1219 14:48:15.657172   23514 simple_test_executor.go:102] 
```

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

None