### PR TITLE
Cleanup klog in clusterloader

### DIFF
--- a/clusterloader2/go.mod
+++ b/clusterloader2/go.mod
@@ -59,7 +59,6 @@ require (
 	k8s.io/component-base v0.29.7
 	k8s.io/component-helpers v0.29.7
 	k8s.io/gengo v0.0.0-20230829151522-9cce18d56c01
-	k8s.io/klog v1.0.0
 	k8s.io/klog/v2 v2.130.1
 	k8s.io/kubelet v0.29.7
 	k8s.io/kubernetes v1.29.7

--- a/clusterloader2/go.sum
+++ b/clusterloader2/go.sum
@@ -2564,7 +2564,6 @@ k8s.io/controller-manager v0.29.7 h1:8FC9kQAm+BUTrAKyCS2uOaTXBytV3eEOIREfrFxaCjo
 k8s.io/controller-manager v0.29.7/go.mod h1:lAua8GONLnkPAHPSzU0POmvHLhsKeHbjHnVtEQPfUno=
 k8s.io/gengo v0.0.0-20230829151522-9cce18d56c01 h1:pWEwq4Asjm4vjW7vcsmijwBhOr1/shsbSYiWXmNGlks=
 k8s.io/gengo v0.0.0-20230829151522-9cce18d56c01/go.mod h1:FiNAH4ZV3gBg2Kwh89tzAEV2be7d5xI0vBa/VySYy3E=
-k8s.io/klog v1.0.0 h1:Pt+yjF5aB1xDSVbau4VsWe+dQNzA0qv1LlXdC2dF6Q8=
 k8s.io/klog v1.0.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
 k8s.io/klog/v2 v2.0.0/go.mod h1:PBfzABfn139FHAV07az/IF9Wp1bkk3vpT2XSJ76fSDE=
 k8s.io/klog/v2 v2.2.0/go.mod h1:Od+F08eJP+W3HUb4pSrPpgp9DGU4GzlpG/TmITuYh/Y=

--- a/clusterloader2/pkg/measurement/common/slos/api_responsiveness_prometheus_test.go
+++ b/clusterloader2/pkg/measurement/common/slos/api_responsiveness_prometheus_test.go
@@ -19,7 +19,6 @@ package slos
 import (
 	"bytes"
 	"encoding/json"
-	"flag"
 	"fmt"
 	"strings"
 	"testing"
@@ -32,34 +31,12 @@ import (
 	"k8s.io/perf-tests/clusterloader2/pkg/measurement"
 	"k8s.io/perf-tests/clusterloader2/pkg/measurement/common/executors"
 	measurementutil "k8s.io/perf-tests/clusterloader2/pkg/measurement/util"
-
-	_ "k8s.io/perf-tests/clusterloader2/pkg/flags" // init klog
 )
 
-var (
-	// klogv1 allows users to turn on/off logging to stderr only through
-	// the use of flag. This prevents us from having control over which
-	// of the test functions have that mechanism turned off when we run
-	// go test command.
-	// TODO(#1286): refactor api_responsiveness_prometheus.go to make
-	// testing of logging easier and remove this hack in the end.
-	klogLogToStderr = true
-)
-
-func turnOffLoggingToStderrInKlog(t *testing.T) {
-	if klogLogToStderr {
-		err := flag.Set("logtostderr", "false")
-		if err != nil {
-			t.Errorf("Unable to set flag %v", err)
-			return
-		}
-		err = flag.Set("v", "2")
-		if err != nil {
-			t.Errorf("Unable to set flag %v", err)
-			return
-		}
-		flag.Parse()
-		klogLogToStderr = false
+func changeLoggingVerbosity(t *testing.T, logLevel string) {
+	var level klog.Level
+	if err := level.Set(logLevel); err != nil {
+		t.Errorf("Unable to set flag %v", err)
 	}
 }
 
@@ -574,7 +551,9 @@ func TestLogging(t *testing.T) {
 		},
 	}
 
-	turnOffLoggingToStderrInKlog(t)
+	klog.LogToStderr(false)
+	defer klog.LogToStderr(true)
+	changeLoggingVerbosity(t, "2")
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -763,7 +742,9 @@ func TestAPIResponsivenessCustomThresholds(t *testing.T) {
 		},
 	}
 
-	turnOffLoggingToStderrInKlog(t)
+	klog.LogToStderr(false)
+	defer klog.LogToStderr(true)
+	changeLoggingVerbosity(t, "2")
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/clusterloader2/pkg/measurement/util/informer/informer.go
+++ b/clusterloader2/pkg/measurement/util/informer/informer.go
@@ -25,7 +25,7 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/dynamic/dynamicinformer"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 	"k8s.io/perf-tests/clusterloader2/pkg/util"
 )
 

--- a/clusterloader2/pkg/prometheus/clients/aks_managed.go
+++ b/clusterloader2/pkg/prometheus/clients/aks_managed.go
@@ -20,14 +20,14 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"k8s.io/klog"
 	"net/http"
-
 	"os"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+
+	"k8s.io/klog/v2"
 )
 
 const (


### PR DESCRIPTION
Brings back part of https://github.com/kubernetes/perf-tests/pull/3050 that was reverted.

Verified that the error reported in https://github.com/kubernetes/perf-tests/pull/3075 was not caused by this part.