### PR TITLE
Update ClusterLoader2's temp KubeConfig PKI for ServiceAccount

### DIFF
--- a/clusterloader2/run-e2e.sh
+++ b/clusterloader2/run-e2e.sh
@@ -88,26 +88,13 @@ cluster_loader_crb_exists=$(kubectl --kubeconfig "${KUBECONFIG}" get clusterrole
 if [[ "$cluster_loader_crb_exists" -eq 0 ]]; then
 	kubectl --kubeconfig "${KUBECONFIG}" create clusterrolebinding cluster-loader --clusterrole=cluster-admin --serviceaccount=default:cluster-loader
 fi
-cluster_loader_secret_exists=$(kubectl --kubeconfig "${KUBECONFIG}" get secret cluster-loader --ignore-not-found | wc -l)
-if [[ "$cluster_loader_secret_exists" -eq 0 ]]; then
-   cat << EOF | kubectl --kubeconfig "${KUBECONFIG}" create -f -
-apiVersion: v1
-kind: Secret
-metadata:
-  name: cluster-loader
-  namespace: default
-  annotations:
-    kubernetes.io/service-account.name: cluster-loader
-type: kubernetes.io/service-account-token
-EOF
-fi
 
 
 # Create a kubeconfig to use the above service account.
 kubeconfig=$(mktemp)
 server=$(kubectl --kubeconfig "${KUBECONFIG}" config view -o jsonpath='{.clusters[0].cluster.server}')
-ca=$(kubectl --kubeconfig "${KUBECONFIG}" get secret cluster-loader -o jsonpath='{.data.ca\.crt}')
-token=$(kubectl --kubeconfig "${KUBECONFIG}" get secret cluster-loader -o jsonpath='{.data.token}' | base64 --decode)
+ca=$(kubectl --kubeconfig "${KUBECONFIG}" get configmap kube-root-ca.crt -o jsonpath='{.data.ca\.crt}' | base64 -w 0)
+token=$(kubectl --kubeconfig "${KUBECONFIG}" --duration=8760h create token cluster-loader)
 echo "
 apiVersion: v1
 kind: Config


### PR DESCRIPTION
Populating a ServiceAccount's Secret with CA and JWT data is a legacy flow [replaced in 1.24+](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.24.md#urgent-upgrade-notes) with the `kube-root-ca.crt ConfigMap` and `token` resources.  Public documentation now encourages using `tokens` instead: https://kubernetes.io/docs/reference/access-authn-authz/service-accounts-admin/#manual-secret-management-for-serviceaccounts

#### What type of PR is this?
/kind bug
/kind deprecation

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Clusters using GKE's [CPA](https://cloud.google.com/kubernetes-engine/docs/concepts/about-control-plane-authority) (and many other modern clusters) no longer populate a SA's secret with CA and token information. 

#### Special notes for your reviewer:

