### PR TITLE
fix kubemark.go logical error

### DIFF
--- a/clusterloader2/pkg/measurement/util/kubemark/kubemark.go
+++ b/clusterloader2/pkg/measurement/util/kubemark/kubemark.go
@@ -56,7 +56,7 @@ func GetKubemarkMasterComponentsResourceUsage(host string, provider provider.Pro
 		var cpu float64
 		var mem uint64
 		var name string
-		if _, err := fmt.Sscanf(strings.TrimSpace(scanner.Text()), "%f %d /usr/local/bin/kube-%s", &cpu, &mem, &name); err == nil {
+		if _, err := fmt.Sscanf(strings.TrimSpace(scanner.Text()), "%f %d /usr/local/bin/kube-%s", &cpu, &mem, &name); err != nil {
 			klog.Errorf("error parsing component resource usage %s. Skipping. %v", name, err)
 		}
 		if name != "" {
@@ -76,7 +76,7 @@ func GetKubemarkMasterComponentsResourceUsage(host string, provider provider.Pro
 		var cpu float64
 		var mem uint64
 		var etcdKind string
-		if _, err := fmt.Sscanf(strings.TrimSpace(scanner.Text()), "%f %d /usr/local/bin/etcd", &cpu, &mem); err == nil {
+		if _, err := fmt.Sscanf(strings.TrimSpace(scanner.Text()), "%f %d /usr/local/bin/etcd", &cpu, &mem); err != nil {
 			klog.Errorf("error parsing etcd resource usage, skipping. %v", err)
 		}
 		dataDirStart := strings.Index(scanner.Text(), "--data-dir")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
https://github.com/kubernetes/perf-tests/blob/master/clusterloader2/pkg/measurement/util/kubemark/kubemark.go

At the fixed file `kubemark.go`, the condition of the error handling should be `!=` but misplaced by `==` at both L59 and L79
This PR fixes this logical error.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

