### PR TITLE
Prometheus server should use SA token when talking to apiserver

### DIFF
--- a/clusterloader2/pkg/prometheus/manifests/master-ip/master-serviceMonitor.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/master-ip/master-serviceMonitor.yaml
@@ -30,6 +30,7 @@ spec:
     scheme: https
     tlsConfig:
       insecureSkipVerify: true
+    bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
   {{if $PROMETHEUS_SLOW_APISERVER}}
     interval: 30s
     scrapeTimeout: 30s


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Prometheus server should use service account token when talking to kube-apiserver. We should not rely on anonymous auth.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

We currently create ClusterRole and ClusterRoleBinding for anonymous auth. https://github.com/kubernetes/perf-tests/blob/6b7d01a3b54dc671e92af23fa4e45b144ec4913c/clusterloader2/pkg/prometheus/prometheus.go#L370-L388
