### PR TITLE
Fix go version and deployment.yaml

### DIFF
--- a/perfdash/Dockerfile
+++ b/perfdash/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG GOLANG_VERSION=1.22
+ARG GOLANG_VERSION=1.23
 FROM golang:${GOLANG_VERSION} AS builder
 
 WORKDIR /workspace

--- a/perfdash/deployment.yaml
+++ b/perfdash/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: perfdash
-        image: gcr.io/k8s-staging-perf-tests/perfdash:2.51
+        image: gcr.io/k8s-staging-perf-tests/perfdash:2.52
         command:
           - /perfdash
           -   --www=true


### PR DESCRIPTION
/kind bug

It fixes version in deployment.yaml and bumps to a new golang version that is required to build.

/assign @serathius 