### PR TITLE
Use constant resources for list benchmark deployment

### DIFF
--- a/clusterloader2/testing/list/config.yaml
+++ b/clusterloader2/testing/list/config.yaml
@@ -3,13 +3,7 @@
 {{$configMapNumber := DefaultParam .CL2_LIST_CONFIG_MAP_NUMBER 10000}}
 {{$configMapGroup := DefaultParam .CL2_LIST_CONFIG_MAP_GROUP "list-configmap"}}
 
-{{$listReplicas := DefaultParam .CL2_LIST_BENCHMARK_PODS 10}}
-{{$inflight := DefaultParam .CL2_LIST_CONCURRENCY 1}}
-
-# CL2_LIST_BENCHMARK_POD_CPU and CL2_LIST_BENCHMARK_POD_MEMORY are expected to be an integer-only value.
-# We will append m (milicores) and Mi for them respectively.
-{{$clusterScopedPodCpu := DefaultParam .CL2_LIST_BENCHMARK_POD_CPU 2000}}
-{{$clusterScopedPodMemory := DefaultParam .CL2_LIST_BENCHMARK_POD_MEMORY 4096}}
+{{$listReplicas := DefaultParam .CL2_LIST_BENCHMARK_PODS 1}}
 
 name: List benchmark
 namespace:
@@ -66,10 +60,7 @@ steps:
     params:
       namePrefix: "list-configmaps-"
       replicas: {{$listReplicas}}
-      inflight: {{$inflight}}
       uri: /api/v1/configmaps?resourceVersion=0
-      cpu: {{$clusterScopedPodCpu}}m
-      memory: {{$clusterScopedPodMemory}}Mi
       namespaced: false
 - module:
     path: /modules/measurements.yaml

--- a/clusterloader2/testing/list/deployment.yaml
+++ b/clusterloader2/testing/list/deployment.yaml
@@ -1,7 +1,7 @@
 # The source of the image is at https://github.com/kubernetes/perf-tests/tree/master/util-images/request-benchmark
 {{$image := DefaultParam .CL2_BENCHMARK_IMAGE "gcr.io/k8s-testimages/perf-tests-util/request-benchmark:latest"}}
-{{$cpu := DefaultParam .cpu "200m"}}
-{{$memory := DefaultParam .memory "400Mi"}}
+{{$cpu := DefaultParam .cpu "1250m"}}
+{{$memory := DefaultParam .memory "32Mi"}}
 
 apiVersion: apps/v1
 kind: Deployment
@@ -25,7 +25,6 @@ spec:
         image: {{$image}}
         imagePullPolicy: Always
         args:
-        - --inflight={{.Inflight}}
         - --namespace={{.Namespace}}
         - --uri={{.Uri}}
         resources:

--- a/clusterloader2/testing/list/modules/list-benchmark.yaml
+++ b/clusterloader2/testing/list/modules/list-benchmark.yaml
@@ -1,9 +1,6 @@
 {{$namePrefix := DefaultParam .namePrefix "list-benchmark-"}}
 {{$replicas := DefaultParam .replicas 0}}
-{{$inflight := DefaultParam .inflight 0}}
 {{$uri := DefaultParam .uri "/"}}
-{{$cpu := DefaultParam .cpu "200m"}}
-{{$memory := DefaultParam .memory "400Mi"}}
 
 steps:
 - name: Creating WaitForControlledPodsRunning measurement
@@ -30,10 +27,7 @@ steps:
       objectTemplatePath: deployment.yaml
       templateFillMap:
         Replicas: {{$replicas}}
-        Inflight: {{$inflight}}
         Uri: {{$uri}}
-        cpu: {{$cpu}}
-        memory: {{$memory}}
 - name: Waiting for WaitForControlledPodsRunning gather
   measurements:
   - Identifier: WaitForListBenchmarkDeployment


### PR DESCRIPTION
Thanks to improvements in https://github.com/kubernetes/perf-tests/pull/3143 we can just use constant resources. Removing passing cpu and memory variables as they should no longer needed. Removing Inflights variable as clients are single threaded and cpu bound so there is no benefit of having multpile concurrent calls from single container.

Setting default benchmark pods to 1 to allow executing the test locally on a smaller machine.

/kind feature
/assign @mborsz 
