### PR TITLE
Add missing kind file with configuration to run tests locally

### DIFF
--- a/clusterloader2/testing/list/kind.yaml
+++ b/clusterloader2/testing/list/kind.yaml
@@ -1,0 +1,13 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  kubeadmConfigPatches:
+  - |
+    kind: ClusterConfiguration
+    controllerManager:
+      extraArgs:
+        bind-address: "0.0.0.0"
+    scheduler:
+      extraArgs:
+        bind-address: "0.0.0.0"


### PR DESCRIPTION
Forgot to add kind file to https://github.com/kubernetes/perf-tests/pull/3163
/kind documentation

