### PR TITLE
Remove usage of system:anonymous from ClusterRoleBinding used to scra…

### DIFF
--- a/clusterloader2/pkg/prometheus/manifests/master-ip/master-serviceMonitor.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/master-ip/master-serviceMonitor.yaml
@@ -36,6 +36,7 @@ spec:
   {{else}}
     interval: 5s
   {{end}}
+    bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
   {{if $PROMETHEUS_SCRAPE_MASTER_KUBELETS}}
   - interval: 5s
     port: kubelet

--- a/clusterloader2/pkg/prometheus/prometheus.go
+++ b/clusterloader2/pkg/prometheus/prometheus.go
@@ -378,10 +378,10 @@ func (pc *Controller) exposeAPIServerMetrics() error {
 	}
 	createClusterRoleBinding := func() error {
 		_, err := clientSet.GetClient().RbacV1().ClusterRoleBindings().Create(context.TODO(), &rbacv1.ClusterRoleBinding{
-			ObjectMeta: metav1.ObjectMeta{Name: "system:anonymous"},
+			ObjectMeta: metav1.ObjectMeta{Name: "apiserver-metrics-viewer-binding"},
 			RoleRef:    rbacv1.RoleRef{Kind: "ClusterRole", Name: "apiserver-metrics-viewer"},
 			Subjects: []rbacv1.Subject{
-				{Kind: "User", Name: "system:anonymous"},
+				{Kind: "User", Name: "prometheus-k8s", Namespace: "monitoring"},
 			},
 		}, metav1.CreateOptions{})
 		return err


### PR DESCRIPTION
…p apiserver metrics

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:

Binding any permissions to system:anonymous and system:unauthenticated is dangerous.
This PR removes usage of system:anonymous in CLusterROleBinding used to talk to apiserver. 

What is more, service account needs to be used when talking to apiserver.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

