### PR TITLE
Increase request-benchmark version to 0.0.8

### DIFF
--- a/util-images/request-benchmark/Makefile
+++ b/util-images/request-benchmark/Makefile
@@ -1,6 +1,6 @@
 PROJECT ?= k8s-testimages
 IMG = gcr.io/$(PROJECT)/perf-tests-util/request-benchmark
-TAG = v0.0.7
+TAG = v0.0.8
 
 all: build push
 


### PR DESCRIPTION

#### What type of PR is this?

/kind feature
#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

It is already pushed

```
➜  request-benchmark git:(d1c0bd772) ✗ make
docker build --pull -t gcr.io/k8s-testimages/perf-tests-util/request-benchmark:v0.0.8 .
Sending build context to Docker daemon  26.62kB
Step 1/12 : FROM golang:1.24 as builder
1.24: Pulling from library/golang
155ad54a8b28: Pull complete
8031108f3cda: Pull complete
1d281e50d3e4: Pull complete
9760da4e8f07: Pull complete
a2a60326dddc: Pull complete
8985a99e1ce3: Pull complete
4f4fb700ef54: Pull complete
Digest: sha256:3f7444391c51a11a039bf0359ee81cc64e663c17d787ad0e637a4de1a3f62a71
Status: Downloaded newer image for golang:1.24
 ---> 245780beb82f
Step 2/12 : ENV GOOS linux
 ---> Running in 1404c20247cb
Removing intermediate container 1404c20247cb
 ---> 016a0af68764
Step 3/12 : ENV CGO_ENABLED 0
 ---> Running in 7525f4738843
Removing intermediate container 7525f4738843
 ---> 3334589c4e83
Step 4/12 : WORKDIR /app
 ---> Running in 93fbf0326e3e
Removing intermediate container 93fbf0326e3e
 ---> d48a86bdf321
Step 5/12 : COPY go.mod go.sum ./
 ---> 41f93744f7c6
Step 6/12 : RUN go mod download
 ---> Running in 29c608e6e2e6
Removing intermediate container 29c608e6e2e6
 ---> 21888d5f62dc
Step 7/12 : COPY . .
 ---> 57a33ef40fe6
Step 8/12 : RUN go build -o benchmark
 ---> Running in 2d2c82f852b8
Removing intermediate container 2d2c82f852b8
 ---> c081a02d6471
Step 9/12 : FROM alpine:latest as production
latest: Pulling from library/alpine
f18232174bc9: Pull complete
Digest: sha256:a8560b36e8b8210634f77d9f7f9efd7ffa463e380b75e2e74aff4511df3ef88c
Status: Downloaded newer image for alpine:latest
 ---> aded1e1a5b37
Step 10/12 : RUN apk add --no-cache ca-certificates && update-ca-certificates
 ---> Running in 924089c321fb
fetch https://dl-cdn.alpinelinux.org/alpine/v3.21/main/x86_64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.21/community/x86_64/APKINDEX.tar.gz
(1/1) Installing ca-certificates (20241121-r1)
Executing busybox-1.37.0-r12.trigger
Executing ca-certificates-20241121-r1.trigger
OK: 7 MiB in 16 packages
Removing intermediate container 924089c321fb
 ---> 8254ff019b25
Step 11/12 : COPY --from=builder app/benchmark .
 ---> e1d01f5546f0
Step 12/12 : ENTRYPOINT [ "/benchmark" ]
 ---> Running in bf6978e7627a
Removing intermediate container bf6978e7627a
 ---> fde5f984da04
Successfully built fde5f984da04
Successfully tagged gcr.io/k8s-testimages/perf-tests-util/request-benchmark:v0.0.8
docker tag gcr.io/k8s-testimages/perf-tests-util/request-benchmark:v0.0.8 gcr.io/k8s-testimages/perf-tests-util/request-benchmark:latest
Built gcr.io/k8s-testimages/perf-tests-util/request-benchmark:v0.0.8 and tagged with latest
docker push gcr.io/k8s-testimages/perf-tests-util/request-benchmark:v0.0.8
The push refers to repository [gcr.io/k8s-testimages/perf-tests-util/request-benchmark]
12e21972a15d: Pushed
b804cc69bf66: Pushed
08000c18d16d: Layer already exists
v0.0.8: digest: sha256:ebf095f52640c204a94d41ae0fa1bb3738866a33bcfbb91fe64abf1a3fea4392 size: 949
docker push gcr.io/k8s-testimages/perf-tests-util/request-benchmark:latest
The push refers to repository [gcr.io/k8s-testimages/perf-tests-util/request-benchmark]
12e21972a15d: Layer already exists
b804cc69bf66: Layer already exists
08000c18d16d: Layer already exists
latest: digest: sha256:ebf095f52640c204a94d41ae0fa1bb3738866a33bcfbb91fe64abf1a3fea4392 size: 949
Pushed gcr.io/k8s-testimages/perf-tests-util/request-benchmark with :latest and :v0.0.8 tags
```

