### PR TITLE
Remove system anonymous from apis metrics v2

### DIFF
--- a/clusterloader2/pkg/prometheus/manifests/default/prometheus-serviceMonitorCoreDNS.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/default/prometheus-serviceMonitorCoreDNS.yaml
@@ -7,7 +7,9 @@ metadata:
   namespace: monitoring
 spec:
   endpoints:
-  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+  - bearerTokenSecret:
+      name: prometheus-token
+      key: token
     interval: 10s
     port: metrics
   jobLabel: k8s-app

--- a/clusterloader2/pkg/prometheus/manifests/default/prometheus-serviceMonitorKubelet.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/default/prometheus-serviceMonitorKubelet.yaml
@@ -16,7 +16,9 @@ spec:
     interval: 30s
     tlsConfig:
       insecureSkipVerify: true
-    bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    bearerTokenSecret:
+      name: prometheus-token
+      key: token
   - port: https-metrics
     scheme: https
     path: /metrics/cadvisor
@@ -24,7 +26,9 @@ spec:
     honorLabels: true
     tlsConfig:
       insecureSkipVerify: true
-    bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    bearerTokenSecret:
+      name: prometheus-token
+      key: token
     metricRelabelings:
       - sourceLabels: [ namespace ]
         regex: 'test-.*'

--- a/clusterloader2/pkg/prometheus/manifests/default/prometheus-serviceMonitorLegacyKubeDNS.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/default/prometheus-serviceMonitorLegacyKubeDNS.yaml
@@ -7,7 +7,9 @@ metadata:
   namespace: monitoring
 spec:
   endpoints:
-  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+  - bearerTokenSecret:
+      name: prometheus-token
+      key: token
     interval: 10s
     targetPort: 10054
   jobLabel: k8s-app

--- a/clusterloader2/pkg/prometheus/manifests/master-ip/master-serviceMonitor.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/master-ip/master-serviceMonitor.yaml
@@ -36,30 +36,43 @@ spec:
   {{else}}
     interval: 5s
   {{end}}
+    bearerTokenSecret:
+      name: prometheus-token
+      key: token
   {{if $PROMETHEUS_SCRAPE_MASTER_KUBELETS}}
   - interval: 5s
     port: kubelet
     scheme: https
     tlsConfig:
       insecureSkipVerify: true
-    bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    bearerTokenSecret:
+      name: prometheus-token
+      key: token
   - interval: 5s
     port: kubelet
     path: /metrics/cadvisor
     scheme: https
     tlsConfig:
       insecureSkipVerify: true
-    bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    bearerTokenSecret:
+      name: prometheus-token
+      key: token
   {{end}}
   - interval: 5s
     port: kube-scheduler
     scheme: https
     tlsConfig:
       insecureSkipVerify: true
+    bearerTokenSecret:
+      name: prometheus-token
+      key: token
   - interval: 5s
     port: kube-controller-manager
     scheme: https
     tlsConfig:
       insecureSkipVerify: true
+    bearerTokenSecret:
+      name: prometheus-token
+      key: token
   selector:
     k8s-app: master

--- a/clusterloader2/pkg/prometheus/prometheus.go
+++ b/clusterloader2/pkg/prometheus/prometheus.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"golang.org/x/sync/errgroup"
+	authenticationv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
@@ -59,6 +60,7 @@ const (
 	nodeExporterPod              = "exporters/node_exporter/node-exporter.yaml"
 	windowsNodeExporterManifests = "exporters/windows_node_exporter/*.yaml"
 	pushgatewayManifests         = "pushgateway/*.yaml"
+	monitoringServiceAccount     = "monitoringserviceaccount"
 )
 
 //go:embed manifests
@@ -222,14 +224,35 @@ func NewController(clusterLoaderConfig *config.ClusterLoaderConfig) (pc *Control
 // This method is idempotent, if the prometheus stack is already set up applying the manifests
 // again will be no-op.
 func (pc *Controller) SetUpPrometheusStack() error {
-	k8sClient := pc.framework.GetClientSets().GetClient()
+	rootClusterClientSet := pc.framework.GetClientSets().GetClient()
 
-	klog.V(2).Info("Setting up prometheus stack")
-	if err := client.CreateNamespace(k8sClient, namespace); err != nil {
+	// In a Kubemark environment, there are two distinct clusters: the root cluster and the test cluster.
+	// Therefore, a testClusterClientSet operating on the test cluster is required.
+	// Prometheus runs in the root cluster, but certain actions must be performed in the test cluster
+	// for which this testClusterClientSet will be used.
+	testClusterClientSet, err := func() (kubernetes.Interface, error) {
+		multiClientSet, err := framework.NewMultiClientSet(pc.clusterLoaderConfig.ClusterConfig.KubeConfigPath, numK8sClients)
+		if err != nil {
+			return nil, err
+		}
+		return multiClientSet.GetClient(), nil
+	}()
+
+	if err != nil {
 		return err
 	}
+
+	klog.V(2).Info("Setting up prometheus stack")
+	if err := client.CreateNamespace(rootClusterClientSet, namespace); err != nil {
+		return err
+	}
+
+	if err := pc.createToken(rootClusterClientSet, testClusterClientSet); err != nil {
+		return err
+	}
+
 	// Removing Storage Class as Reclaim Policy cannot be changed
-	if err := client.DeleteStorageClass(k8sClient, storageClass); err != nil {
+	if err := client.DeleteStorageClass(rootClusterClientSet, storageClass); err != nil {
 		return err
 	}
 	if err := pc.applyDefaultManifests(coreManifests); err != nil {
@@ -248,7 +271,7 @@ func (pc *Controller) SetUpPrometheusStack() error {
 		// Backward compatibility
 		// If enabled scraping windows node, need to setup windows node and template mapping
 		if isWindowsNodeScrapingEnabled(pc.templateMapping, pc.clusterLoaderConfig) {
-			if err := setUpWindowsNodeAndTemplate(k8sClient, pc.templateMapping); err != nil {
+			if err := setUpWindowsNodeAndTemplate(rootClusterClientSet, pc.templateMapping); err != nil {
 				return err
 			}
 		}
@@ -272,7 +295,7 @@ func (pc *Controller) SetUpPrometheusStack() error {
 		}
 	}
 	if _, ok := pc.templateMapping["MasterIps"]; ok {
-		if err := pc.exposeAPIServerMetrics(); err != nil {
+		if err := pc.configureRBACForMetrics(testClusterClientSet); err != nil {
 			return err
 		}
 		if err := pc.applyDefaultManifests(masterIPServiceMonitors); err != nil {
@@ -293,7 +316,7 @@ func (pc *Controller) SetUpPrometheusStack() error {
 		}
 	}
 	if err := pc.waitForPrometheusToBeHealthy(); err != nil {
-		dumpAdditionalLogsOnPrometheusSetupFailure(k8sClient)
+		dumpAdditionalLogsOnPrometheusSetupFailure(rootClusterClientSet)
 		return err
 	}
 	klog.V(2).Info("Prometheus stack set up successfully")
@@ -355,33 +378,87 @@ func (pc *Controller) applyManifests(path, manifestGlob string) error {
 		os.DirFS(path), manifestGlob, pc.templateMapping, client.Retry(apierrs.IsNotFound))
 }
 
-// exposeAPIServerMetrics configures anonymous access to the apiserver metrics.
-func (pc *Controller) exposeAPIServerMetrics() error {
-	klog.V(2).Info("Exposing kube-apiserver metrics in the cluster")
-	// We need to get a client to the cluster where the test is being executed on,
-	// not the cluster that the prometheus is running in. Usually, there is only
-	// once cluster, but in case of kubemark we have two and thus we need to
-	// create a new client here.
-	clientSet, err := framework.NewMultiClientSet(
-		pc.clusterLoaderConfig.ClusterConfig.KubeConfigPath, numK8sClients)
+// In a Kubemark environment, Prometheus runs in the root cluster, while the simulated nodes reside in a separate test cluster.
+// Consequently, Prometheus cannot natively scrape metrics from the test cluster due to cross-cluster limitations.
+// To address this, this function performs the following:
+// 1. Creates a ServiceAccount and its associated token within the test cluster.
+// 2. Stores the generated token as a secret in the root cluster.
+// Prometheus in the root cluster is configured to use this secret for authenticating metric scraping requests from the test cluster.
+// This allows Prometheus to successfully collect metrics from the simulated nodes in the Kubemark test cluster.
+func (pc *Controller) createToken(k8sClient kubernetes.Interface, testClusterClientSet kubernetes.Interface) error {
+	klog.V(2).Info("Creating ServiceAccount in testing cluster")
+
+	saObj := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: monitoringServiceAccount,
+		},
+	}
+	serviceAccount := func() error {
+		_, err := testClusterClientSet.CoreV1().ServiceAccounts(corev1.NamespaceDefault).Create(context.TODO(), saObj, metav1.CreateOptions{})
+		return err
+	}
+
+	token := func() (string, error) {
+		expirationSeconds := int64(86400) // 24h
+		tokenReq := &authenticationv1.TokenRequest{
+			Spec: authenticationv1.TokenRequestSpec{
+				ExpirationSeconds: &expirationSeconds,
+			},
+		}
+		tokenResp, err := testClusterClientSet.CoreV1().ServiceAccounts(corev1.NamespaceDefault).CreateToken(context.TODO(), saObj.Name, tokenReq, metav1.CreateOptions{})
+		if err != nil {
+			return "", fmt.Errorf("failed to create token: %v", err)
+		}
+		if len(tokenResp.Status.Token) == 0 {
+			return "", fmt.Errorf("failed to create token: no token in server response")
+		}
+		return tokenResp.Status.Token, nil
+	}
+
+	if err := retryCreateFunction(serviceAccount); err != nil {
+		return err
+	}
+	tokenResponse, err := retryCreateFunctionWithResponse(token)
 	if err != nil {
 		return err
 	}
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "prometheus-token",
+			Namespace: namespace,
+		},
+		Data: map[string][]byte{
+			"token": []byte(tokenResponse),
+		},
+		Type: corev1.SecretTypeOpaque,
+	}
+	_, err = k8sClient.CoreV1().Secrets(namespace).Create(context.TODO(), secret, metav1.CreateOptions{})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// configureRBACForMetrics creates a ClusterRole and ClusterRoleBinding
+// to allow the monitoringServiceAccount (used by Prometheus) to scrape metrics.
+func (pc *Controller) configureRBACForMetrics(testClusterClientSet kubernetes.Interface) error {
+	klog.V(2).Info("Exposing kube-apiserver metrics in the cluster")
 	createClusterRole := func() error {
-		_, err := clientSet.GetClient().RbacV1().ClusterRoles().Create(context.TODO(), &rbacv1.ClusterRole{
-			ObjectMeta: metav1.ObjectMeta{Name: "apiserver-metrics-viewer"},
+		_, err := testClusterClientSet.RbacV1().ClusterRoles().Create(context.TODO(), &rbacv1.ClusterRole{
+			ObjectMeta: metav1.ObjectMeta{Name: "metrics-viewer"},
 			Rules: []rbacv1.PolicyRule{
 				{Verbs: []string{"get"}, NonResourceURLs: []string{"/metrics"}},
+				{APIGroups: []string{""}, Verbs: []string{"get"}, Resources: []string{"nodes/metrics"}},
 			},
 		}, metav1.CreateOptions{})
 		return err
 	}
 	createClusterRoleBinding := func() error {
-		_, err := clientSet.GetClient().RbacV1().ClusterRoleBindings().Create(context.TODO(), &rbacv1.ClusterRoleBinding{
-			ObjectMeta: metav1.ObjectMeta{Name: "system:anonymous"},
-			RoleRef:    rbacv1.RoleRef{Kind: "ClusterRole", Name: "apiserver-metrics-viewer"},
+		_, err := testClusterClientSet.RbacV1().ClusterRoleBindings().Create(context.TODO(), &rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: "metrics-viewer-binding"},
+			RoleRef:    rbacv1.RoleRef{Kind: "ClusterRole", Name: "metrics-viewer"},
 			Subjects: []rbacv1.Subject{
-				{Kind: "User", Name: "system:anonymous"},
+				{Kind: "ServiceAccount", Name: monitoringServiceAccount, Namespace: corev1.NamespaceDefault},
 			},
 		}, metav1.CreateOptions{})
 		return err
@@ -472,6 +549,21 @@ func (pc *Controller) isPrometheusReady() (bool, error) {
 		pc.framework.GetClientSets().GetClient(),
 		func(Target) bool { return true }, // All targets.
 		expectedTargets)
+}
+
+func retryCreateFunctionWithResponse(f func() (string, error)) (string, error) {
+	var result string
+	err := client.RetryWithExponentialBackOff(
+		client.RetryFunction(func() error {
+			var err error
+			result, err = f()
+			return err
+		}, client.Allow(apierrs.IsAlreadyExists)))
+
+	if err != nil {
+		return "", err
+	}
+	return result, nil
 }
 
 func retryCreateFunction(f func() error) error {


### PR DESCRIPTION
…p apiserver metrics

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:

Binding any permissions to system:anonymous and system:unauthenticated is dangerous.
This PR removes usage of system:anonymous in CLusterROleBinding used to talk to apiserver. 

What is more, service account needs to be used when talking to apiserver.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

