### PR TITLE
[DNM] feat: add ENABLE_API_SERVER_VALIDATION_METRICS and associated validation metric check

### DIFF
--- a/clusterloader2/testing/load/modules/measurements.yaml
+++ b/clusterloader2/testing/load/modules/measurements.yaml
@@ -40,6 +40,7 @@
 {{$RESTART_COUNT_THRESHOLD_OVERRIDES:= DefaultParam .RESTART_COUNT_THRESHOLD_OVERRIDES ""}}
 {{$USE_SIMPLE_LATENCY_QUERY := DefaultParam .USE_SIMPLE_LATENCY_QUERY false}}
 {{$ENABLE_VIOLATIONS_FOR_NETWORK_PROGRAMMING_LATENCIES := DefaultParam .CL2_ENABLE_VIOLATIONS_FOR_NETWORK_PROGRAMMING_LATENCIES false}}
+{{$ENABLE_API_SERVER_VALIDATION_METRICS := DefaultParam .CL2_ENABLE_API_SERVER_VALIDATION_METRICS true}}
 {{$NETWORK_PROGRAMMING_LATENCY_THRESHOLD := DefaultParam .CL2_NETWORK_PROGRAMMING_LATENCY_THRESHOLD "30s"}}
 {{$NETWORK_LATENCY_THRESHOLD := DefaultParam .CL2_NETWORK_LATENCY_THRESHOLD "0s"}}
 
@@ -117,6 +118,24 @@ steps:
       - name: Total
         query: sum(kubeproxy_sync_proxy_rules_iptables_partial_restore_failures_total)
         requireSamples: false # It is a feature gate and may not be enabled
+        threshold: 0
+{{end}}
+{{if $ENABLE_API_SERVER_VALIDATION_METRICS}}
+  - Identifier: APIServerDeclarativeValidationMetrics
+    Method: GenericPrometheusQuery
+    Params:
+      action: {{$action}}
+      metricName: APIServerDeclarativeValidation
+      metricVersion: v1alpha1
+      unit: failures
+      queries:
+      - name: ValidationMismatches
+        query: sum(apiserver_validation_declarative_validation_mismatch_total)
+        requireSamples: false # May not be present in all clusters
+        threshold: 0
+      - name: ValidationPanics
+        query: sum(apiserver_validation_declarative_validation_panic_total)
+        requireSamples: false # May not be present in all clusters
         threshold: 0
 {{end}}
 {{if $PROMETHEUS_SCRAPE_KUBE_STATE_METRICS}}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR adds an additional metrics check necessary for testing of Declarative Validation related to this section in the KEP: https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/5073-declarative-validation-with-validation-gen/README.md#runtime-verification-testing

The metrics check on the scalability test here ensures that the feature is working as expected and not triggering these metrics that should never be > 0 in normal usage.  These new metrics are:
- declarative_validation_mismatch_total
- declarative_validation_panic_total


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
It is part of https://github.com/kubernetes/enhancements/issues/5073

#### Special notes for your reviewer:
Related slack thread: https://kubernetes.slack.com/archives/C09QZ4DQB/p1741645966063629

