### PR TITLE
watchlist: increase the number of informers to 16 to compare with streaming encoders

### DIFF
--- a/clusterloader2/testing/watch-list/config.yaml
+++ b/clusterloader2/testing/watch-list/config.yaml
@@ -42,8 +42,7 @@ steps:
         min: 1
         max: 1
         basename: watch-list
-      # TODO(p0lyn0mial): bring back 2 replicas
-      replicasPerNamespace: 1
+      replicasPerNamespace: 2
       tuningSet: Uniform10qps
       objectBundle:
         - basename: watch-list-secret

--- a/clusterloader2/testing/watch-list/job.yaml
+++ b/clusterloader2/testing/watch-list/job.yaml
@@ -21,6 +21,5 @@ spec:
               memory: "16Gi"
               cpu: "6"
           command: [ "watch-list" ]
-          # TODO(p0lyn0mial): bring back 16 informers
-          args: [ "--alsologtostderr=true", "--v=4", "--timeout={{.Duration}}", "--count=6", "--namespace=watch-list-1", "--enableWatchListFeature={{.EnableWatchListFeature}}"]
+          args: [ "--alsologtostderr=true", "--v=4", "--timeout={{.Duration}}", "--count=16", "--namespace=watch-list-1", "--enableWatchListFeature={{.EnableWatchListFeature}}"]
       restartPolicy: Never


### PR DESCRIPTION
bring back the number of informers to 16. this will help us compare memory utilisation with the streaming encoders feature.