### PR TITLE
Update golang scripts

### DIFF
--- a/golang/push.sh
+++ b/golang/push.sh
@@ -18,4 +18,9 @@ set -euxo pipefail
 
 # Push Kubernetes build to GCS.
 cd $ROOT_DIR/k8s.io/kubernetes
-../release/push-build.sh --nomock --ci --bucket=$GCS_BUCKET --private-bucket
+../release/push-build.sh \
+  --nomock \
+  --ci \
+  --bucket=$GCS_BUCKET \
+  --private-bucket \
+  --version-suffix=$(date +%s)


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
https://github.com/kubernetes/test-infra/pull/33436 bumped the K8s version used in the `ci-build-and-push-k8s-at-golang-tip` job after which it stopped using the locally built golang version - instead, it started to rely on and download the version specified in k/k's `.go-version` file.

To address this, we pass the `GOTOOLCHAIN=local` env var to the build scripts to make it use the locally built version of golang.

#### Which issue(s) this PR fixes:
1) This PR makes sure that kube-build picks up the manually built version of golang.
2) This also fixes https://github.com/kubernetes/perf-tests/issues/3146.