### PR TITLE
Bump prometheus version to 2.40.0 in prometheus operator

### DIFF
--- a/clusterloader2/pkg/prometheus/manifests/prometheus-prometheus.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/prometheus-prometheus.yaml
@@ -65,7 +65,7 @@ spec:
   podMonitorNamespaceSelector: {}
   podMonitorSelector: {}
   priorityClassName: system-node-critical
-  version: v2.25.0
+  version: v2.40.0
   retention: 7d
   {{if $PROMETHEUS_PVC_ENABLED}}
   # We add node tolerations for control-plane nodes in Azure Windows test jobs which do not support Google PD


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
This bumps the version of Prometheus used in CL2's Prometheus Operator deployment to [2.40.0](https://github.com/prometheus/prometheus/releases/tag/v2.40.0).

That version contains a change that makes Prometheus talk to the K8s API using protobuf instead of JSON when doing service discovery: https://github.com/prometheus/prometheus/pull/11353.

/assign @wojtek-t