### PR TITLE
Increase Reporter extensibility

### DIFF
--- a/clusterloader2/pkg/test/simple_reporter.go
+++ b/clusterloader2/pkg/test/simple_reporter.go
@@ -71,7 +71,7 @@ func (str *simpleReporter) ReportTestStepFinish(duration time.Duration, stepName
 }
 
 func (str *simpleReporter) ReportTestStep(result *StepResult) {
-	for _, subtestResult := range result.getAllResults() {
+	for _, subtestResult := range result.GetAllResults() {
 		str.ReportTestStepFinish(subtestResult.duration, subtestResult.name, subtestResult.err)
 	}
 }

--- a/clusterloader2/pkg/test/step_summary.go
+++ b/clusterloader2/pkg/test/step_summary.go
@@ -49,6 +49,8 @@ func NewStepResult(stepName string) *StepResult {
 	}
 }
 
+func (s *StepResult) Name() string { return s.name }
+
 func (s *StepResult) AddSubStepResult(name string, id int, err *errors.ErrorList) {
 	s.lock.Lock()
 	defer s.lock.Unlock()


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This change exposes the SubstepResult struct in order to make `test.Reporter` a fully extensible interface. Currently the only out-of-the-box Reporter implementation invokes its own `ReportTestStepFinish` method, which does expose this data, but seemingly only to itself (it probably shouldn't be in the main interface for this reason). It relies on a package-private method from `ReportTestStep` to fill out this data, and the default Executor only invokes that top level method – this prevents users from implementing custom reporters with any level of test-step visibility.

The only way to access this newly public substep data is via the `StepResult.GetAllResults` method which is already mutex protected so simply exposing this seems safe. To that end only getter methods are added to ensure data mutation is limited.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

