### PR TITLE
Remove previous go instalation in build-go.sh, bump go compiler to 1.24.2

### DIFF
--- a/golang/Makefile
+++ b/golang/Makefile
@@ -15,7 +15,7 @@
 .PHONY: build-go build push
 
 export GCS_BUCKET?=k8s-infra-scale-golang-builds
-export GO_COMPILER_PKG?=go1.24.0.linux-amd64.tar.gz
+export GO_COMPILER_PKG?=go1.24.2.linux-amd64.tar.gz
 export GO_COMPILER_URL?=https://dl.google.com/go/$(GO_COMPILER_PKG)
 export ROOT_DIR?=/home/prow/go/src
 

--- a/golang/build-go.sh
+++ b/golang/build-go.sh
@@ -18,6 +18,7 @@ set -euxo pipefail
 
 function install_go_compiler {
   wget -q $GO_COMPILER_URL
+  rm -rf /usr/local/go
   tar -C /usr/local -xzf $GO_COMPILER_PKG
   rm $GO_COMPILER_PKG
   export PATH=$PATH:/usr/local/go/bin


### PR DESCRIPTION
Remove previous go instalation in build-go.sh and bump go compiler to 1.24.2


#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This fixes recent failures of ci-build-and-push-k8s-at-golang-tip.  Currently the job fails at install_go_compiler step, as kubekins was updated to use 1.24.2 golang in https://github.com/kubernetes/test-infra/commit/5ad67f09e073e03c704e488cb8c02b426bdee66b (note that variants are linked from kubekins directory). In 1.24.2 the `go/src/debug/buildinfo/testdata/go117` and `go/src/debug/buildinfo/testdata/notgo` are directories, meanwhile in 1.24.0 those are files. That's why tar fails.

Also according to https://go.dev/doc/install we should clean up the old golang installation anyway, per:
```
Do not untar the archive into an existing /usr/local/go tree. This is known to produce broken Go installations.
```


#### Which issue(s) this PR fixes:
https://testgrid.k8s.io/sig-scalability-golang#build-and-push-k8s-at-golang-tip

