### PR TITLE
Adding threshold by percentile for podStartupLatency

### DIFF
--- a/clusterloader2/pkg/measurement/common/slos/slo_measurement_test.go
+++ b/clusterloader2/pkg/measurement/common/slos/slo_measurement_test.go
@@ -32,8 +32,11 @@ func Test_getMeasurementConfig(t *testing.T) {
 					"threshold": 200,
 				},
 				"PodStartupLatency": map[string]interface{}{
-					"threshold": 5,
-					"latency":   "10s",
+					"threshold":       5,
+					"perc50Threshold": 5,
+					"perc90Threshold": 10,
+					"perc99Threshold": 15,
+					"latency":         "10s",
 				},
 			},
 		},
@@ -51,6 +54,15 @@ func Test_getMeasurementConfig(t *testing.T) {
 	measurementConfig, _ = getMeasurementConfig(config, "PodStartupLatency")
 	params = measurementConfig.Params
 	if result := params["threshold"]; result != 5 {
+		t.Errorf("want %v, got %v", 5, result)
+	}
+	if result := params["perc50Threshold"]; result != 5 {
+		t.Errorf("want %v, got %v", 5, result)
+	}
+	if result := params["perc90Threshold"]; result != 10 {
+		t.Errorf("want %v, got %v", 5, result)
+	}
+	if result := params["perc99Threshold"]; result != 15 {
 		t.Errorf("want %v, got %v", 5, result)
 	}
 	if result := params["latency"]; result != "10s" {

--- a/clusterloader2/pkg/measurement/util/latency_metric.go
+++ b/clusterloader2/pkg/measurement/util/latency_metric.go
@@ -59,6 +59,20 @@ func (metric *LatencyMetric) VerifyThreshold(threshold time.Duration) error {
 	return nil
 }
 
+// VerifyThreshold verifies latency metric against given percentile thresholds.
+func (metric *LatencyMetric) VerifyThresholdByPercentile(perc50Threshold, perc90Threshold, perc99Threshold time.Duration) error {
+	if metric.Perc50 > perc50Threshold {
+		return fmt.Errorf("too high latency 50th percentile: got %v expected: %v", metric.Perc50, perc50Threshold)
+	}
+	if metric.Perc90 > perc90Threshold {
+		return fmt.Errorf("too high latency 90th percentile: got %v expected: %v", metric.Perc90, perc90Threshold)
+	}
+	if metric.Perc99 > perc99Threshold {
+		return fmt.Errorf("too high latency 99th percentile: got %v expected: %v", metric.Perc99, perc99Threshold)
+	}
+	return nil
+}
+
 // ToPerfData converts latency metric to PerfData.
 func (metric *LatencyMetric) ToPerfData(name string) DataItem {
 	return DataItem{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Intorducing threshold by percentile 50, 90 and 99 for the PodStartupLatency only. The default values of the new thresholds are the "threshold" value. So this change should be no-op unless the params are used in the test configuration.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

