### PR TITLE
Clusterloader2 docs update

### DIFF
--- a/clusterloader2/docs/GETTING_STARTED.md
+++ b/clusterloader2/docs/GETTING_STARTED.md
@@ -16,10 +16,10 @@ cd perf-tests
 
 ## Install GVM
 Follow instructions on [GVM install].
-Install golang with specific version (1.15.12 was tested in this tutorial):
+Install golang with specific version (1.24.3 was tested in this tutorial):
 ```bash
-gvm install go1.15.12
-gvm use go1.15.12
+gvm install go1.24.3
+gvm use go1.24.3
 ```
 Next, add perf-tests repository to GOPATH:
 
@@ -30,9 +30,9 @@ gvm linkthis k8s.io/perf-tests
 ## Create cluster using kind
 Follow the [kind installation][Kind install] guide.
 
-Create cluster v1.21.1 with one master and one node:
+Create cluster v1.27.3 with one master and one node:
 ```bash
-kind create cluster --image=kindest/node:v1.21.1 --name=test-cluster --wait=5m
+kind create cluster --image=kindest/node:v1.27.3 --name=test-cluster --wait=5m
 ```
 
 This command additionally generates cluster access credentials which are


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind documentation


#### What this PR does / why we need it:
Updates versions of go and cluster to work with modern environments (tested 6/3/2025 on an Ubuntu 24.04.2 LTS install)

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
Previous versions (go1.15.21 and cluster v1.21.1) were failing for various steps (installing kind for go 1.15.21, and kind create cluster was failing for cluster v1.21.1)
