### PR TITLE
Fix for the coredns configmap update: the corefile was not updated, e…

### DIFF
--- a/dns/py/params.py
+++ b/dns/py/params.py
@@ -160,7 +160,11 @@ class CorednsCache(Param):
   def set(self, inputs, value):
     if value > 0:
       cf = inputs.configmap_yaml['data']['Corefile']
-      cfList = cf.decode().split("\n")
+      # fix the cf type so that it works also for python3
+      if(type(cf) == str):
+        cfList = cf.split("\n")
+      else:
+        cfList = cf.decode().split("\n")
       cfList.insert(1,
                     "  cache {\n"
                     "    success " + repr(value) + "\n"

--- a/dns/py/runner.py
+++ b/dns/py/runner.py
@@ -124,7 +124,7 @@ class Runner(object):
             self._create(inputs.deployment_yaml)
             self._create(self.service_yaml)
             if self.configmap_yaml is not None:
-              self._create(self.configmap_yaml)
+              self._create(inputs.configmap_yaml)
             self._wait_for_status(True)
           test_threads=[]
           #Spawn off a thread to run the test case in each client pod simultaneously.


### PR DESCRIPTION
…ven though a different cache size is set up in the test parameters.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug

Optionally add one or more of the following kinds if applicable:
/kind flake
-->

#### What this PR does / why we need it:
When test GKE DNS performance with the auto creation of dns-perf-server, the coredns configmap corefile was not updated even if different cache size was set as parameters. This change should fix the coredns configmap update, and enable the test can also be run on python3.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

