### PR TITLE
feat: support cluster-scoped objs in wait_for_generic_k8s_object

### DIFF
--- a/clusterloader2/pkg/measurement/common/wait_for_generic_k8s_object.go
+++ b/clusterloader2/pkg/measurement/common/wait_for_generic_k8s_object.go
@@ -133,6 +133,12 @@ func getGroupVersionResource(params map[string]interface{}) (schema.GroupVersion
 func getNamespaces(namespacesPrefix string, params map[string]interface{}) (measurementutil.NamespacesRange, error) {
 	namespaceRange, err := util.GetMap(params, "namespaceRange")
 	if err != nil {
+		if util.IsErrKeyNotFound(err) {
+			// If not provided, assume waiting for cluster-scoped objects.
+			return measurementutil.NamespacesRange{
+				Prefix: "",
+			}, nil
+		}
 		return measurementutil.NamespacesRange{}, err
 	}
 	minParam, err := util.GetInt(namespaceRange, "min")

--- a/clusterloader2/pkg/measurement/util/wait_for_conditions.go
+++ b/clusterloader2/pkg/measurement/util/wait_for_conditions.go
@@ -65,12 +65,19 @@ func (o *WaitForGenericK8sObjectsOptions) Summary() string {
 
 // String returns printable representation of the namespaces range.
 func (nr *NamespacesRange) String() string {
+	if nr.Prefix == "" {
+		return ""
+	}
 	return fmt.Sprintf("%s-(%d-%d)", nr.Prefix, nr.Min, nr.Max)
 }
 
 // getMap returns a map with namespaces which should be queried.
 func (nr *NamespacesRange) getMap() map[string]bool {
 	result := map[string]bool{}
+	if nr.Prefix == "" {
+		result[""] = true // Cluster-scoped objects.
+		return result
+	}
 	for i := nr.Min; i <= nr.Max; i++ {
 		result[fmt.Sprintf("%s-%d", nr.Prefix, i)] = true
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Current `wait_for_generic_k8s_object` measurement does not support cluster-scoped objects. This simple PR enables it by allowing `namespaceRange` to NOT be specified and treating such objs as cluster-scoped.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

