### PR TITLE
use GenericPrometheusQuery to get scheduler numbers instead of Schedu…

### DIFF
--- a/clusterloader2/testing/dra/README.md
+++ b/clusterloader2/testing/dra/README.md
@@ -22,11 +22,17 @@ export CL2_FILL_PERCENTAGE=90        # Cluster fill percentage
 
 2. Run the test with:
 ```
+# Make sure a Prometheus stack is deployed so that metric-based measurements work.
+# The easiest way is to pass `--enable-prometheus-server=true` to ClusterLoader2.
+# (This flag deploys the Prometheus Operator and the standard monitoring stack
+#   using the manifests from `pkg/prometheus/manifests`.)
+
 ./run-e2e.sh cluster-loader2 \
 --provider=kind \
 --kubeconfig=/root/.kube/config \
 --report-dir=/tmp/clusterloader2-results \
 --testconfig=testing/dra/config.yaml \
+--enable-prometheus-server=true \
 --nodes=5
 ```
 

--- a/clusterloader2/testing/dra/config.yaml
+++ b/clusterloader2/testing/dra/config.yaml
@@ -45,73 +45,154 @@ dependencies:
 steps:
 - name: Start measurements
   measurements:
-  - Identifier: WaitForFinishedJobs
-    Method: WaitForFinishedJobs
-    Params:
-      action: start
-      labelSelector: job-type = short-lived
-  - Identifier: WaitForControlledPodsRunning
-    Method: WaitForControlledPodsRunning
-    Params:
-      action: start
-      apiVersion: batch/v1
-      kind: Job
-      labelSelector: job-type = long-running
-      operationTimeout: 120s
-  - Identifier: FastFillSchedulingMetrics
-    Method: SchedulingMetrics
-    Params:
-      action: start
-  - Identifier: FastFillPodStartupLatency
-    Method: PodStartupLatency
-    Params:
-      action: start
-      labelSelector: job-type = long-running
-      threshold: 20s
-- name: Clearing SchedulingMetrics
-  measurements:
-  - Identifier: FastFillSchedulingMetrics
-    Method: SchedulingMetrics
-    Params:
-      action: reset
+    - Identifier: WaitForFinishedJobs
+      Method: WaitForFinishedJobs
+      Params:
+        action: start
+        labelSelector: job-type = short-lived
+    - Identifier: WaitForControlledPodsRunning
+      Method: WaitForControlledPodsRunning
+      Params:
+        action: start
+        apiVersion: batch/v1
+        kind: Job
+        labelSelector: job-type = long-running
+        operationTimeout: 120s
+    - Identifier: FastFillPodStartupLatency
+      Method: PodStartupLatency
+      Params:
+        action: start
+        labelSelector: job-type = long-running
+    - Identifier: FastFillSchedulingMetrics
+      Method: GenericPrometheusQuery
+      Params:
+        action: start
+        metricName: fastfill_scheduler_latency
+        metricVersion: v1
+        unit: seconds
+        dimensions:
+        - extension_point
+        queries:
+        # E2E scheduling latency
+        - name: E2E_P50
+          query: histogram_quantile(0.50,
+                  sum(rate(scheduler_e2e_scheduling_duration_seconds_bucket[%v])) by (le))
+        - name: E2E_P90
+          query: histogram_quantile(0.90,
+                  sum(rate(scheduler_e2e_scheduling_duration_seconds_bucket[%v])) by (le))
+        - name: E2E_P99
+          query: histogram_quantile(0.99,
+                  sum(rate(scheduler_e2e_scheduling_duration_seconds_bucket[%v])) by (le))
+        # Scheduling-algorithm latency
+        - name: Algorithm_P50
+          query: histogram_quantile(0.50,
+                  sum(rate(scheduler_scheduling_algorithm_duration_seconds_bucket[%v])) by (le))
+        - name: Algorithm_P90
+          query: histogram_quantile(0.90,
+                  sum(rate(scheduler_scheduling_algorithm_duration_seconds_bucket[%v])) by (le))
+        - name: Algorithm_P99
+          query: histogram_quantile(0.99,
+                  sum(rate(scheduler_scheduling_algorithm_duration_seconds_bucket[%v])) by (le))
+        # Pre-emption evaluation latency
+        - name: Preemption_P50
+          query: histogram_quantile(0.50,
+                  sum(rate(scheduler_scheduling_algorithm_preemption_evaluation_seconds_bucket[%v])) by (le))
+        - name: Preemption_P90
+          query: histogram_quantile(0.90,
+                  sum(rate(scheduler_scheduling_algorithm_preemption_evaluation_seconds_bucket[%v])) by (le))
+        - name: Preemption_P99
+          query: histogram_quantile(0.99,
+                  sum(rate(scheduler_scheduling_algorithm_preemption_evaluation_seconds_bucket[%v])) by (le))
+        # Framework extension point latency (reported per extension_point label)
+        - name: FrameworkDuration_P50
+          query: histogram_quantile(0.50,
+                  sum(rate(scheduler_framework_extension_point_duration_seconds_bucket[%v])) by (le,extension_point))
+        - name: FrameworkDuration_P90
+          query: histogram_quantile(0.90,
+                  sum(rate(scheduler_framework_extension_point_duration_seconds_bucket[%v])) by (le,extension_point))
+        - name: FrameworkDuration_P99
+          query: histogram_quantile(0.99,
+                  sum(rate(scheduler_framework_extension_point_duration_seconds_bucket[%v])) by (le,extension_point))
 - name: Create ResourceClaimTemplates in namespaces
   phases:
-  - namespaceRange:
-      min: 1
-      max: {{$namespaces}}
-    replicasPerNamespace: 1
-    tuningSet: FastFill
-    objectBundle:
-    - basename: single-gpu
-      objectTemplatePath: "resourceclaimtemplate.yaml"
+    - namespaceRange:
+        min: 1
+        max: {{$namespaces}}
+      replicasPerNamespace: 1
+      tuningSet: FastFill
+      objectBundle:
+      - basename: single-gpu
+        objectTemplatePath: "resourceclaimtemplate.yaml"
 - name: Fill cluster to {{$fillPercentage}}% utilization
   phases:
-  - namespaceRange:
-      min: 1
-      max: {{$namespaces}}
-    replicasPerNamespace: {{$fillPodsPerNamespace}}
-    tuningSet: FastFill
-    objectBundle:
-    - basename: long-running
-      objectTemplatePath: "long-running-job.yaml"
-      templateFillMap:
-        Replicas: {{$longJobSize}}
-        Mode: {{$MODE}}
-        Sleep: {{$longJobRunningTime}}
+    - namespaceRange:
+        min: 1
+        max: {{$namespaces}}
+      replicasPerNamespace: {{$fillPodsPerNamespace}}
+      tuningSet: FastFill
+      objectBundle:
+      - basename: long-running
+        objectTemplatePath: "long-running-job.yaml"
+        templateFillMap:
+          Replicas: {{$longJobSize}}
+          Mode: {{$MODE}}
+          Sleep: {{$longJobRunningTime}}
 - name: Wait for fill pods to be running
   measurements:
-  - Identifier: WaitForControlledPodsRunning
-    Method: WaitForControlledPodsRunning
-    Params:
-      action: gather
-      labelSelector: job-type = long-running
-      timeout: 15m
+    - Identifier: WaitForControlledPodsRunning
+      Method: WaitForControlledPodsRunning
+      Params:
+        action: gather
+        labelSelector: job-type = long-running
+        timeout: 15m
 - name: Gather measurements for long running pods
   measurements:
     - Identifier: FastFillSchedulingMetrics
-      Method: SchedulingMetrics
+      Method: GenericPrometheusQuery
       Params:
         action: gather
+        metricName: fastfill_scheduler_latency
+        metricVersion: v1
+        unit: seconds
+        dimensions:
+        - extension_point
+        queries:
+        - name: E2E_P50
+          query: histogram_quantile(0.50,
+                  sum(rate(scheduler_e2e_scheduling_duration_seconds_bucket[%v])) by (le))
+        - name: E2E_P90
+          query: histogram_quantile(0.90,
+                  sum(rate(scheduler_e2e_scheduling_duration_seconds_bucket[%v])) by (le))
+        - name: E2E_P99
+          query: histogram_quantile(0.99,
+                  sum(rate(scheduler_e2e_scheduling_duration_seconds_bucket[%v])) by (le))
+        - name: Algorithm_P50
+          query: histogram_quantile(0.50,
+                  sum(rate(scheduler_scheduling_algorithm_duration_seconds_bucket[%v])) by (le))
+        - name: Algorithm_P90
+          query: histogram_quantile(0.90,
+                  sum(rate(scheduler_scheduling_algorithm_duration_seconds_bucket[%v])) by (le))
+        - name: Algorithm_P99
+          query: histogram_quantile(0.99,
+                  sum(rate(scheduler_scheduling_algorithm_duration_seconds_bucket[%v])) by (le))
+        - name: Preemption_P50
+          query: histogram_quantile(0.50,
+                  sum(rate(scheduler_scheduling_algorithm_preemption_evaluation_seconds_bucket[%v])) by (le))
+        - name: Preemption_P90
+          query: histogram_quantile(0.90,
+                  sum(rate(scheduler_scheduling_algorithm_preemption_evaluation_seconds_bucket[%v])) by (le))
+        - name: Preemption_P99
+          query: histogram_quantile(0.99,
+                  sum(rate(scheduler_scheduling_algorithm_preemption_evaluation_seconds_bucket[%v])) by (le))
+        - name: FrameworkDuration_P50
+          query: histogram_quantile(0.50,
+                  sum(rate(scheduler_framework_extension_point_duration_seconds_bucket[%v])) by (le,extension_point))
+        - name: FrameworkDuration_P90
+          query: histogram_quantile(0.90,
+                  sum(rate(scheduler_framework_extension_point_duration_seconds_bucket[%v])) by (le,extension_point))
+        - name: FrameworkDuration_P99
+          query: histogram_quantile(0.99,
+                  sum(rate(scheduler_framework_extension_point_duration_seconds_bucket[%v])) by (le,extension_point))
     - Identifier: FastFillPodStartupLatency
       Method: PodStartupLatency
       Params:
@@ -119,13 +200,51 @@ steps:
 - name: reset metrics for steady state churn
   measurements:
     - Identifier: ChurnSchedulingMetrics
-      Method: SchedulingMetrics
+      Method: GenericPrometheusQuery
       Params:
         action: start
-    - Identifier: ChurnSchedulingMetrics
-      Method: SchedulingMetrics
-      Params:
-        action: reset
+        metricName: churn_scheduler_latency
+        metricVersion: v1
+        unit: seconds
+        dimensions:
+        - extension_point
+        queries:
+        - name: E2E_P50
+          query: histogram_quantile(0.50,
+                  sum(rate(scheduler_e2e_scheduling_duration_seconds_bucket[%v])) by (le))
+        - name: E2E_P90
+          query: histogram_quantile(0.90,
+                  sum(rate(scheduler_e2e_scheduling_duration_seconds_bucket[%v])) by (le))
+        - name: E2E_P99
+          query: histogram_quantile(0.99,
+                  sum(rate(scheduler_e2e_scheduling_duration_seconds_bucket[%v])) by (le))
+        - name: Algorithm_P50
+          query: histogram_quantile(0.50,
+                  sum(rate(scheduler_scheduling_algorithm_duration_seconds_bucket[%v])) by (le))
+        - name: Algorithm_P90
+          query: histogram_quantile(0.90,
+                  sum(rate(scheduler_scheduling_algorithm_duration_seconds_bucket[%v])) by (le))
+        - name: Algorithm_P99
+          query: histogram_quantile(0.99,
+                  sum(rate(scheduler_scheduling_algorithm_duration_seconds_bucket[%v])) by (le))
+        - name: Preemption_P50
+          query: histogram_quantile(0.50,
+                  sum(rate(scheduler_scheduling_algorithm_preemption_evaluation_seconds_bucket[%v])) by (le))
+        - name: Preemption_P90
+          query: histogram_quantile(0.90,
+                  sum(rate(scheduler_scheduling_algorithm_preemption_evaluation_seconds_bucket[%v])) by (le))
+        - name: Preemption_P99
+          query: histogram_quantile(0.99,
+                  sum(rate(scheduler_scheduling_algorithm_preemption_evaluation_seconds_bucket[%v])) by (le))
+        - name: FrameworkDuration_P50
+          query: histogram_quantile(0.50,
+                  sum(rate(scheduler_framework_extension_point_duration_seconds_bucket[%v])) by (le,extension_point))
+        - name: FrameworkDuration_P90
+          query: histogram_quantile(0.90,
+                  sum(rate(scheduler_framework_extension_point_duration_seconds_bucket[%v])) by (le,extension_point))
+        - name: FrameworkDuration_P99
+          query: histogram_quantile(0.99,
+                  sum(rate(scheduler_framework_extension_point_duration_seconds_bucket[%v])) by (le,extension_point))
     - Identifier: ChurnPodStartupLatency
       Method: PodStartupLatency
       Params:
@@ -136,19 +255,19 @@ steps:
         perc99Threshold: 80s
 - name: Create steady state {{$MODE}} jobs
   phases:
-  - namespaceRange:
-      min: 1
-      max: {{$namespaces}}
-    replicasPerNamespace: {{$smallJobsPerNamespace}}
-    tuningSet: SteadyState
-    objectBundle:
-    - basename: small
-      objectTemplatePath: "job.yaml"
-      templateFillMap:
-        Replicas: {{$smallJobSize}}
-        CompletionReplicas: {{$smallJobCompletions}}
-        Mode: {{$MODE}}
-        Sleep: {{$jobRunningTime}}
+    - namespaceRange:
+        min: 1
+        max: {{$namespaces}}
+      replicasPerNamespace: {{$smallJobsPerNamespace}}
+      tuningSet: SteadyState
+      objectBundle:
+      - basename: small
+        objectTemplatePath: "job.yaml"
+        templateFillMap:
+          Replicas: {{$smallJobSize}}
+          CompletionReplicas: {{$smallJobCompletions}}
+          Mode: {{$MODE}}
+          Sleep: {{$jobRunningTime}}
 - name: Wait for short-lived jobs to finish
   measurements:
     - Identifier: WaitForFinishedJobs
@@ -159,14 +278,56 @@ steps:
         timeout: 15m
 - name: Measure scheduler metrics
   measurements:
-  - Identifier: ChurnSchedulingMetrics
-    Method: SchedulingMetrics
-    Params:
-      action: gather
-  - Identifier: ChurnPodStartupLatency
-    Method: PodStartupLatency
-    Params:
-      action: gather
-      perc50Threshold: 40s
-      perc90Threshold: 60s
-      perc99Threshold: 80s
+    - Identifier: ChurnSchedulingMetrics
+      Method: GenericPrometheusQuery
+      Params:
+        action: gather
+        metricName: churn_scheduler_latency
+        metricVersion: v1
+        unit: seconds
+        dimensions:
+        - extension_point
+        queries:
+        - name: E2E_P50
+          query: histogram_quantile(0.50,
+                  sum(rate(scheduler_e2e_scheduling_duration_seconds_bucket[%v])) by (le))
+        - name: E2E_P90
+          query: histogram_quantile(0.90,
+                  sum(rate(scheduler_e2e_scheduling_duration_seconds_bucket[%v])) by (le))
+        - name: E2E_P99
+          query: histogram_quantile(0.99,
+                  sum(rate(scheduler_e2e_scheduling_duration_seconds_bucket[%v])) by (le))
+        - name: Algorithm_P50
+          query: histogram_quantile(0.50,
+                  sum(rate(scheduler_scheduling_algorithm_duration_seconds_bucket[%v])) by (le))
+        - name: Algorithm_P90
+          query: histogram_quantile(0.90,
+                  sum(rate(scheduler_scheduling_algorithm_duration_seconds_bucket[%v])) by (le))
+        - name: Algorithm_P99
+          query: histogram_quantile(0.99,
+                  sum(rate(scheduler_scheduling_algorithm_duration_seconds_bucket[%v])) by (le))
+        - name: Preemption_P50
+          query: histogram_quantile(0.50,
+                  sum(rate(scheduler_scheduling_algorithm_preemption_evaluation_seconds_bucket[%v])) by (le))
+        - name: Preemption_P90
+          query: histogram_quantile(0.90,
+                  sum(rate(scheduler_scheduling_algorithm_preemption_evaluation_seconds_bucket[%v])) by (le))
+        - name: Preemption_P99
+          query: histogram_quantile(0.99,
+                  sum(rate(scheduler_scheduling_algorithm_preemption_evaluation_seconds_bucket[%v])) by (le))
+        - name: FrameworkDuration_P50
+          query: histogram_quantile(0.50,
+                  sum(rate(scheduler_framework_extension_point_duration_seconds_bucket[%v])) by (le,extension_point))
+        - name: FrameworkDuration_P90
+          query: histogram_quantile(0.90,
+                  sum(rate(scheduler_framework_extension_point_duration_seconds_bucket[%v])) by (le,extension_point))
+        - name: FrameworkDuration_P99
+          query: histogram_quantile(0.99,
+                  sum(rate(scheduler_framework_extension_point_duration_seconds_bucket[%v])) by (le,extension_point))
+    - Identifier: ChurnPodStartupLatency
+      Method: PodStartupLatency
+      Params:
+        action: gather
+        perc50Threshold: 40s
+        perc90Threshold: 60s
+        perc99Threshold: 80s


### PR DESCRIPTION
…lingMetrics

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

This PR removes using SchedulingMetrics Measurement for DRA test job.

It instead uses GenericPrometheusQuery to get the same numbers as SchedulingMetrics

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

