### PR TITLE
tuningSet: fix TimeLimitedLoad for zero actions

### DIFF
--- a/clusterloader2/pkg/tuningset/time_limited.go
+++ b/clusterloader2/pkg/tuningset/time_limited.go
@@ -34,6 +34,9 @@ func newTimeLimitedLoad(params *api.TimeLimitedLoad) TuningSet {
 }
 
 func (t *timeLimitedLoad) Execute(actions []func()) {
+	if len(actions) == 0 {
+		return
+	}
 	sleepDuration := time.Duration(t.params.TimeLimit.ToTimeDuration().Nanoseconds() / int64(len(actions)))
 	var wg wait.Group
 	for i := range actions {


### PR DESCRIPTION
When creating a scale test that scales with number of nodes, it's possible that for small scale clusters some of the objects are not created, resulting in number of actions equal to zero for specific phase. For TimeLimitedLoad it caused panic due to division by zero.

/kind bug

