### PR TITLE
Upgrade netperf test docker file go version and disable cgo

### DIFF
--- a/network/benchmarks/netperf/Dockerfile
+++ b/network/benchmarks/netperf/Dockerfile
@@ -21,15 +21,15 @@
 #
 # Args: --mode=worker --host=<service cluster ip> --port=5202
 #
-ARG GOLANG_VERSION=1.18
-FROM golang:${GOLANG_VERSION} as builder
+ARG GOLANG_VERSION=1.24
+FROM golang:${GOLANG_VERSION} AS builder
 WORKDIR /workspace
 
 COPY nptest/nptest.go nptest.go
 COPY go.sum go.sum
 COPY go.mod go.mod
 
-RUN go build -o nptests
+RUN CGO_ENABLED=0 go build -o nptests
 
 FROM debian:bullseye
 ENV LD_LIBRARY_PATH=/usr/local/lib


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
1. the go version in go.mod is already 1.24, and the default version in dockerfile is still 1.18
2. After I built and ran it, I got an error saying version `GLIBC_2.32' not found, so I set enable_cgo=0
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

