### PR TITLE
add dra-baseline tests with workloads without resourceclaims

### DIFF
--- a/clusterloader2/testing/dra-baseline/README.md
+++ b/clusterloader2/testing/dra-baseline/README.md
@@ -1,0 +1,64 @@
+(8000 m – 80 m) / 8 ≈ 990 m CPU
+```
+
+##### 2  Run the test
+
+```bash
+# Ensure a Prometheus stack is running so metric-based measurements succeed.
+
+./run-e2e.sh cluster-loader2 \
+  --provider=kind \
+  --kubeconfig=$HOME/.kube/config \
+  --report-dir=/tmp/clusterloader2-results \
+  --testconfig=testing/dra-baseline/config.yaml \
+  --enable-prometheus-server=true \
+  --nodes=1        # adjust to match your cluster size
+```
+
+##### What the test does
+
+1. Calculates per-pod CPU from node capacity and `CL2_PODS_PER_NODE`.
+2. Fills each node to ~90 % CPU utilisation with long-running Jobs.
+3. Waits until all fill pods are running, then gathers startup & scheduler metrics.
+4. Resets metrics and runs short-lived Jobs (churn) that consume the remaining capacity.
+5. Gathers the same metrics for the churn phase.
+
+Collected measurements include PodStartupLatency and Prometheus-based scheduler metrics, allowing direct comparison to the DRA test (`testing/dra/config.yaml`).
+```
+
+This mirrors the structure and tone of `testing/dra/README.md` while documenting the CPU-only baseline test and its new tunable parameters.
+
+### Usage
+
+Follow the **Getting Started** guide at `clusterloader2/docs/GETTING_STARTED.md`
+to bring up a kind cluster suitable for ClusterLoader² tests.
+
+#### Steady-State CPU Baseline Test
+
+This scenario saturates each worker node to ≈ 90 % of its *effective* CPU
+capacity with long-running pods and then measures scheduler performance while
+continuously creating short-lived pods that consume the remaining 10 %.
+
+Unlike the original `testing/dra/` test, **no Device Resource Allocation
+(ResourceClaims) are used**—each pod simply requests CPU and memory.  
+This provides a clean baseline for comparing DRA overhead.
+
+---
+
+##### 1  Environment variables
+
+```bash
+export CL2_MODE=Indexed                # Job completion mode (Indexed/NonIndexed)
+export CL2_NODES_PER_NAMESPACE=1       # 1 namespace per node
+export CL2_PODS_PER_NODE=8             # target pods per node
+export CL2_NODE_AVAILABLE_MILLICORES=8000   # node allocatable CPU
+export CL2_SYSTEM_USED_MILLICORES=80        # CPU already used by system pods
+export CL2_FILL_PERCENTAGE=90          # % of capacity for long-running pods
+export CL2_LOAD_TEST_THROUGHPUT=20     # QPS for the fast fill phase
+export CL2_STEADY_STATE_QPS=5          # QPS for steady-state churn
+export CL2_LONG_JOB_RUNNING_TIME=1h    # runtime of long-running pods
+export CL2_JOB_RUNNING_TIME=30s        # runtime of short-lived pods
+export CL2_POD_MEMORY=128Mi            # memory request per pod
+```
+
+With the defaults above, each pod will request 

--- a/clusterloader2/testing/dra-baseline/config.yaml
+++ b/clusterloader2/testing/dra-baseline/config.yaml
@@ -1,0 +1,160 @@
+{{$MODE                 := DefaultParam .CL2_MODE "Indexed"}}
+{{$NODES_PER_NAMESPACE  := MinInt .Nodes (DefaultParam .CL2_NODES_PER_NAMESPACE 100)}}
+{{$LOAD_TEST_THROUGHPUT := DefaultParam .CL2_LOAD_TEST_THROUGHPUT 10}}
+{{$STEADY_STATE_QPS     := DefaultParam .CL2_STEADY_STATE_QPS 5}}
+{{$NODE_AVAILABLE_MILLICORES := DefaultParam .CL2_NODE_AVAILABLE_MILLICORES 8000}}
+{{$SYSTEM_USED_MILLICORES    := DefaultParam .CL2_SYSTEM_USED_MILLICORES     80}}
+{{$PODS_PER_NODE             := DefaultParam .CL2_PODS_PER_NODE              8}}
+{{$POD_MEMORY := DefaultParam .CL2_POD_MEMORY "128Mi"}}
+{{$CPU_AVAILABLE_PER_NODE := SubtractInt $NODE_AVAILABLE_MILLICORES $SYSTEM_USED_MILLICORES}}
+{{$POD_CPU_MILLICORES     := DivideInt   $CPU_AVAILABLE_PER_NODE $PODS_PER_NODE}}
+
+
+{{$namespaces := DivideInt .Nodes $NODES_PER_NAMESPACE}}
+
+{{$cpusPerNode := DefaultParam .CL2_CPUS_PER_NODE 8}}
+{{$totalCPUs   := MultiplyInt $cpusPerNode .Nodes}}
+
+{{$fillPercentage       := DefaultParam .CL2_FILL_PERCENTAGE 90}}
+{{$fillPodsCount        := DivideInt (MultiplyInt $totalCPUs $fillPercentage) 100}}
+{{$fillPodsPerNamespace := DivideInt $fillPodsCount $namespaces}}
+{{$longJobSize          := 1}}
+{{$longJobRunningTime   := DefaultParam .CL2_LONG_JOB_RUNNING_TIME "1h"}}
+
+{{$smallJobPodsCount     := SubtractInt $totalCPUs (MultiplyInt $fillPodsPerNamespace $namespaces)}}
+{{$smallJobsPerNamespace := DivideInt $smallJobPodsCount $namespaces}}
+{{$smallJobSize          := 1}}
+{{$smallJobCompletions   := 10}}
+{{$jobRunningTime        := DefaultParam .CL2_JOB_RUNNING_TIME "30s"}}
+
+name: dra-baseline
+
+namespace:
+  number: {{$namespaces}}
+
+tuningSets:
+- name: FastFill
+  qpsLoad:
+    qps: {{$LOAD_TEST_THROUGHPUT}}
+- name: SteadyState
+  qpsLoad:
+    qps: {{$STEADY_STATE_QPS}}
+
+steps:
+- name: Start measurements
+  measurements:
+  - Identifier: WaitForFinishedJobs
+    Method: WaitForFinishedJobs
+    Params:
+      action: start
+      labelSelector: job-type = short-lived
+  - Identifier: WaitForControlledPodsRunning
+    Method: WaitForControlledPodsRunning
+    Params:
+      action: start
+      apiVersion: batch/v1
+      kind: Job
+      labelSelector: job-type = long-running
+      operationTimeout: 120s
+  - Identifier: FastFillPodStartupLatency
+    Method: PodStartupLatency
+    Params:
+      action: start
+      labelSelector: job-type = long-running
+  - Identifier: FastFillSchedulingMetrics
+    Method: PrometheusSchedulingMetrics
+    Params:
+      action: start
+
+- name: Fill cluster to {{$fillPercentage}}% utilisation
+  phases:
+  - namespaceRange:
+      min: 1
+      max: {{$namespaces}}
+    replicasPerNamespace: {{$fillPodsPerNamespace}}
+    tuningSet: FastFill
+    objectBundle:
+    - basename: long-running
+      objectTemplatePath: "long-running-job.yaml"
+      templateFillMap:
+        Replicas: {{$longJobSize}}
+        Mode: {{$MODE}}
+        Sleep: {{$longJobRunningTime}}
+        CPUMilli: {{$POD_CPU_MILLICORES}}
+        Memory:   {{$POD_MEMORY}}
+
+- name: Wait for fill pods to be running
+  measurements:
+  - Identifier: WaitForControlledPodsRunning
+    Method: WaitForControlledPodsRunning
+    Params:
+      action: gather
+      labelSelector: job-type = long-running
+      timeout: 15m
+
+- name: Gather measurements for long running pods
+  measurements:
+  - Identifier: FastFillSchedulingMetrics
+    Method: PrometheusSchedulingMetrics
+    Params:
+      action: gather
+  - Identifier: FastFillPodStartupLatency
+    Method: PodStartupLatency
+    Params:
+      action: gather
+
+- name: reset metrics for steady state churn
+  measurements:
+  - Identifier: ChurnSchedulingMetrics
+    Method: PrometheusSchedulingMetrics
+    Params:
+      action: start
+  - Identifier: ChurnPodStartupLatency
+    Method: PodStartupLatency
+    Params:
+      action: start
+      labelSelector: job-type = short-lived
+      perc50Threshold: 40s
+      perc90Threshold: 60s
+      perc99Threshold: 80s
+
+- name: Create steady state {{$MODE}} jobs
+  phases:
+  - namespaceRange:
+      min: 1
+      max: {{$namespaces}}
+    replicasPerNamespace: {{$smallJobsPerNamespace}}
+    tuningSet: SteadyState
+    objectBundle:
+    - basename: small
+      objectTemplatePath: "job.yaml"
+      templateFillMap:
+        Replicas: {{$smallJobSize}}
+        CompletionReplicas: {{$smallJobCompletions}}
+        Mode: {{$MODE}}
+        Sleep: {{$jobRunningTime}}
+        CPUMilli: {{$POD_CPU_MILLICORES}}
+        Memory:   {{$POD_MEMORY}}
+
+- name: Wait for short-lived jobs to finish
+  measurements:
+  - Identifier: WaitForFinishedJobs
+    Method: WaitForFinishedJobs
+    Params:
+      action: gather
+      labelSelector: job-type = short-lived
+      timeout: 15m
+
+- name: Measure scheduler metrics
+  measurements:
+  - Identifier: ChurnSchedulingMetrics
+    Method: PrometheusSchedulingMetrics
+    Params:
+      action: gather
+  - Identifier: ChurnPodStartupLatency
+    Method: PodStartupLatency
+    Params:
+      action: gather
+      perc50Threshold: 40s
+      perc90Threshold: 60s
+      perc99Threshold: 80s 

--- a/clusterloader2/testing/dra-baseline/job.yaml
+++ b/clusterloader2/testing/dra-baseline/job.yaml
@@ -1,0 +1,27 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{.Name}}
+  labels:
+    group: baseline-job
+    job-type: short-lived
+spec:
+  parallelism: {{.Replicas}}
+  completions: {{.CompletionReplicas}}
+  completionMode: {{.Mode}}
+  ttlSecondsAfterFinished: 300
+  template:
+    metadata:
+      labels:
+        group: baseline-pod
+        job-type: short-lived
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: {{.Name}}
+        image: gcr.io/k8s-staging-perf-tests/sleep:v0.0.3
+        args: ["{{.Sleep}}"]
+        resources:
+          requests:
+            cpu: "{{.CPUMilli}}m"
+            memory: "{{.Memory}}"

--- a/clusterloader2/testing/dra-baseline/long-running-job.yaml
+++ b/clusterloader2/testing/dra-baseline/long-running-job.yaml
@@ -1,0 +1,27 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{.Name}}
+  labels:
+    group: baseline-job
+    job-type: long-running
+spec:
+  parallelism: {{.Replicas}}
+  completions: {{.Replicas}}
+  completionMode: {{.Mode}}
+  activeDeadlineSeconds: 86400   # 24 h
+  template:
+    metadata:
+      labels:
+        group: baseline-pod
+        job-type: long-running
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: {{.Name}}
+        image: gcr.io/k8s-staging-perf-tests/sleep:v0.0.3
+        args: ["{{.Sleep}}"]
+        resources:
+          requests:
+            cpu: "{{.CPUMilli}}m"
+            memory: "{{.Memory}}"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR adds test such that 90% of available CPU in the cluster is first saturated and then 10% remaining CPU is used by pods that are churned for 10 times. 

This creates a baseline test to compare how cluster performs with and without DRA

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

