### PR TITLE
Bump version of go compiler that bootstraps golang tip test to 1.25.0

### DIFF
--- a/golang/Makefile
+++ b/golang/Makefile
@@ -15,7 +15,7 @@
 .PHONY: build-go build push
 
 export GCS_BUCKET?=k8s-infra-scale-golang-builds
-export GO_COMPILER_PKG?=go1.24.6.linux-amd64.tar.gz
+export GO_COMPILER_PKG?=go1.25.6.linux-amd64.tar.gz
 export GO_COMPILER_URL?=https://dl.google.com/go/$(GO_COMPILER_PKG)
 export ROOT_DIR?=/home/prow/go/src
 


### PR DESCRIPTION
This change updates the golang version preemptively, before golang1.25 will become un-buildable with 1.24

This is a rhythmical update. Prev instance: https://github.com/kubernetes/perf-tests/pull/3238

/assign @mborsz