### PR TITLE
Add wait for ingress deletion in NEG test

### DIFF
--- a/clusterloader2/testing/neg/config.yaml
+++ b/clusterloader2/testing/neg/config.yaml
@@ -119,6 +119,10 @@ steps:
     Method: WaitForControlledPodsRunning
     Params:
       action: gather
+- module:
+    path: /modules/ingress-measurements.yaml
+    params:
+      action: waitForDeletion
 - name: Wait after deletion
   measurements:
     - Identifier: Wait


### PR DESCRIPTION
What type of PR is this?
/kind bug
/kind flake

What this PR does / why we need it
- Ensures NEG tests wait until all Ingress resources are actually deleted before proceeding, reducing end-of-test flakiness.
- Handles immediate deletions where `DeletionTimestamp` may be nil by recording deletion phases using a local timestamp fallback, so deletion latency is tracked consistently.

Changes
- Add explicit wait for Ingress deletion in the NEG test flow:
  - `clusterloader2/testing/neg/config.yaml:125`
    - Add module step invoking `ingress-measurements.yaml` with `action: waitForDeletion`.
- Record delete phases even when `DeletionTimestamp` is nil:
  - `clusterloader2/pkg/measurement/common/service_creation_latency.go:365`
    - Service deletion: set `deleting` from `DeletionTimestamp` when present; otherwise use `time.Now()`. Always set `deleted` to `time.Now()`.
  - `clusterloader2/pkg/measurement/common/service_creation_latency.go:383`
    - Ingress deletion: same behavior as Services.

Which issue(s) this PR fixes
Fixes #

- This aligns NEG cleanup with L4LB tests, which already wait for deletion, making behavior consistent.
- Mixed time sources: creation uses server time; deletion fallback uses `time.Now()`. Negative latencies are already clamped to zero in `phase_latency.go`, so this remains safe, but be aware of potential minor clock skew when interpreting results.

Release note
```release-note
ClusterLoader2: Ensure NEG tests wait for Ingress deletions before finalizing. ServiceCreationLatency now records deletion phases even when DeletionTimestamp is nil, improving reliability of deletion tracking and reducing test flakiness.
```

