### PR TITLE
Move retryable error checks in `RetryFunction` after user retry options

### DIFF
--- a/clusterloader2/pkg/framework/client/objects.go
+++ b/clusterloader2/pkg/framework/client/objects.go
@@ -144,9 +144,6 @@ func RetryFunction(f func() error, options ...*APICallOptions) wait.ConditionFun
 		if err == nil {
 			return true, nil
 		}
-		if IsRetryableAPIError(err) || IsRetryableNetError(err) {
-			return false, nil
-		}
 		for _, shouldAllowError := range shouldAllowErrorFuncs {
 			if shouldAllowError(err) {
 				return true, nil
@@ -156,6 +153,9 @@ func RetryFunction(f func() error, options ...*APICallOptions) wait.ConditionFun
 			if shouldRetryError(err) {
 				return false, nil
 			}
+		}
+		if IsRetryableAPIError(err) || IsRetryableNetError(err) {
+			return false, nil
 		}
 		return false, err
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

Previously, `RetryFunction` checked for retryable API and network errors before applying user-provided retry options. This ordering made it impossible to configure certain behaviors, such as allowing a `500 Internal Server Error` without triggering a retry. This behavior once interfered with a performance test by automatically retrying on server errors, resulting in a QPS far higher than configured.

After this PR is merged, checks for retryable errors in `RetryFunction` will be performed after evaluating user-provided retry options, allowing those options to override the default retry behavior when desired.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

N/A

#### Special notes for your reviewer:

N/A