### PR TITLE
Fix `Framework.{Patch,Delete,Get}Object` methods not passing `APICallOptions` to the underlying client methods

### DIFF
--- a/clusterloader2/pkg/framework/framework.go
+++ b/clusterloader2/pkg/framework/framework.go
@@ -255,18 +255,18 @@ func (f *Framework) CreateObject(namespace string, name string, obj *unstructure
 }
 
 // PatchObject updates object (using patch) with given name using given object description.
-func (f *Framework) PatchObject(namespace string, name string, obj *unstructured.Unstructured, _ ...*client.APICallOptions) error {
-	return client.PatchObject(f.dynamicClients.GetClient(), namespace, name, obj)
+func (f *Framework) PatchObject(namespace string, name string, obj *unstructured.Unstructured, options ...*client.APICallOptions) error {
+	return client.PatchObject(f.dynamicClients.GetClient(), namespace, name, obj, options...)
 }
 
 // DeleteObject deletes object with given name and group-version-kind.
-func (f *Framework) DeleteObject(gvk schema.GroupVersionKind, namespace string, name string, _ ...*client.APICallOptions) error {
-	return client.DeleteObject(f.dynamicClients.GetClient(), gvk, namespace, name)
+func (f *Framework) DeleteObject(gvk schema.GroupVersionKind, namespace string, name string, options ...*client.APICallOptions) error {
+	return client.DeleteObject(f.dynamicClients.GetClient(), gvk, namespace, name, options...)
 }
 
 // GetObject retrieves object with given name and group-version-kind.
-func (f *Framework) GetObject(gvk schema.GroupVersionKind, namespace string, name string, _ ...*client.APICallOptions) (*unstructured.Unstructured, error) {
-	return client.GetObject(f.dynamicClients.GetClient(), gvk, namespace, name)
+func (f *Framework) GetObject(gvk schema.GroupVersionKind, namespace string, name string, options ...*client.APICallOptions) (*unstructured.Unstructured, error) {
+	return client.GetObject(f.dynamicClients.GetClient(), gvk, namespace, name, options...)
 }
 
 // ApplyTemplatedManifests finds and applies all manifest template files matching the provided


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:

In [`k8s.io/clusterloader2/pkg/framework.(*Framework).{Patch,Delete,Get}Object`](https://github.com/kubernetes/perf-tests/blob/21b588110de4b1fd9c1480c2dbd2ae85cde13b8c/clusterloader2/pkg/framework/framework.go#L257-L270), the final `options` parameter seems to be intended to be forwarded to the underlying client methods to control retry behavior (as in `CreateObject`). It wasn’t, and in a subsequent cleanup it was renamed to `_` (https://github.com/kubernetes/perf-tests/commit/dfe847f5281d074cc3f82dd39a6ab774437b4d4b). This PR plumbs options through to the client calls, restoring the expected configurable retry semantics.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
<!-- Fixes # -->

N/A

#### Special notes for your reviewer:

N/A