### PR TITLE
Add serathius to owners of list benchmark

### DIFF
--- a/clusterloader2/testing/list/OWNERS
+++ b/clusterloader2/testing/list/OWNERS
@@ -1,0 +1,2 @@
+approvers:
+- serathius


### PR DESCRIPTION
Multiple PRs are stuck in review, while the current owners are busy. As the author of the list benchmark I would be happy to help review it.