### PR TITLE
Measure resource size in load test

### DIFF
--- a/clusterloader2/testing/load/modules/measurements.yaml
+++ b/clusterloader2/testing/load/modules/measurements.yaml
@@ -247,6 +247,21 @@ steps:
       clusterOOMsTrackerEnabled: {{$ENABLE_CLUSTER_OOMS_TRACKER}}
       restartCountThresholdOverrides: {{YamlQuote $RESTART_COUNT_THRESHOLD_OVERRIDES 4}}
       enableRestartCountCheck: {{$ENABLE_RESTART_COUNT_CHECK}}
+  - Identifier: ResourceSize
+    Method: GenericPrometheusQuery
+    Params:
+      action: {{$action}}
+      metricName: ResourceSize
+      metricVersion: v1
+      unit: MiB
+      dimensions:
+      - resource
+      - group
+      queries:
+      - name: Perc99
+        query: quantile_over_time(0.99, sum by (group, resource) (apiserver_resource_size_estimate_bytes / 1024 / 1024)[%v:])
+      - name: max
+        query: max_over_time(sum by (group, resource) (apiserver_resource_size_estimate_bytes / 1024 / 1024)[%v:])
 - module:
     path: modules/dns-performance-metrics.yaml
     params:


### PR DESCRIPTION
/kind feature

Ref https://github.com/kubernetes/kubernetes/issues/134375

Make the metric to be collected by default, as it should always be available for 1.34+ and didn't find any group that would make sense.

Not sure about using percentiles, but didn't want to diverge too much from other metrics

Tested on local kind cluster and go the following results:
<details>
<summary>GenericPrometheusQuery Resource Size_load_2025-10-15T13:41:51+02:00.json</Summary>

{
  "version": "v1",
  "dataItems": [
    {
      "data": {
        "Perc50": 0.026885986328125,
        "Perc90": 0.38033294677734375,
        "Perc99": 0.38033294677734375
      },
      "unit": "MiB",
      "labels": {
        "group": "apps",
        "resource": "deployments"
      }
    },
    {
      "data": {
        "Perc50": 0.009891510009765625,
        "Perc90": 0.016356468200683594,
        "Perc99": 0.016356468200683594
      },
      "unit": "MiB",
      "labels": {
        "group": "apps",
        "resource": "statefulsets"
      }
    },
    {
      "data": {
        "Perc50": 0.0046844482421875,
        "Perc90": 0.0046844482421875,
        "Perc99": 0.0046844482421875
      },
      "unit": "MiB",
      "labels": {
        "group": "flowcontrol.apiserver.k8s.io",
        "resource": "prioritylevelconfigurations"
      }
    },
    {
      "data": {
        "Perc50": 0,
        "Perc90": 0.0029277801513671875,
        "Perc99": 0.0029277801513671875
      },
      "unit": "MiB",
      "labels": {
        "group": "batch",
        "resource": "jobs"
      }
    },
    {
      "data": {
        "Perc50": 0,
        "Perc90": 0,
        "Perc99": 0
      },
      "unit": "MiB",
      "labels": {
        "group": "admissionregistration.k8s.io",
        "resource": "mutatingwebhookconfigurations"
      }
    },
    {
      "data": {
        "Perc50": 0.019346237182617188,
        "Perc90": 0.019346237182617188,
        "Perc99": 0.019346237182617188
      },
      "unit": "MiB",
      "labels": {
        "group": "apiregistration.k8s.io",
        "resource": "apiservices"
      }
    },
    {
      "data": {
        "Perc50": 0.041258811950683594,
        "Perc90": 0.041258811950683594,
        "Perc99": 0.041258811950683594
      },
      "unit": "MiB",
      "labels": {
        "group": "",
        "resource": "nodes"
      }
    },
    {
      "data": {
        "Perc50": 0,
        "Perc90": 0,
        "Perc99": 0
      },
      "unit": "MiB",
      "labels": {
        "group": "",
        "resource": "podtemplates"
      }
    },
    {
      "data": {
        "Perc50": 0.00054168701171875,
        "Perc90": 0.00054168701171875,
        "Perc99": 0.00054168701171875
      },
      "unit": "MiB",
      "labels": {
        "group": "",
        "resource": "resourcequotas"
      }
    },
    {
      "data": {
        "Perc50": 0,
        "Perc90": 0,
        "Perc99": 0
      },
      "unit": "MiB",
      "labels": {
        "group": "",
        "resource": "replicationcontrollers"
      }
    },
    {
      "data": {
        "Perc50": 0.0009069442749023438,
        "Perc90": 0.0009069442749023438,
        "Perc99": 0.0009069442749023438
      },
      "unit": "MiB",
      "labels": {
        "group": "networking.k8s.io",
        "resource": "servicecidrs"
      }
    },
    {
      "data": {
        "Perc50": 0.2095794677734375,
        "Perc90": 0.2095794677734375,
        "Perc99": 1.941230773925782
      },
      "unit": "MiB",
      "labels": {
        "group": "",
        "resource": "pods"
      }
    },
    {
      "data": {
        "Perc50": 0,
        "Perc90": 0,
        "Perc99": 0
      },
      "unit": "MiB",
      "labels": {
        "group": "storage.k8s.io",
        "resource": "volumeattachments"
      }
    },
    {
      "data": {
        "Perc50": 0,
        "Perc90": 0,
        "Perc99": 0
      },
      "unit": "MiB",
      "labels": {
        "group": "node.k8s.io",
        "resource": "runtimeclasses"
      }
    },
    {
      "data": {
        "Perc50": 0.011098861694335938,
        "Perc90": 0.038726806640625,
        "Perc99": 0.038726806640625
      },
      "unit": "MiB",
      "labels": {
        "group": "discovery.k8s.io",
        "resource": "endpointslices"
      }
    },
    {
      "data": {
        "Perc50": 0.0066928863525390625,
        "Perc90": 0.0066928863525390625,
        "Perc99": 0.0066928863525390625
      },
      "unit": "MiB",
      "labels": {
        "group": "monitoring.coreos.com",
        "resource": "prometheusrules"
      }
    },
    {
      "data": {
        "Perc50": 0,
        "Perc90": 0,
        "Perc99": 0
      },
      "unit": "MiB",
      "labels": {
        "group": "networking.k8s.io",
        "resource": "ingresses"
      }
    },
    {
      "data": {
        "Perc50": 0,
        "Perc90": 0,
        "Perc99": 0
      },
      "unit": "MiB",
      "labels": {
        "group": "resource.k8s.io",
        "resource": "resourceclaimtemplates"
      }
    },
    {
      "data": {
        "Perc50": 0.006871223449707031,
        "Perc90": 0.006871223449707031,
        "Perc99": 0.006871223449707031
      },
      "unit": "MiB",
      "labels": {
        "group": "storage.k8s.io",
        "resource": "csinodes"
      }
    },
    {
      "data": {
        "Perc50": 0,
        "Perc90": 0,
        "Perc99": 0
      },
      "unit": "MiB",
      "labels": {
        "group": "admissionregistration.k8s.io",
        "resource": "validatingadmissionpolicies"
      }
    },
    {
      "data": {
        "Perc50": 0.010868072509765625,
        "Perc90": 0.010868072509765625,
        "Perc99": 0.010868072509765625
      },
      "unit": "MiB",
      "labels": {
        "group": "flowcontrol.apiserver.k8s.io",
        "resource": "flowschemas"
      }
    },
    {
      "data": {
        "Perc50": 0,
        "Perc90": 0,
        "Perc99": 0
      },
      "unit": "MiB",
      "labels": {
        "group": "resource.k8s.io",
        "resource": "resourceslices"
      }
    },
    {
      "data": {
        "Perc50": 0.006488800048828125,
        "Perc90": 0.006488800048828125,
        "Perc99": 0.006488800048828125
      },
      "unit": "MiB",
      "labels": {
        "group": "coordination.k8s.io",
        "resource": "leases"
      }
    },
    {
      "data": {
        "Perc50": 0,
        "Perc90": 0,
        "Perc99": 0
      },
      "unit": "MiB",
      "labels": {
        "group": "",
        "resource": "limitranges"
      }
    },
    {
      "data": {
        "Perc50": 0,
        "Perc90": 0,
        "Perc99": 0
      },
      "unit": "MiB",
      "labels": {
        "group": "monitoring.coreos.com",
        "resource": "probes"
      }
    },
    {
      "data": {
        "Perc50": 0,
        "Perc90": 0,
        "Perc99": 0
      },
      "unit": "MiB",
      "labels": {
        "group": "batch",
        "resource": "cronjobs"
      }
    },
    {
      "data": {
        "Perc50": 0,
        "Perc90": 0,
        "Perc99": 0.050713062286376974
      },
      "unit": "MiB",
      "labels": {
        "group": "",
        "resource": "persistentvolumes"
      }
    },
    {
      "data": {
        "Perc50": 0,
        "Perc90": 0,
        "Perc99": 0
      },
      "unit": "MiB",
      "labels": {
        "group": "autoscaling",
        "resource": "horizontalpodautoscalers"
      }
    },
    {
      "data": {
        "Perc50": 0,
        "Perc90": 0,
        "Perc99": 0
      },
      "unit": "MiB",
      "labels": {
        "group": "storage.k8s.io",
        "resource": "csistoragecapacities"
      }
    },
    {
      "data": {
        "Perc50": 0.02394866943359375,
        "Perc90": 0.3722648620605469,
        "Perc99": 0.3722648620605469
      },
      "unit": "MiB",
      "labels": {
        "group": "apps",
        "resource": "replicasets"
      }
    },
    {
      "data": {
        "Perc50": 0.007877349853515625,
        "Perc90": 0.007877349853515625,
        "Perc99": 0.007877349853515625
      },
      "unit": "MiB",
      "labels": {
        "group": "rbac.authorization.k8s.io",
        "resource": "rolebindings"
      }
    },
    {
      "data": {
        "Perc50": 0,
        "Perc90": 0,
        "Perc99": 0
      },
      "unit": "MiB",
      "labels": {
        "group": "networking.k8s.io",
        "resource": "ingressclasses"
      }
    },
    {
      "data": {
        "Perc50": 0,
        "Perc90": 0,
        "Perc99": 0
      },
      "unit": "MiB",
      "labels": {
        "group": "networking.k8s.io",
        "resource": "networkpolicies"
      }
    },
    {
      "data": {
        "Perc50": 0.0067596435546875,
        "Perc90": 0.01407623291015625,
        "Perc99": 0.01407623291015625
      },
      "unit": "MiB",
      "labels": {
        "group": "",
        "resource": "secrets"
      }
    },
    {
      "data": {
        "Perc50": 0,
        "Perc90": 0,
        "Perc99": 0
      },
      "unit": "MiB",
      "labels": {
        "group": "storage.k8s.io",
        "resource": "volumeattributesclasses"
      }
    },
    {
      "data": {
        "Perc50": 0,
        "Perc90": 0,
        "Perc99": 0
      },
      "unit": "MiB",
      "labels": {
        "group": "resource.k8s.io",
        "resource": "resourceclaims"
      }
    },
    {
      "data": {
        "Perc50": 0.0035648345947265625,
        "Perc90": 0.010854721069335938,
        "Perc99": 0.010854721069335938
      },
      "unit": "MiB",
      "labels": {
        "group": "networking.k8s.io",
        "resource": "ipaddresses"
      }
    },
    {
      "data": {
        "Perc50": 0,
        "Perc90": 0,
        "Perc99": 0
      },
      "unit": "MiB",
      "labels": {
        "group": "admissionregistration.k8s.io",
        "resource": "validatingwebhookconfigurations"
      }
    },
    {
      "data": {
        "Perc50": 0.007185935974121094,
        "Perc90": 0.007185935974121094,
        "Perc99": 0.007185935974121094
      },
      "unit": "MiB",
      "labels": {
        "group": "",
        "resource": "serviceaccounts"
      }
    },
    {
      "data": {
        "Perc50": 0.0030803680419921875,
        "Perc90": 0.0030803680419921875,
        "Perc99": 0.0030803680419921875
      },
      "unit": "MiB",
      "labels": {
        "group": "",
        "resource": "namespaces"
      }
    },
    {
      "data": {
        "Perc50": 0.0062351226806640625,
        "Perc90": 0.0062351226806640625,
        "Perc99": 0.0062351226806640625
      },
      "unit": "MiB",
      "labels": {
        "group": "rbac.authorization.k8s.io",
        "resource": "roles"
      }
    },
    {
      "data": {
        "Perc50": 0.023949623107910156,
        "Perc90": 0.023949623107910156,
        "Perc99": 0.023949623107910156
      },
      "unit": "MiB",
      "labels": {
        "group": "certificates.k8s.io",
        "resource": "certificatesigningrequests"
      }
    },
    {
      "data": {
        "Perc50": 0,
        "Perc90": 0,
        "Perc99": 0.053571224212646505
      },
      "unit": "MiB",
      "labels": {
        "group": "",
        "resource": "persistentvolumeclaims"
      }
    },
    {
      "data": {
        "Perc50": 0,
        "Perc90": 0,
        "Perc99": 0
      },
      "unit": "MiB",
      "labels": {
        "group": "admissionregistration.k8s.io",
        "resource": "validatingadmissionpolicybindings"
      }
    },
    {
      "data": {
        "Perc50": 0.0073642730712890625,
        "Perc90": 0.028967857360839844,
        "Perc99": 0.028967857360839844
      },
      "unit": "MiB",
      "labels": {
        "group": "",
        "resource": "endpoints"
      }
    },
    {
      "data": {
        "Perc50": -9.5367431640625e-7,
        "Perc90": -9.5367431640625e-7,
        "Perc99": -9.5367431640625e-7
      },
      "unit": "MiB",
      "labels": {
        "group": "",
        "resource": "events"
      }
    },
    {
      "data": {
        "Perc50": 0.008276939392089844,
        "Perc90": 0.016119003295898438,
        "Perc99": 0.016119003295898438
      },
      "unit": "MiB",
      "labels": {
        "group": "",
        "resource": "services"
      }
    },
    {
      "data": {
        "Perc50": 0.001129150390625,
        "Perc90": 0.001129150390625,
        "Perc99": 0.001129150390625
      },
      "unit": "MiB",
      "labels": {
        "group": "storage.k8s.io",
        "resource": "storageclasses"
      }
    },
    {
      "data": {
        "Perc50": 0,
        "Perc90": 0,
        "Perc99": 0
      },
      "unit": "MiB",
      "labels": {
        "group": "monitoring.coreos.com",
        "resource": "alertmanagerconfigs"
      }
    },
    {
      "data": {
        "Perc50": 0.5695266723632812,
        "Perc90": 0.5776863098144531,
        "Perc99": 0.5776863098144531
      },
      "unit": "MiB",
      "labels": {
        "group": "",
        "resource": "configmaps"
      }
    },
    {
      "data": {
        "Perc50": 0,
        "Perc90": 0,
        "Perc99": 0
      },
      "unit": "MiB",
      "labels": {
        "group": "monitoring.coreos.com",
        "resource": "podmonitors"
      }
    },
    {
      "data": {
        "Perc50": 0.0034284591674804688,
        "Perc90": 0.0034284591674804688,
        "Perc99": 0.0034284591674804688
      },
      "unit": "MiB",
      "labels": {
        "group": "monitoring.coreos.com",
        "resource": "prometheuses"
      }
    },
    {
      "data": {
        "Perc50": 0.0075626373291015625,
        "Perc90": 0.0075626373291015625,
        "Perc99": 0.0075626373291015625
      },
      "unit": "MiB",
      "labels": {
        "group": "monitoring.coreos.com",
        "resource": "servicemonitors"
      }
    },
    {
      "data": {
        "Perc50": 1.3950576782226562,
        "Perc90": 1.3950576782226562,
        "Perc99": 1.3950576782226562
      },
      "unit": "MiB",
      "labels": {
        "group": "apiextensions.k8s.io",
        "resource": "customresourcedefinitions"
      }
    },
    {
      "data": {
        "Perc50": 0,
        "Perc90": 0,
        "Perc99": 0
      },
      "unit": "MiB",
      "labels": {
        "group": "storage.k8s.io",
        "resource": "csidrivers"
      }
    },
    {
      "data": {
        "Perc50": 0.03624248504638672,
        "Perc90": 0.03624248504638672,
        "Perc99": 0.03624248504638672
      },
      "unit": "MiB",
      "labels": {
        "group": "rbac.authorization.k8s.io",
        "resource": "clusterrolebindings"
      }
    },
    {
      "data": {
        "Perc50": 0,
        "Perc90": 0,
        "Perc99": 0
      },
      "unit": "MiB",
      "labels": {
        "group": "policy",
        "resource": "poddisruptionbudgets"
      }
    },
    {
      "data": {
        "Perc50": 0.010992050170898438,
        "Perc90": 0.04264068603515625,
        "Perc99": 0.04264068603515625
      },
      "unit": "MiB",
      "labels": {
        "group": "apps",
        "resource": "controllerrevisions"
      }
    },
    {
      "data": {
        "Perc50": 0,
        "Perc90": 0,
        "Perc99": 0
      },
      "unit": "MiB",
      "labels": {
        "group": "monitoring.coreos.com",
        "resource": "alertmanagers"
      }
    },
    {
      "data": {
        "Perc50": 0.059795379638671875,
        "Perc90": 0.059795379638671875,
        "Perc99": 0.059795379638671875
      },
      "unit": "MiB",
      "labels": {
        "group": "rbac.authorization.k8s.io",
        "resource": "clusterroles"
      }
    },
    {
      "data": {
        "Perc50": 0.0007457733154296875,
        "Perc90": 0.0012273788452148438,
        "Perc99": 0.0012273788452148438
      },
      "unit": "MiB",
      "labels": {
        "group": "scheduling.k8s.io",
        "resource": "priorityclasses"
      }
    },
    {
      "data": {
        "Perc50": 0.0061492919921875,
        "Perc90": 0.0175323486328125,
        "Perc99": 0.0175323486328125
      },
      "unit": "MiB",
      "labels": {
        "group": "apps",
        "resource": "daemonsets"
      }
    },
    {
      "data": {
        "Perc50": 0,
        "Perc90": 0,
        "Perc99": 0
      },
      "unit": "MiB",
      "labels": {
        "group": "monitoring.coreos.com",
        "resource": "thanosrulers"
      }
    },
    {
      "data": {
        "Perc50": 0,
        "Perc90": 0,
        "Perc99": 0
      },
      "unit": "MiB",
      "labels": {
        "group": "resource.k8s.io",
        "resource": "deviceclasses"
      }
    }
  ]
}

</details>