### PR TITLE
Allow increases object size via environment variable

### DIFF
--- a/clusterloader2/testing/load/daemonset.yaml
+++ b/clusterloader2/testing/load/daemonset.yaml
@@ -6,6 +6,7 @@
 
 {{$ENABLE_NETWORK_POLICY_ENFORCEMENT_LATENCY_TEST := DefaultParam .CL2_ENABLE_NETWORK_POLICY_ENFORCEMENT_LATENCY_TEST false}}
 {{$NET_POLICY_ENFORCEMENT_LATENCY_NODE_LABEL_VALUE := DefaultParam .CL2_NET_POLICY_ENFORCEMENT_LATENCY_NODE_LABEL_VALUE "net-policy-client"}}
+{{$podPayloadSize := DefaultParam .CL2_DAEMONSET_POD_PAYLOAD_SIZE 0}}
 
 apiVersion: apps/v1
 kind: DaemonSet
@@ -33,6 +34,8 @@ spec:
         env:
           - name: TEST_ENV
             value: {{$Env}}
+          - name: ENV_VAR
+            value: {{RandData $podPayloadSize}}
         resources:
           # Keep the CpuRequest/MemoryRequest request equal percentage of 1-core, 4GB node.
           # For now we're setting it to 0.5%.

--- a/clusterloader2/testing/load/deployment.yaml
+++ b/clusterloader2/testing/load/deployment.yaml
@@ -4,6 +4,7 @@
 {{$CpuRequest := DefaultParam .CpuRequest "5m"}}
 {{$MemoryRequest := DefaultParam .MemoryRequest "20M"}}
 {{$dnsQPSPerClient := DefaultParam .CL2_DNS_QPS_PER_CLIENT 1}}
+{{$podPayloadSize := DefaultParam .CL2_DEPLOYMENT_POD_PAYLOAD_SIZE 0}}
 # Guard the new DNS tests. Remove it once it's confirmed that it works on a subset of tests.
 {{$USE_ADVANCED_DNSTEST := DefaultParam .CL2_USE_ADVANCED_DNSTEST false}}
 {{$RUN_ON_ARM_NODES := DefaultParam .CL2_RUN_ON_ARM_NODES false}}
@@ -78,6 +79,9 @@ spec:
         name: {{.Name}}
   {{end}}
 {{end}}
+        env:
+        - name: ENV_VAR
+          value: {{RandData $podPayloadSize}}
         resources:
           requests:
             cpu: {{$CpuRequest}}

--- a/clusterloader2/testing/load/simple-deployment.yaml
+++ b/clusterloader2/testing/load/simple-deployment.yaml
@@ -2,7 +2,7 @@
 # Keep the CpuRequest/MemoryRequest request equal percentage of 1-core, 4GB node.
 # For now we're setting it to 0.5%.
 {{$CpuRequest := DefaultParam .CpuRequest "5m"}}
-{{$EnvVar := DefaultParam .EnvVar "a"}}
+{{$podPayloadSize := DefaultParam .CL2_DEPLOYMENT_POD_PAYLOAD_SIZE 0}}
 {{$MemoryRequest := DefaultParam .MemoryRequest "20M"}}
 {{$Image := DefaultParam .Image "registry.k8s.io/pause:3.9"}}
 {{$RUN_ON_ARM_NODES := DefaultParam .CL2_RUN_ON_ARM_NODES false}}
@@ -31,7 +31,7 @@ spec:
       containers:
       - env:
         - name: ENV_VAR
-          value: {{$EnvVar}}
+          value: {{RandData $podPayloadSize}}
         image: {{$Image}}
         imagePullPolicy: IfNotPresent
         name: {{.Name}}

--- a/clusterloader2/testing/load/statefulset.yaml
+++ b/clusterloader2/testing/load/statefulset.yaml
@@ -1,6 +1,7 @@
 {{$HostNetworkMode := DefaultParam .CL2_USE_HOST_NETWORK_PODS false}}
 {{$EnablePVs := DefaultParam .CL2_ENABLE_PVS true}}
 {{$RUN_ON_ARM_NODES := DefaultParam .CL2_RUN_ON_ARM_NODES false}}
+{{$podPayloadSize := DefaultParam .CL2_STATEFULSET_POD_PAYLOAD_SIZE 0}}
 {{$Image := DefaultParam .Image "registry.k8s.io/pause:3.9"}}
 
 apiVersion: apps/v1
@@ -27,6 +28,9 @@ spec:
       containers:
       - name: {{.Name}}
         image: {{$Image}}
+        env:
+        - name: ENV_VAR
+          value: {{RandData $podPayloadSize}}
         ports:
           - containerPort: 80
             name: web


### PR DESCRIPTION
Skipped Job type as environment variable is immutable, causing reconciliation to break. Will address this in the future.

/kind feature


Ref https://github.com/kubernetes/kubernetes/issues/134375