### PR TITLE
fix missing project id and delete deprecated LegacyIsMasterNode function

### DIFF
--- a/clusterloader2/pkg/measurement/common/scheduler_latency.go
+++ b/clusterloader2/pkg/measurement/common/scheduler_latency.go
@@ -99,7 +99,7 @@ func (s *schedulerLatencyMeasurement) Execute(config *measurement.Config) ([]mea
 
 	var masterRegistered = false
 	for _, node := range nodes.Items {
-		if util.LegacyIsMasterNode(&node) || util.IsControlPlaneNode(&node) {
+		if util.IsControlPlaneNode(&node) {
 			masterRegistered = true
 		}
 	}

--- a/clusterloader2/pkg/measurement/util/gatherers/container_resource_gatherer.go
+++ b/clusterloader2/pkg/measurement/util/gatherers/container_resource_gatherer.go
@@ -116,7 +116,7 @@ func NewResourceUsageGatherer(c clientset.Interface, host string, port int, prov
 
 		masterNodes := sets.NewString()
 		for _, node := range nodeList.Items {
-			if pkgutil.LegacyIsMasterNode(&node) || pkgutil.IsControlPlaneNode(&node) {
+			if pkgutil.IsControlPlaneNode(&node) {
 				masterNodes.Insert(node.Name)
 			}
 		}

--- a/clusterloader2/pkg/prometheus/prometheus.go
+++ b/clusterloader2/pkg/prometheus/prometheus.go
@@ -540,7 +540,7 @@ func (pc *Controller) runNodeExporter() error {
 	numMasters := 0
 	for _, node := range nodes {
 		node := node
-		if util.LegacyIsMasterNode(&node) || util.IsControlPlaneNode(&node) {
+		if util.IsControlPlaneNode(&node) {
 			numMasters++
 			g.Go(func() error {
 				f, err := manifestsFS.Open(nodeExporterPod)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:

Scale jobs using kops aren't reading the project id correctly because the GCP project id is not explicitly set. I changed it to read node providerID set by the cloud controller manager.

https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kubernetes-e2e-kops-gce-5000-ipalias-using-cl2/1980979471863255040

I also cleaned up a function deprecated in k8s 1.19

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

