### PR TITLE
dra test config: bump wait for jobs to finish timeout

### DIFF
--- a/clusterloader2/testing/dra/config.yaml
+++ b/clusterloader2/testing/dra/config.yaml
@@ -210,7 +210,7 @@ steps:
       Params:
         action: gather
         labelSelector: job-type = short-lived
-        timeout: 15m
+        timeout: 30m
 - name: Measure scheduler metrics
   measurements:
     - Identifier: ChurnSchedulingMetrics


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug


<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
The current 5k node test is failing because the test is not waiting for all the jobs to finish. This PR is bumping the timeout for the jobs.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
1. job run: https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kubernetes-e2e-kops-gce-5000-node-dra-with-workload-ipalias-using-cl2/1990978381612584960
2. failure message: `E1119 05:37:26.257214   21793 clusterloader.go:258]   Errors: [measurement call WaitForFinishedJobs - WaitForFinishedJobs error: 1824 Jobs timed out: test-2d3ecr-2/small-1000,...`
3. latency numbers are still under the SLO
```
    {
      "data": {
        "Perc50": 2032.288272,
        "Perc90": 2631.835891,
        "Perc99": 3056.095243
      },
      "unit": "ms",
      "labels": {
        "Metric": "pod_startup"
      }
    },
``` 
from here: https://storage.googleapis.com/kubernetes-ci-logs/logs/ci-kubernetes-e2e-kops-gce-5000-node-dra-with-workload-ipalias-using-cl2/1990978381612584960/artifacts/StatelessPodStartupLatency_ChurnPodStartupLatency_dra-steady-state_2025-11-19T05:27:25Z.json

