### PR TITLE
Add requests to exec deployment

### DIFF
--- a/clusterloader2/pkg/execservice/exec_service.go
+++ b/clusterloader2/pkg/execservice/exec_service.go
@@ -84,7 +84,10 @@ func SetUpExecService(f *framework.Framework, c config.ExecServiceConfig) error 
 		klog.V(3).Infof("%s: service already running!", execServiceName)
 	}
 	klog.V(2).Infof("%v: setting up service!", execServiceName)
-	mapping := make(map[string]interface{})
+	mapping, err := config.LoadCL2Envs()
+	if err != nil {
+		return fmt.Errorf("mapping creation error: %v", err)
+	}
 	mapping["Name"] = execDeploymentName
 	mapping["Namespace"] = execDeploymentNamespace
 	mapping["Replicas"] = execPodReplicas

--- a/clusterloader2/pkg/execservice/manifest/exec_deployment.yaml
+++ b/clusterloader2/pkg/execservice/manifest/exec_deployment.yaml
@@ -1,3 +1,6 @@
+{{$CpuRequest := DefaultParam .CL2_EXECSERVICE_CPU_REQUESTS ""}}
+{{$MemoryRequest := DefaultParam .CL2_EXECSERVICE_MEMORY_REQUESTS ""}}
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -16,3 +19,11 @@ spec:
       containers:
       - name: agnhost
         image: {{.ImageRegistry}}/e2e-test-images/agnhost:2.32
+        resources:
+          requests:
+{{if $CpuRequest}}
+            cpu: {{$CpuRequest}}
+{{end}}
+{{if $MemoryRequest}}
+            memory: {{$MemoryRequest}}
+{{end}}


### PR DESCRIPTION
/kind feature

Adding requests to the execservice to prevent OOMs in execservice. 

On the 5k scalability tests the nodes are running close the memory limit. This causes issues for resource-size experiments where we get  `api_availability_measurement.go:83] execservice issue: problem with RunCommand(): output="", err=signal: killed` which are sign of OOMs.

To mitigate it I assigned enough requests to ensure that exec_deployment is scheduled on heapster node to ensure enough resources. 

Alternatively I could make it templated to avoid requiring too much resources in base case.

/assign @mborsz