### PR TITLE
Limit QPS in list benchmark to reduce CPU variance

### DIFF
--- a/clusterloader2/testing/list/deployment.yaml
+++ b/clusterloader2/testing/list/deployment.yaml
@@ -28,6 +28,7 @@ spec:
         - --namespace={{.Namespace}}
         - --uri={{.Uri}}
         - --content-type={{.ContentType}}
+        - --qps=500
         resources:
           requests:
             cpu: {{$cpu}}


### PR DESCRIPTION
### Stabilize list benchmark by limiting QPS

This PR adds an explicit QPS limit to the request-benchmark invocation used by the list benchmark to reduce run-to-run CPU variance introduced by streaming LIST responses.

**Changes:**
1. Adds a fixed `--qps=500` flag to the list benchmark deployment (`clusterloader2/testing/list/deployment.yaml`)
2. Ensures request rate is paced rather than unbounded when running the LIST benchmark
3. Improves stability and repeatability of CPU usage measurements without changing benchmark semantics

**Which issue(s) this PR is related to:**
Fixes kubernetes/kubernetes#130869

**Special notes for your reviewer:**
This change intentionally uses a fixed QPS value to minimize variance with minimal surface area. The specific value is not a throughput target and can be adjusted or parameterized in a follow-up if needed. Streaming behavior and benchmark workload remain unchanged.

**Does this PR introduce a user-facing change?**
```release-note
NONE
```