### PR TITLE
Fix imagePullPolicy location in deployment.yaml

### DIFF
--- a/clusterloader2/testing/access-tokens/deployment.yaml
+++ b/clusterloader2/testing/access-tokens/deployment.yaml
@@ -18,10 +18,10 @@ spec:
         group: access-tokens
         name: {{.Name}}
     spec:
-      imagePullPolicy: Always
       containers:
         - name: access-tokens
           image: gcr.io/k8s-testimages/perf-tests-util/access-tokens:v0.0.6
+          imagePullPolicy: Always
           args:
           {{range $tokenId := Loop .Tokens}}
             - --access-token-dirs=/var/tokens/{{$name}}-{{$tokenId}}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:
Running clusterloader shows the following warning:
https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kops/17741/presubmit-kops-aws-scale-amazonvpc-using-cl2/2005828766433021952
```
I1230 03:55:38.459265   58038 clusterloader.go:243] --------------------------------------------------------------------------------
I1230 03:55:38.459270   58038 clusterloader.go:244] Running /home/prow/go/src/k8s.io/perf-tests/clusterloader2/testing/access-tokens/config.yaml
I1230 03:55:38.459275   58038 clusterloader.go:245] --------------------------------------------------------------------------------
I1230 03:55:46.702730   58038 warnings.go:110] "Warning: unknown field \"spec.template.spec.imagePullPolicy\""
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
n/a

#### Special notes for your reviewer:
n/a
