### PR TITLE
benchmark: fix GCS bucket path for fetching CI job logs

### DIFF
--- a/benchmark/pkg/metricsfetcher/util/util.go
+++ b/benchmark/pkg/metricsfetcher/util/util.go
@@ -46,10 +46,18 @@ type GCSLogUtils struct {
 	googleGCSBucketUtils *utils.Utils
 }
 
+// GCS bucket and directory for Kubernetes CI logs.
+// Note: Jobs were migrated from "kubernetes-jenkins" to "kubernetes-ci-logs"
+// as part of the k8s-infra migration.
+const (
+	K8sCILogsBucket = "kubernetes-ci-logs"
+	LogDir          = "logs"
+)
+
 // NewGCSLogUtils returns new GCSLogUtils struct with GCS utils initialized.
 func NewGCSLogUtils() GCSLogUtils {
 	return GCSLogUtils{
-		googleGCSBucketUtils: utils.NewUtils(utils.KubekinsBucket, utils.LogDir),
+		googleGCSBucketUtils: utils.NewUtils(K8sCILogsBucket, LogDir),
 	}
 }
 


### PR DESCRIPTION
The benchmark tool was using the old "kubernetes-jenkins" GCS bucket to fetch job logs, but all CI jobs have been migrated to the "kubernetes-ci-logs" bucket as part of the k8s-infra migration.

This was causing the benchmark job (ci-perf-tests-kubemark-100-benchmark) to fail with "No matching dirs were found" errors when trying to fetch metrics from ci-kubernetes-e2e-gci-gce-scalability and ci-kubernetes-kubemark-100-gce jobs.

- https://storage.googleapis.com/k8s-metrics/failures-latest.html?include=perf&sort=days&asc=0
- https://testgrid.k8s.io/sig-scalability-perf-tests#kubemark-100-benchmark

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

