### PR TITLE
Allow increating informer on all namespaces

### DIFF
--- a/util-images/watch-list/Makefile
+++ b/util-images/watch-list/Makefile
@@ -1,6 +1,6 @@
 PROJECT ?= k8s-staging-perf-tests
 IMG = gcr.io/$(PROJECT)/watch-list
-TAG = v0.0.2
+TAG = v0.0.3
 
 all: push
 


### PR DESCRIPTION
/kind feature

/assign @mborsz 

https://github.com/kubernetes/perf-tests/blob/master/clusterloader2/testing/watch-list/job.yaml already specifies namespace.