### PR TITLE
configure scraping etcd ports on kops

### DIFF
--- a/clusterloader2/pkg/prometheus/manifests/master-ip/master-endpoints.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/master-ip/master-endpoints.yaml
@@ -23,6 +23,8 @@ subsets:
         port: 2379
       - name: etcd-2382
         port: 2382
+      - name: etcd-4001
+        port: 4001
       - name: kubelet
         port: 10250
       - name: kube-scheduler

--- a/clusterloader2/pkg/prometheus/manifests/master-ip/master-service.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/master-ip/master-service.yaml
@@ -20,6 +20,8 @@ spec:
       port: 2379
     - name: etcd-2382
       port: 2382
+    - name: etcd-4001
+      port: 4001
     - name: kubelet
       port: 10250
     - name: kube-scheduler

--- a/clusterloader2/pkg/prometheus/manifests/master-ip/master-serviceMonitor.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/master-ip/master-serviceMonitor.yaml
@@ -19,6 +19,8 @@ spec:
     port: etcd-2379
   - interval: 5s
     port: etcd-2382
+  - interval: 5s
+    port: etcd-4001
   {{end}}
   {{if $PROMETHEUS_SCRAPE_NODE_EXPORTER}}
   # TODO(mborsz): Debug why node-exporter is that slow and change interval back to 5s.

--- a/clusterloader2/pkg/provider/util.go
+++ b/clusterloader2/pkg/provider/util.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"strconv"
 
 	sshutil "k8s.io/perf-tests/clusterloader2/pkg/util"
 )
@@ -31,7 +33,15 @@ var (
 func getComponentProtocolAndPort(componentName string) (string, int, error) {
 	switch componentName {
 	case "etcd":
-		return "https://", 2379, nil
+		if os.Getenv("ETCD_PORT") != "" {
+			port, err := strconv.Atoi(os.Getenv("ETCD_PORT"))
+			if err != nil {
+				return "", -1, fmt.Errorf("cannot parse ETCD_PORT: %v", err)
+			}
+			return "https://", port, nil
+		} else {
+			return "https://", 2379, nil
+		}
 	case "kube-apiserver":
 		return "https://", 443, nil
 	case "kube-controller-manager":


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind enhancement

#### What this PR does / why we need it:

kops uses etcd manager and the main etcd server listens on 4001 instead of 2379
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

