### PR TITLE
Adding mapEventsByOrder option for PodStartupLatency

### DIFF
--- a/clusterloader2/pkg/measurement/common/slos/pod_startup_latency_test.go
+++ b/clusterloader2/pkg/measurement/common/slos/pod_startup_latency_test.go
@@ -1,0 +1,160 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package slos
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestGatherScheduleTimes(t *testing.T) {
+	testCases := []struct {
+		name             string
+		mapEventsByOrder bool
+		podCreates       []struct {
+			name string
+			time time.Time
+		}
+		events []struct {
+			podName string
+			time    time.Time
+		}
+		wantScheduleTimes map[string]time.Time
+		wantErr           bool
+	}{
+		{
+			name:             "map by key (default)",
+			mapEventsByOrder: false,
+			podCreates: []struct {
+				name string
+				time time.Time
+			}{
+				{name: "pod1", time: time.Unix(100, 0)},
+				{name: "pod2", time: time.Unix(200, 0)},
+			},
+			events: []struct {
+				podName string
+				time    time.Time
+			}{
+				{podName: "pod2", time: time.Unix(210, 0)},
+				{podName: "pod1", time: time.Unix(110, 0)},
+			},
+			wantScheduleTimes: map[string]time.Time{
+				"default/pod1": time.Unix(110, 0),
+				"default/pod2": time.Unix(210, 0),
+			},
+		},
+		{
+			name:             "map by order",
+			mapEventsByOrder: true,
+			podCreates: []struct {
+				name string
+				time time.Time
+			}{
+				{name: "pod-late-create", time: time.Unix(200, 0)},
+				{name: "pod-early-create", time: time.Unix(100, 0)},
+			},
+			events: []struct {
+				podName string
+				time    time.Time
+			}{
+				{podName: "some-pod-2", time: time.Unix(210, 0)},
+				{podName: "some-pod-1", time: time.Unix(110, 0)},
+			},
+			wantScheduleTimes: map[string]time.Time{
+				"default/pod-early-create": time.Unix(110, 0),
+				"default/pod-late-create":  time.Unix(210, 0),
+			},
+		},
+		{
+			name:             "map by order - mismatch count",
+			mapEventsByOrder: true,
+			podCreates: []struct {
+				name string
+				time time.Time
+			}{
+				{name: "pod1", time: time.Unix(100, 0)},
+			},
+			events: []struct {
+				podName string
+				time    time.Time
+			}{
+				{podName: "event1", time: time.Unix(110, 0)},
+				{podName: "event2", time: time.Unix(120, 0)},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := createPodStartupLatencyMeasurement().(*podStartupLatencyMeasurement)
+			p.mapEventsByOrder = tc.mapEventsByOrder
+			p.selector.Namespace = "default"
+
+			for _, pc := range tc.podCreates {
+				key := createMetaNamespaceKey("default", pc.name)
+				p.podStartupEntries.Set(key, createPhase, pc.time)
+			}
+
+			client := fake.NewSimpleClientset()
+			for _, e := range tc.events {
+				event := &corev1.Event{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      e.podName + "-event",
+						Namespace: "default",
+					},
+					InvolvedObject: corev1.ObjectReference{
+						Kind:      "Pod",
+						Name:      e.podName,
+						Namespace: "default",
+					},
+					Source:    corev1.EventSource{Component: defaultSchedulerName},
+					EventTime: metav1.MicroTime{Time: e.time},
+				}
+				_, err := client.CoreV1().Events("default").Create(context.TODO(), event, metav1.CreateOptions{})
+				if err != nil {
+					t.Fatalf("failed to create event: %v", err)
+				}
+			}
+
+			err := p.gatherScheduleTimes(client, defaultSchedulerName)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("gatherScheduleTimes() error = %v, wantErr %v", err, tc.wantErr)
+				return
+			}
+
+			if !tc.wantErr {
+				for key, wantTime := range tc.wantScheduleTimes {
+					gotTime, exists := p.podStartupEntries.Get(key, schedulePhase)
+					if !exists {
+						t.Errorf("schedule time for %s not found", key)
+						continue
+					}
+					if !gotTime.Equal(wantTime) {
+						t.Errorf("schedule time for %s = %v, want %v", key, gotTime, wantTime)
+					}
+				}
+			}
+		})
+	}
+}

--- a/clusterloader2/pkg/measurement/util/phase_latency.go
+++ b/clusterloader2/pkg/measurement/util/phase_latency.go
@@ -42,6 +42,28 @@ type ObjectTransitionTimes struct {
 	times map[string]map[string]time.Time
 }
 
+// KeyTimestamp is a pair of key and timestamp.
+type KeyTimestamp struct {
+	Key       string
+	Timestamp time.Time
+}
+
+// GetOrderedKeys returns keys having given phase entry, sorted by phase time.
+func (o *ObjectTransitionTimes) GetOrderedKeys(phase string) []KeyTimestamp {
+	o.lock.Lock()
+	defer o.lock.Unlock()
+	var result []KeyTimestamp
+	for key, entry := range o.times {
+		if t, exists := entry[phase]; exists {
+			result = append(result, KeyTimestamp{Key: key, Timestamp: t})
+		}
+	}
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].Timestamp.Before(result[j].Timestamp)
+	})
+	return result
+}
+
 // NewObjectTransitionTimes creates new ObjectTransitionTimes instance.
 func NewObjectTransitionTimes(name string) *ObjectTransitionTimes {
 	return &ObjectTransitionTimes{

--- a/clusterloader2/pkg/measurement/util/phase_latency_test.go
+++ b/clusterloader2/pkg/measurement/util/phase_latency_test.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestGetOrderedKeys(t *testing.T) {
+	ott := NewObjectTransitionTimes("test")
+	ott.Set("pod3", "phase1", time.Unix(300, 0))
+	ott.Set("pod1", "phase1", time.Unix(100, 0))
+	ott.Set("pod2", "phase1", time.Unix(200, 0))
+	ott.Set("pod4", "phase2", time.Unix(50, 0))
+
+	got := ott.GetOrderedKeys("phase1")
+	want := []KeyTimestamp{
+		{Key: "pod1", Timestamp: time.Unix(100, 0)},
+		{Key: "pod2", Timestamp: time.Unix(200, 0)},
+		{Key: "pod3", Timestamp: time.Unix(300, 0)},
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("GetOrderedKeys() = %v, want %v", got, want)
+	}
+
+	gotEmpty := ott.GetOrderedKeys("non-existent")
+	if len(gotEmpty) != 0 {
+		t.Errorf("GetOrderedKeys() for non-existent phase = %v, want empty", gotEmpty)
+	}
+}


### PR DESCRIPTION
This option (if enabled) changes the way the PodStartupLatency calculates the latency, intead of matching each pod creation time with the same pod shceduled time, it will matches the first creation time with the first schedule time whatever the pod is the same or not.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This option (if enabled) changes the way the PodStartupLatency calculates the latency, intead of matching each pod creation time with the same pod scheduled time, it will matches the first creation time with the first schedule time whatever the pod is the same or not.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

