### PR TITLE
Bump version of go compiler that bootstraps golang tip test to 1.26.0

### DIFF
--- a/golang/Makefile
+++ b/golang/Makefile
@@ -15,7 +15,7 @@
 .PHONY: build-go build push
 
 export GCS_BUCKET?=k8s-infra-scale-golang-builds
-export GO_COMPILER_PKG?=go1.24.6.linux-amd64.tar.gz
+export GO_COMPILER_PKG?=go1.26.0.linux-amd64.tar.gz
 export GO_COMPILER_URL?=https://dl.google.com/go/$(GO_COMPILER_PKG)
 export ROOT_DIR?=/home/prow/go/src
 


### PR DESCRIPTION
This change updates the golang version preemptively, before golang1.26 will become un-buildable with 1.25

This is a rhythmical update. Prev instance: https://github.com/kubernetes/perf-tests/pull/3539 (not merged due to non-existing 1.25.6 version at that point)

/assign @mborsz 

