### PR TITLE
Aggregate CPU and Memory accross all nodes instead of per node to fix AWS jobs

### DIFF
--- a/perfdash/parser.go
+++ b/perfdash/parser.go
@@ -106,8 +106,15 @@ type resourceUsage struct {
 	CPU    float64
 	Memory float64
 }
+type resourceUsageAggregate struct {
+	CPUSum    float64
+	MemorySum float64
+	Count     int
+}
+
 type usageAtPercentiles map[string]resourceUsage
 type podNameToUsage map[string]usageAtPercentiles
+type usageAggregateAtPercentiles map[string]resourceUsageAggregate
 
 func parseResourceUsageData(data []byte, buildNumber int, testResult *BuildData) {
 	testResult.Version = "v1"
@@ -118,12 +125,18 @@ func parseResourceUsageData(data []byte, buildNumber int, testResult *BuildData)
 		return
 	}
 	usage := make(podNameToUsage)
+	aggregatedUsage := make(usageAggregateAtPercentiles)
 	for percentile, items := range obj {
 		for _, item := range items {
 			name := RemoveDisambiguationInfixes(item.Name)
 			if _, ok := usage[name]; !ok {
 				usage[name] = make(usageAtPercentiles)
 			}
+			aggr := aggregatedUsage[percentile]
+			aggr.CPUSum += float64(item.CPU)
+			aggr.MemorySum += float64(item.Memory)
+			aggr.Count++
+			aggregatedUsage[percentile] = aggr
 			cpu, memory := float64(item.CPU), float64(item.Memory)
 			if otherUsage, ok := usage[name][percentile]; ok {
 				// Note that we take max of each resource separately, potentially manufacturing a
@@ -145,6 +158,17 @@ func parseResourceUsageData(data []byte, buildNumber int, testResult *BuildData)
 		testResult.Builds.AddBuildData(build, cpu)
 		testResult.Builds.AddBuildData(build, memory)
 	}
+	aggregatedCPU := perftype.DataItem{Unit: "cores", Labels: map[string]string{"PodName": "all-nodes", "Resource": "CPU_Average"}, Data: make(map[string]float64)}
+	aggregatedMemory := perftype.DataItem{Unit: "MiB", Labels: map[string]string{"PodName": "all-nodes", "Resource": "memory_Average"}, Data: make(map[string]float64)}
+	for percentile, usage := range aggregatedUsage {
+		if usage.Count == 0 {
+			continue
+		}
+		aggregatedCPU.Data[percentile] = usage.CPUSum / float64(usage.Count)
+		aggregatedMemory.Data[percentile] = (usage.MemorySum / float64(usage.Count)) / (1024 * 1024)
+	}
+	testResult.Builds.AddBuildData(build, aggregatedCPU)
+	testResult.Builds.AddBuildData(build, aggregatedMemory)
 }
 
 func parseRequestCountData(data []byte, buildNumber int, testResult *BuildData) {

--- a/perfdash/parser_test.go
+++ b/perfdash/parser_test.go
@@ -148,6 +148,93 @@ func Test_parseContainerRestarts(t *testing.T) {
 	}
 }
 
+func Test_parseResourceUsageDataAddsAverageResourcesBackwardCompatible(t *testing.T) {
+	data := []byte(`{
+		"Perc50": [
+			{"Name": "ip-10-0-0-1/kubelet", "CPU": 1, "Mem": 104857600},
+			{"Name": "ip-10-0-0-2/kubelet", "CPU": 3, "Mem": 314572800}
+		],
+		"Perc90": [
+			{"Name": "ip-10-0-0-1/kubelet", "CPU": 2, "Mem": 209715200},
+			{"Name": "ip-10-0-0-2/kubelet", "CPU": 4, "Mem": 419430400}
+		]
+	}`)
+
+	got := &BuildData{Builds: NewBuilds(nil)}
+	parseResourceUsageData(data, 7, got)
+
+	assert.Equal(t, "v1", got.Version)
+	require.NotNil(t, got.Builds)
+	assert.ElementsMatch(t, []perftype.DataItem{
+		{
+			Unit: "cores",
+			Labels: map[string]string{
+				"PodName":  "ip-10-0-0-1/kubelet",
+				"Resource": "CPU",
+			},
+			Data: map[string]float64{
+				"Perc50": 1,
+				"Perc90": 2,
+			},
+		},
+		{
+			Unit: "MiB",
+			Labels: map[string]string{
+				"PodName":  "ip-10-0-0-1/kubelet",
+				"Resource": "memory",
+			},
+			Data: map[string]float64{
+				"Perc50": 100,
+				"Perc90": 200,
+			},
+		},
+		{
+			Unit: "cores",
+			Labels: map[string]string{
+				"PodName":  "ip-10-0-0-2/kubelet",
+				"Resource": "CPU",
+			},
+			Data: map[string]float64{
+				"Perc50": 3,
+				"Perc90": 4,
+			},
+		},
+		{
+			Unit: "MiB",
+			Labels: map[string]string{
+				"PodName":  "ip-10-0-0-2/kubelet",
+				"Resource": "memory",
+			},
+			Data: map[string]float64{
+				"Perc50": 300,
+				"Perc90": 400,
+			},
+		},
+		{
+			Unit: "cores",
+			Labels: map[string]string{
+				"PodName":  "all-nodes",
+				"Resource": "CPU_Average",
+			},
+			Data: map[string]float64{
+				"Perc50": 2,
+				"Perc90": 3,
+			},
+		},
+		{
+			Unit: "MiB",
+			Labels: map[string]string{
+				"PodName":  "all-nodes",
+				"Resource": "memory_Average",
+			},
+			Data: map[string]float64{
+				"Perc50": 200,
+				"Perc90": 300,
+			},
+		},
+	}, got.Builds.Builds("7"))
+}
+
 func Test_BuildDataToJson(t *testing.T) {
 	tests := []struct {
 		name      string


### PR DESCRIPTION
# Overview
Contributes to issue https://github.com/kubernetes/perf-tests/issues/3843

Contributes to naming inconsistency issue with the AWS jobs, preventing LoadResources to be meaningful as it is not taking the average across all the nodes 




2 possibilities were considered to fix:
Option 1: Arrange for the AWS nodes to have well-defined names
Option 2. Change the metrics gathering/display to just average over all the nodes without regard to their names

GCE tests don't have the same issue because they have a more consistent naming for the nodes whereas AWS logs the instance-id in the nodename. It makes it insconsisent to see the resource usage. Therefore, this PR averages CPU/Memory across all the nodes.

In this PR, option 2 was selected.

Updated `parseResourceUsageData` to take the average accross the nodes 


# Testing

```
> go test parser.go parser_test.go
ok      command-line-arguments  0.370s
```
Deployed perfdash on `localhost:8080` after following https://github.com/kubernetes/perf-tests/blob/master/perfdash/README.md
```
make push
make run
```

**[done] Confirming that CL2 generates the desired result files:**

- LoadResources uses parseResourceUsageData and has the ResourceUsageSummary prefix, which corresponds to: https://storage.googleapis.com/kubernetes-ci-logs/pr-logs/pull/perf-tests/3844/pull-perf-tests-ec2-master-scale-performance-100/2028715726881165312/artifacts/ResourceUsageSummary_load_2026-03-03T06:50:12Z.json 
    -  Job execution: https://gcsweb.k8s.io/gcs/kubernetes-ci-logs/pr-logs/pull/perf-tests/3844/pull-perf-tests-ec2-master-scale-performance-100/2028715726881165312/artifacts/ 

The artifacts are not containing the new `resourceUsageAggregate` struct added because this change is not modifying the `type resourceUsagePercentiles map[string][]resourceUsages` rather, it adds `type usageAggregateAtPercentiles map[string]resourceUsageAggregate` which is the new struct computed. I am not modifying the struct below, which contains the resources. 

https://github.com/kubernetes/perf-tests/blob/8d2258664f6ec75647c3274ed62765879dcaa79f/perfdash/parser.go#L135

However, I after running the perfdash locally, I'm able to see the aggregation across all the nodes.

## Result after
URL = `http://localhost:8080/#/?jobname=gce-5000Nodes&metriccategoryname=E2E&metricname=LoadResources&Resource=CPU_Average&PodName=all-nodes` after the PR 
<img width="1594" height="1046" alt="image" src="https://github.com/user-attachments/assets/6be7a7ce-dbbf-4667-8366-6aa4816ddf64" />

## Before
- https://perf-dash.k8s.io/#/?jobname=gce-5000Nodes&metriccategoryname=E2E&metricname=LoadResources&PodName=kube-proxy-control-plane-us-east1-b%2Fkube-proxy&Resource=CPU

The `all-nodes` is more useful for AWS jobs as the namings differ.