### PR TITLE
Use krel push instead of the legacy push-build.sh

### DIFF
--- a/golang/push.sh
+++ b/golang/push.sh
@@ -17,10 +17,11 @@
 set -euxo pipefail
 
 # Push Kubernetes build to GCS.
-cd $ROOT_DIR/k8s.io/kubernetes
-../release/push-build.sh \
+cd "$ROOT_DIR/k8s.io/release"
+go run ./cmd/krel push \
+  --repo-root "$ROOT_DIR/k8s.io/kubernetes" \
   --nomock \
   --ci \
-  --bucket=$GCS_BUCKET \
+  --bucket="$GCS_BUCKET" \
   --private-bucket \
-  --version-suffix=$(date +%s)
+  --version-suffix="$(date +%s)"


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The `push-build.sh` script has been deprecated for a while and we should use `krel push` instead. This is a follow-up to #2909 which got bot-closed due to inactivity.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

cc @mm4tt @tosi3k @kubernetes/release-managers