### PR TITLE
test(clusterloader2): add unit test for ConvertSampleToHistogram

### DIFF
--- a/clusterloader2/pkg/measurement/util/histogram_test.go
+++ b/clusterloader2/pkg/measurement/util/histogram_test.go
@@ -150,3 +150,24 @@ func TestHistogramQuantile(t *testing.T) {
 		}
 	}
 }
+
+func TestConvertSampleToHistogram(t *testing.T) {
+	sample := &model.Sample{
+		Metric: model.Metric{
+			"name":             "test_metric",
+			model.BucketLabel: "1.0",
+		},
+		Value: 5,
+	}
+	hist := NewHistogram(nil)
+	ConvertSampleToHistogram(sample, hist)
+
+	expectedLabels := map[string]string{"name": "test_metric"}
+	if !reflect.DeepEqual(hist.Labels, expectedLabels) {
+		t.Errorf("expected labels %v, got %v", expectedLabels, hist.Labels)
+	}
+
+	if hist.Buckets["1.0"] != 5 {
+		t.Errorf("expected bucket 1.0 to have value 5, got %d", hist.Buckets["1.0"])
+	}
+}


### PR DESCRIPTION
Updates #572. This PR adds unit test coverage for the \ConvertSampleToHistogram\ function in the clusterloader2 measurement utilities.