### PR TITLE
ClusterLoader2: Allow setting runtimeClassName

### DIFF
--- a/clusterloader2/testing/load/modules/reconcile-objects/daemonset.yaml
+++ b/clusterloader2/testing/load/modules/reconcile-objects/daemonset.yaml
@@ -7,6 +7,7 @@
 {{$ENABLE_NETWORK_POLICY_ENFORCEMENT_LATENCY_TEST := DefaultParam .CL2_ENABLE_NETWORK_POLICY_ENFORCEMENT_LATENCY_TEST false}}
 {{$NET_POLICY_ENFORCEMENT_LATENCY_NODE_LABEL_VALUE := DefaultParam .CL2_NET_POLICY_ENFORCEMENT_LATENCY_NODE_LABEL_VALUE "net-policy-client"}}
 {{$podPayloadSize := DefaultParam .CL2_DAEMONSET_POD_PAYLOAD_SIZE 0}}
+{{$RuntimeClassName := DefaultParam .CL2_RUNTIME_CLASS_NAME nil}}
 
 apiVersion: apps/v1
 kind: DaemonSet
@@ -27,6 +28,9 @@ spec:
         group: load
         name: {{.Name}}
     spec:
+      {{if $RuntimeClassName}}
+      runtimeClassName: {{$RuntimeClassName}}
+      {{end}}
       hostNetwork: {{$HostNetworkMode}}
       containers:
       - name: {{.Name}}

--- a/clusterloader2/testing/load/modules/reconcile-objects/deployment.yaml
+++ b/clusterloader2/testing/load/modules/reconcile-objects/deployment.yaml
@@ -17,6 +17,7 @@
 {{$RunNetPolicyTest := and $EnableNetworkPolicyEnforcementLatencyTest (eq (Mod .Index $NetPolServerOnEveryNthPod) 0)}}
 
 {{$Image := DefaultParam .Image "registry.k8s.io/pause:3.9"}}
+{{$RuntimeClassName := DefaultParam .CL2_RUNTIME_CLASS_NAME nil}}
 
 apiVersion: apps/v1
 kind: Deployment
@@ -44,6 +45,9 @@ spec:
   {{end}}
 {{end}}
     spec:
+      {{if $RuntimeClassName}}
+      runtimeClassName: {{$RuntimeClassName}}
+      {{end}}
       hostNetwork: {{$HostNetworkMode}}
       containers:
 {{if .EnableDNSTests}}

--- a/clusterloader2/testing/load/modules/reconcile-objects/job.yaml
+++ b/clusterloader2/testing/load/modules/reconcile-objects/job.yaml
@@ -2,6 +2,7 @@
 {{$RUN_ON_ARM_NODES := DefaultParam .CL2_RUN_ON_ARM_NODES false}}
 {{$Image := DefaultParam .Image "registry.k8s.io/pause:3.9"}}
 {{$podPayloadSize := DefaultParam .CL2_JOB_POD_PAYLOAD_SIZE 0}}
+{{$RuntimeClassName := DefaultParam .CL2_RUNTIME_CLASS_NAME nil}}
 
 apiVersion: batch/v1
 kind: Job
@@ -23,6 +24,9 @@ spec:
         group: load
         name: {{.Name}}
     spec:
+      {{if $RuntimeClassName}}
+      runtimeClassName: {{$RuntimeClassName}}
+      {{end}}
       hostNetwork: {{$HostNetworkMode}}
       containers:
       - name: {{.Name}}

--- a/clusterloader2/testing/load/modules/reconcile-objects/statefulset.yaml
+++ b/clusterloader2/testing/load/modules/reconcile-objects/statefulset.yaml
@@ -3,6 +3,7 @@
 {{$RUN_ON_ARM_NODES := DefaultParam .CL2_RUN_ON_ARM_NODES false}}
 {{$podPayloadSize := DefaultParam .CL2_STATEFULSET_POD_PAYLOAD_SIZE 0}}
 {{$Image := DefaultParam .Image "registry.k8s.io/pause:3.9"}}
+{{$RuntimeClassName := DefaultParam .CL2_RUNTIME_CLASS_NAME nil}}
 
 apiVersion: apps/v1
 kind: StatefulSet
@@ -24,6 +25,9 @@ spec:
         group: load
         name: {{.Name}}
     spec:
+      {{if $RuntimeClassName}}
+      runtimeClassName: {{$RuntimeClassName}}
+      {{end}}
       hostNetwork: {{$HostNetworkMode}}
       containers:
       - name: {{.Name}}


### PR DESCRIPTION
What type of PR is this?
/kind feature

What this PR does / why we need it:
The PR allows to set the runtimeClassName for the clusterloader2 load scenario.
This allows to run the tests against other runtimes, such as gvisor.
