### PR TITLE
Set timeout to checking prometheus targets

### DIFF
--- a/clusterloader2/pkg/measurement/common/probes/probes.go
+++ b/clusterloader2/pkg/measurement/common/probes/probes.go
@@ -17,7 +17,9 @@ limitations under the License.
 package probes
 
 import (
+	"context"
 	"embed"
+	"errors"
 	"fmt"
 	"path"
 	"strings"
@@ -25,7 +27,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
-	"k8s.io/perf-tests/clusterloader2/pkg/errors"
+	cl2errors "k8s.io/perf-tests/clusterloader2/pkg/errors"
 	"k8s.io/perf-tests/clusterloader2/pkg/framework"
 	"k8s.io/perf-tests/clusterloader2/pkg/framework/client"
 	"k8s.io/perf-tests/clusterloader2/pkg/measurement"
@@ -152,7 +154,7 @@ func (p *probesMeasurement) Execute(config *measurement.Config) ([]measurement.S
 		return nil, p.start(config)
 	case "gather":
 		summary, err := p.gather(config.Params)
-		if err != nil && !errors.IsMetricViolationError(err) {
+		if err != nil && !cl2errors.IsMetricViolationError(err) {
 			return nil, err
 		}
 		return []measurement.Summary{summary}, err
@@ -266,7 +268,7 @@ func (p *probesMeasurement) gather(params map[string]interface{}) (measurement.S
 	if threshold > 0 {
 		suffix = fmt.Sprintf(", expected perc99 <= %v", threshold)
 		if err := latency.VerifyThreshold(threshold); err != nil {
-			violation = errors.NewMetricViolationError(p.String(), err.Error())
+			violation = cl2errors.NewMetricViolationError(p.String(), err.Error())
 			prefix = " WARNING"
 		}
 	}
@@ -289,10 +291,22 @@ func (p *probesMeasurement) waitForProbesReady(config *measurement.Config) error
 	if err != nil {
 		return err
 	}
-	return wait.Poll(checkProbesReadyInterval, checkProbesReadyTimeout, p.checkProbesReady)
+	return wait.Poll(
+		checkProbesReadyInterval,
+		checkProbesReadyTimeout,
+		func() (bool, error) {
+			ctx, cancel := context.WithTimeout(context.Background(), checkProbesReadyInterval)
+			defer cancel()
+			done, err := p.checkProbesReady(ctx)
+			if err != nil && errors.Is(err, context.DeadlineExceeded) {
+				return done, nil
+			}
+			return done, err
+		},
+	)
 }
 
-func (p *probesMeasurement) checkProbesReady() (bool, error) {
+func (p *probesMeasurement) checkProbesReady(ctx context.Context) (bool, error) {
 	// TODO(mm4tt): Using prometheus targets to check whether probes are up is a bit hacky.
 	//              Consider rewriting this to something more intuitive.
 	selector := func(t prometheus.Target) bool {
@@ -305,8 +319,7 @@ func (p *probesMeasurement) checkProbesReady() (bool, error) {
 		return false
 	}
 	expectedTargets := p.replicasPerProbe * len(p.config.ProbeLabelValues)
-	return prometheus.CheckAllTargetsReady(
-		p.framework.GetClientSets().GetClient(), selector, expectedTargets)
+	return prometheus.CheckAllTargetsReady(ctx, p.framework.GetClientSets().GetClient(), selector, expectedTargets)
 }
 
 func (p *probesMeasurement) createSummary(latency measurementutil.LatencyMetric) (measurement.Summary, error) {

--- a/clusterloader2/pkg/prometheus/prometheus.go
+++ b/clusterloader2/pkg/prometheus/prometheus.go
@@ -565,10 +565,19 @@ func (pc *Controller) waitForPrometheusToBeHealthy() error {
 	return wait.PollImmediate(
 		checkPrometheusReadyInterval,
 		pc.readyTimeout,
-		pc.isPrometheusReady)
+		func() (bool, error) {
+			ctx, cancel := context.WithTimeout(context.Background(), checkPrometheusReadyInterval)
+			defer cancel()
+			done, err := pc.isPrometheusReady(ctx)
+			if err != nil && errors.Is(err, context.DeadlineExceeded) {
+				return done, nil
+			}
+			return done, err
+		},
+	)
 }
 
-func (pc *Controller) isPrometheusReady() (bool, error) {
+func (pc *Controller) isPrometheusReady(ctx context.Context) (bool, error) {
 	// TODO(mm4tt): Re-enable kube-proxy monitoring and expect more targets.
 	// This is a safeguard from a race condition where the prometheus server is started before
 	// targets are registered. These 4 targets are always expected, in all possible configurations:
@@ -580,20 +589,20 @@ func (pc *Controller) isPrometheusReady() (bool, error) {
 		// changed in https://github.com/kubernetes/kubernetes/pull/77561, depending on the k8s version
 		// etcd metrics may be available at port 2379 xor 2382. We solve that by setting two etcd
 		// serviceMonitors one for 2379 and other for 2382 and expect that at least 1 of them should be healthy.
-		ok, err := CheckAllTargetsReady( // All non-etcd targets should be ready.
+		ok, err := CheckAllTargetsReady(ctx, // All non-etcd targets should be ready.
 			pc.framework.GetClientSets().GetClient(),
 			func(t Target) bool { return !isEtcdEndpoint(t.Labels["endpoint"]) },
 			expectedTargets)
 		if err != nil || !ok {
 			return ok, err
 		}
-		return CheckTargetsReady( // 1 out of 2 etcd targets should be ready.
+		return CheckTargetsReady(ctx, // 1 out of 2 etcd targets should be ready.
 			pc.framework.GetClientSets().GetClient(),
 			func(t Target) bool { return isEtcdEndpoint(t.Labels["endpoint"]) },
 			2, // expected targets: etcd-2379 and etcd-2382
 			1) // one of them should be healthy
 	}
-	return CheckAllTargetsReady(
+	return CheckAllTargetsReady(ctx,
 		pc.framework.GetClientSets().GetClient(),
 		func(Target) bool { return true }, // All targets.
 		expectedTargets)

--- a/clusterloader2/pkg/prometheus/util.go
+++ b/clusterloader2/pkg/prometheus/util.go
@@ -20,6 +20,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
+	"regexp"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -27,8 +30,6 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/remotecommand"
-	"os"
-	"regexp"
 
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
@@ -52,17 +53,18 @@ type Target struct {
 
 // CheckAllTargetsReady returns true iff there is at least minActiveTargets matching the selector and
 // all of them are ready.
-func CheckAllTargetsReady(k8sClient kubernetes.Interface, selector func(Target) bool, minActiveTargets int) (bool, error) {
-	return CheckTargetsReady(k8sClient, selector, minActiveTargets, allTargets)
+func CheckAllTargetsReady(ctx context.Context, k8sClient kubernetes.Interface, selector func(Target) bool, minActiveTargets int) (bool, error) {
+	return CheckTargetsReady(ctx, k8sClient, selector, minActiveTargets, allTargets)
 }
 
 // CheckTargetsReady returns true iff there is at least minActiveTargets matching the selector and
 // at least minReadyTargets of them are ready.
-func CheckTargetsReady(k8sClient kubernetes.Interface, selector func(Target) bool, minActiveTargets, minReadyTargets int) (bool, error) {
+func CheckTargetsReady(ctx context.Context, k8sClient kubernetes.Interface, selector func(Target) bool, minActiveTargets, minReadyTargets int) (bool, error) {
+
 	raw, err := k8sClient.CoreV1().
 		Services(namespace).
 		ProxyGet("http", "prometheus-k8s", "9090", "api/v1/targets", nil /*params*/).
-		DoRaw(context.TODO())
+		DoRaw(ctx)
 	if err != nil {
 		response := "(empty)"
 		if raw != nil {


### PR DESCRIPTION
We are seeing case that prometheus setup timeout after 15 minutes even though it only checked API once.

https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kops/18048/pull-kops-gce-master-scale-performance-100/2031269289339654144
Ref https://github.com/kubernetes/kops/pull/18048

We expect the `error while calling prometheus api` error every 30 seconds.
```
W0310 07:41:52.373712   57485 util.go:72] error while calling prometheus api: the server is currently unable to handle the request (get services http:prometheus-k8s:9090), response: k8s�

v1Status]

���Failure3no endpoints available for service "prometheus-k8s""ServiceUnavailable0��"�
I0310 07:44:17.236922   16474 boskos.go:86] Sending heartbeat to Boskos
I0310 07:49:17.341709   16474 boskos.go:86] Sending heartbeat to Boskos
I0310 07:54:17.450536   16474 boskos.go:86] Sending heartbeat to Boskos
F0310 07:56:52.563414   57485 clusterloader.go:355] Error while setting up prometheus stack: timed out waiting for the condition
```

/kind bug
/cc @mborsz