### PR TITLE
Bump perfdash version to 2.57

### DIFF
--- a/perfdash/Makefile
+++ b/perfdash/Makefile
@@ -1,7 +1,7 @@
 all: push
 
 # See deployment.yaml for the version currently running-- bump this ahead before rebuilding!
-TAG?=2.56
+TAG?=2.57
 
 REPO?=gcr.io/k8s-staging-perf-tests
 

--- a/perfdash/deployment.yaml
+++ b/perfdash/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: perfdash
-        image: gcr.io/k8s-staging-perf-tests/perfdash:2.56
+        image: gcr.io/k8s-staging-perf-tests/perfdash:2.57
         command:
           - /perfdash
           -   --www=true


### PR DESCRIPTION
## Overview

This PR bumps the perfdash version. 
Follow up of PR https://github.com/kubernetes/perf-tests/pull/3844 


## Testing
Local testing
```
cd perfdash
make run
```