### PR TITLE
fix: capture higher-precision metrics for pod_startup_latency

### DIFF
--- a/clusterloader2/pkg/measurement/common/slos/pod_startup_latency.go
+++ b/clusterloader2/pkg/measurement/common/slos/pod_startup_latency.go
@@ -19,17 +19,14 @@ package slos
 import (
 	"context"
 	"fmt"
-	"sort"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/tools/pager"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
 	"k8s.io/perf-tests/clusterloader2/pkg/errors"
@@ -37,6 +34,7 @@ import (
 	measurementutil "k8s.io/perf-tests/clusterloader2/pkg/measurement/util"
 	"k8s.io/perf-tests/clusterloader2/pkg/measurement/util/informer"
 	"k8s.io/perf-tests/clusterloader2/pkg/util"
+	"k8s.io/utils/clock"
 )
 
 const (
@@ -45,10 +43,22 @@ const (
 	podStartupLatencyMeasurementName  = "PodStartupLatency"
 	informerSyncTimeout               = time.Minute
 
-	createPhase   = "create"
+	// createPhase corresponds to the the time the resource is created, according to the watch stream.
+	// Granularity: Nanoseconds
+	createPhase = "create"
+
+	// SchedulePhase corresponds to the time when the scheduler schedules the pod, according to the watch stream.
+	// Granularity: Nanoseconds
 	schedulePhase = "schedule"
-	runPhase      = "run"
-	watchPhase    = "watch"
+
+	// runPhase corresponds to the time when the pod is running, according to the watch strema.
+	// Granularity: Nanoseconds
+	runPhase = "run"
+
+	// watchPhase corresponds to the time when the watch sees the pod running for the first time.
+	// Deprecated: this is now equivalent to runPhase.
+	// Granularity: Nanoseconds
+	watchPhase = "watch"
 )
 
 func init() {
@@ -63,6 +73,7 @@ func createPodStartupLatencyMeasurement() measurement.Measurement {
 		podStartupEntries: measurementutil.NewObjectTransitionTimes(podStartupLatencyMeasurementName),
 		podMetadata:       measurementutil.NewPodsMetadata(podStartupLatencyMeasurementName),
 		eventQueue:        workqueue.NewTyped[*eventData](),
+		clock:             clock.RealClock{},
 	}
 }
 
@@ -86,6 +97,7 @@ type podStartupLatencyMeasurement struct {
 	perc90Threshold  time.Duration
 	perc99Threshold  time.Duration
 	mapEventsByOrder bool
+	clock            clock.Clock
 }
 
 // Execute supports two actions:
@@ -173,7 +185,7 @@ func (p *podStartupLatencyMeasurement) start(c clientset.Interface) error {
 }
 
 func (p *podStartupLatencyMeasurement) addEvent(_, obj interface{}) {
-	event := &eventData{obj: obj, recvTime: time.Now()}
+	event := &eventData{obj: obj, recvTime: p.clock.Now()}
 	p.eventQueue.Add(event)
 }
 
@@ -222,6 +234,10 @@ var podStartupTransitions = map[string]measurementutil.Transition{
 		From: createPhase,
 		To:   watchPhase,
 	},
+	"create_to_run": {
+		From: createPhase,
+		To:   runPhase,
+	},
 }
 
 func podStartupTransitionsWithThreshold(threshold time.Duration) map[string]measurementutil.Transition {
@@ -247,10 +263,6 @@ func (p *podStartupLatencyMeasurement) gather(c clientset.Interface, identifier 
 	}
 
 	p.stop()
-
-	if err := p.gatherScheduleTimes(c, schedulerName); err != nil {
-		return nil, err
-	}
 
 	checks := []podStartupLatencyCheck{
 		{
@@ -288,76 +300,6 @@ func (p *podStartupLatencyMeasurement) gather(c clientset.Interface, identifier 
 	return summaries, err
 }
 
-// TODO(#2006): gatherScheduleTimes is currently listing events at the end of the test.
-//
-//	Given that events by default have 1h TTL, for measurements across longer periods
-//	it just returns incomplete results.
-//	Given that we don't 100% accuracy, we should switch to a mechanism that is similar
-//	to the one that slo-monitor is using (added in #1477).
-func (p *podStartupLatencyMeasurement) gatherScheduleTimes(c clientset.Interface, schedulerName string) error {
-	selector := fields.Set{
-		"involvedObject.kind": "Pod",
-		"source":              schedulerName,
-	}.AsSelector().String()
-	options := metav1.ListOptions{FieldSelector: selector}
-	pageLister := pager.New(func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
-		return c.CoreV1().Events(p.selector.Namespace).List(ctx, opts)
-	})
-	pageLister.PageSize = 10000
-
-	// Filter events to only include those that belong to pods we are tracking.
-	var filteredEvents []corev1.Event
-	err := pageLister.EachListItem(context.TODO(), options, func(obj runtime.Object) error {
-		event := obj.(*corev1.Event)
-		key := createMetaNamespaceKey(event.InvolvedObject.Namespace, event.InvolvedObject.Name)
-		if _, exists := p.podStartupEntries.Get(key, createPhase); exists {
-			filteredEvents = append(filteredEvents, *event)
-		}
-		return nil
-	})
-	if err != nil {
-		return err
-	}
-
-	if p.mapEventsByOrder {
-		orderedCreates := p.podStartupEntries.GetOrderedKeys(createPhase)
-		if len(orderedCreates) != len(filteredEvents) {
-			klog.Errorf("number of pod creations (%d) does not match number of scheduling events gathered (%d)", len(orderedCreates), len(filteredEvents))
-		}
-		sort.Slice(filteredEvents, func(i, j int) bool {
-			t1 := filteredEvents[i].EventTime.Time
-			if t1.IsZero() {
-				t1 = filteredEvents[i].FirstTimestamp.Time
-			}
-			t2 := filteredEvents[j].EventTime.Time
-			if t2.IsZero() {
-				t2 = filteredEvents[j].FirstTimestamp.Time
-			}
-			return t1.Before(t2)
-		})
-
-		for i := 0; i < len(orderedCreates) && i < len(filteredEvents); i++ {
-			event := filteredEvents[i]
-			key := orderedCreates[i].Key
-			if !event.EventTime.IsZero() {
-				p.podStartupEntries.Set(key, schedulePhase, event.EventTime.Time)
-			} else {
-				p.podStartupEntries.Set(key, schedulePhase, event.FirstTimestamp.Time)
-			}
-		}
-	} else {
-		for _, event := range filteredEvents {
-			key := createMetaNamespaceKey(event.InvolvedObject.Namespace, event.InvolvedObject.Name)
-			if !event.EventTime.IsZero() {
-				p.podStartupEntries.Set(key, schedulePhase, event.EventTime.Time)
-			} else {
-				p.podStartupEntries.Set(key, schedulePhase, event.FirstTimestamp.Time)
-			}
-		}
-	}
-	return nil
-}
-
 func (p *podStartupLatencyMeasurement) processEvent(event *eventData) {
 	obj, recvTime := event.obj, event.recvTime
 	if obj == nil {
@@ -371,24 +313,24 @@ func (p *podStartupLatencyMeasurement) processEvent(event *eventData) {
 	key := createMetaNamespaceKey(pod.Namespace, pod.Name)
 	p.podMetadata.SetStateless(key, isPodStateless(pod))
 
-	if pod.Status.Phase == corev1.PodRunning {
-		if _, found := p.podStartupEntries.Get(key, createPhase); !found {
-			p.podStartupEntries.Set(key, watchPhase, recvTime)
-			p.podStartupEntries.Set(key, createPhase, pod.CreationTimestamp.Time)
-			var startTime metav1.Time
-			for _, cs := range pod.Status.ContainerStatuses {
-				if cs.State.Running != nil {
-					if startTime.Before(&cs.State.Running.StartedAt) {
-						startTime = cs.State.Running.StartedAt
-					}
-				}
-			}
-			if startTime != metav1.NewTime(time.Time{}) {
-				p.podStartupEntries.Set(key, runPhase, startTime.Time)
-			} else {
-				klog.Errorf("%s: pod %v (%v) is reported to be running, but none of its containers is", p, pod.Name, pod.Namespace)
-			}
+	// Check if pod is scheduled and if so set schedulePhase if it's not set already.
+	if pod.Spec.NodeName != "" {
+		if _, found := p.podStartupEntries.Get(key, schedulePhase); !found {
+			p.podStartupEntries.Set(key, schedulePhase, recvTime)
 		}
+	}
+
+	// Check if pod is running and if so set runPhase if it's not set already.
+	if pod.Status.Phase == corev1.PodRunning {
+		if _, found := p.podStartupEntries.Get(key, runPhase); !found {
+			p.podStartupEntries.Set(key, runPhase, recvTime)
+			p.podStartupEntries.Set(key, watchPhase, recvTime)
+		}
+	}
+
+	// Check if this is the first time we see this pod and if so set createPhase.
+	if _, found := p.podStartupEntries.Get(key, createPhase); !found {
+		p.podStartupEntries.Set(key, createPhase, recvTime)
 	}
 }
 

--- a/clusterloader2/pkg/measurement/common/slos/pod_startup_latency_test.go
+++ b/clusterloader2/pkg/measurement/common/slos/pod_startup_latency_test.go
@@ -17,163 +17,175 @@ limitations under the License.
 package slos
 
 import (
-	"context"
+	"encoding/json"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes/fake"
+	measurementutil "k8s.io/perf-tests/clusterloader2/pkg/measurement/util"
+	clocktesting "k8s.io/utils/clock/testing"
 )
 
-func TestGatherScheduleTimes(t *testing.T) {
-	testCases := []struct {
-		name             string
-		mapEventsByOrder bool
-		podCreates       []struct {
-			name string
-			time time.Time
-		}
-		events []struct {
-			podName string
-			time    time.Time
-		}
-		wantScheduleTimes map[string]time.Time
-		wantErr           bool
-	}{
-		{
-			name:             "map by key (default)",
-			mapEventsByOrder: false,
-			podCreates: []struct {
-				name string
-				time time.Time
-			}{
-				{name: "pod1", time: time.Unix(100, 0)},
-				{name: "pod2", time: time.Unix(200, 0)},
-			},
-			events: []struct {
-				podName string
-				time    time.Time
-			}{
-				{podName: "pod2", time: time.Unix(210, 0)},
-				{podName: "pod1", time: time.Unix(110, 0)},
-			},
-			wantScheduleTimes: map[string]time.Time{
-				"default/pod1": time.Unix(110, 0),
-				"default/pod2": time.Unix(210, 0),
-			},
+func TestPodStartupLatency(t *testing.T) {
+	p := createPodStartupLatencyMeasurement().(*podStartupLatencyMeasurement)
+	t0 := time.Unix(100, 0)
+	fc := clocktesting.NewFakeClock(t0)
+	p.clock = fc
+	p.selector.Namespace = "default"
+	p.isRunning = true
+	p.stopCh = make(chan struct{})
+	p.threshold = 10 * time.Second
+	p.perc50Threshold = 10 * time.Second
+	p.perc90Threshold = 10 * time.Second
+	p.perc99Threshold = 10 * time.Second
+
+	// We will have 2 pods:
+	// pod-stateless:
+	//   created: t0
+	//   scheduled: t0 + 2s
+	//   running: t0 + 5s
+	//   latencies:
+	//     create_to_schedule: 2s (2000 ms)
+	//     schedule_to_run: 3s (3000 ms)
+	//     pod_startup: 5s (5000 ms)
+	// pod-stateful:
+	//   created: t0 + 10s
+	//   scheduled: t0 + 12s
+	//   running: t0 + 18s
+	//   latencies:
+	//     create_to_schedule: 2s (2000 ms)
+	//     schedule_to_run: 6s (6000 ms)
+	//     pod_startup: 8s (8000 ms) (This starts within 10s threshold to avoid SLO violation logspam)
+
+	// Event series:
+	// 1. Stateless pod created
+	podStateless := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod-stateless",
+			Namespace: "default",
 		},
-		{
-			name:             "map by order",
-			mapEventsByOrder: true,
-			podCreates: []struct {
-				name string
-				time time.Time
-			}{
-				{name: "pod-late-create", time: time.Unix(200, 0)},
-				{name: "pod-early-create", time: time.Unix(100, 0)},
-			},
-			events: []struct {
-				podName string
-				time    time.Time
-			}{
-				{podName: "pod-late-create", time: time.Unix(210, 0)},
-				{podName: "pod-early-create", time: time.Unix(110, 0)},
-			},
-			wantScheduleTimes: map[string]time.Time{
-				"default/pod-early-create": time.Unix(110, 0),
-				"default/pod-late-create":  time.Unix(210, 0),
-			},
+	}
+	p.addEvent(nil, podStateless)
+
+	// 2. Stateless pod scheduled at t0 + 2s
+	fc.SetTime(t0.Add(2 * time.Second))
+	podStatelessScheduled := podStateless.DeepCopy()
+	podStatelessScheduled.Spec.NodeName = "node1"
+	p.addEvent(nil, podStatelessScheduled)
+
+	// 3. Stateless pod running at t0 + 5s
+	fc.SetTime(t0.Add(5 * time.Second))
+	podStatelessRunning := podStatelessScheduled.DeepCopy()
+	podStatelessRunning.Status.Phase = corev1.PodRunning
+	p.addEvent(nil, podStatelessRunning)
+
+	// 4. Stateful pod created at t0 + 10s
+	fc.SetTime(t0.Add(10 * time.Second))
+	podStateful := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod-stateful",
+			Namespace: "default",
 		},
-		{
-			name:             "map by order - mismatch count",
-			mapEventsByOrder: true,
-			podCreates: []struct {
-				name string
-				time time.Time
-			}{
-				{name: "pod1", time: time.Unix(100, 0)},
-			},
-			events: []struct {
-				podName string
-				time    time.Time
-			}{
-				{podName: "event1", time: time.Unix(110, 0)},
-				{podName: "event2", time: time.Unix(120, 0)},
-			},
-		},
-		{
-			name:             "filtering untracked pods",
-			mapEventsByOrder: true,
-			podCreates: []struct {
-				name string
-				time time.Time
-			}{
-				{name: "tracked-pod", time: time.Unix(100, 0)},
-			},
-			events: []struct {
-				podName string
-				time    time.Time
-			}{
-				{podName: "untracked-pod", time: time.Unix(110, 0)},
-				{podName: "tracked-pod", time: time.Unix(120, 0)},
-			},
-			wantScheduleTimes: map[string]time.Time{
-				"default/tracked-pod": time.Unix(120, 0),
+		Spec: corev1.PodSpec{
+			Volumes: []corev1.Volume{
+				{
+					Name: "stateful-vol",
+					VolumeSource: corev1.VolumeSource{
+						HostPath: &corev1.HostPathVolumeSource{Path: "/data"},
+					},
+				},
 			},
 		},
 	}
+	p.addEvent(nil, podStateful)
 
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			p := createPodStartupLatencyMeasurement().(*podStartupLatencyMeasurement)
-			p.mapEventsByOrder = tc.mapEventsByOrder
-			p.selector.Namespace = "default"
+	// 5. Stateful pod scheduled at t0 + 12s
+	fc.SetTime(t0.Add(12 * time.Second))
+	podStatefulScheduled := podStateful.DeepCopy()
+	podStatefulScheduled.Spec.NodeName = "node1"
+	p.addEvent(nil, podStatefulScheduled)
 
-			for _, pc := range tc.podCreates {
-				key := createMetaNamespaceKey("default", pc.name)
-				p.podStartupEntries.Set(key, createPhase, pc.time)
-			}
+	// 6. Stateful pod running at t0 + 18s
+	fc.SetTime(t0.Add(18 * time.Second))
+	podStatefulRunning := podStatefulScheduled.DeepCopy()
+	podStatefulRunning.Status.Phase = corev1.PodRunning
+	p.addEvent(nil, podStatefulRunning)
 
-			client := fake.NewSimpleClientset()
-			for _, e := range tc.events {
-				event := &corev1.Event{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      e.podName + "-event",
-						Namespace: "default",
-					},
-					InvolvedObject: corev1.ObjectReference{
-						Kind:      "Pod",
-						Name:      e.podName,
-						Namespace: "default",
-					},
-					Source:    corev1.EventSource{Component: defaultSchedulerName},
-					EventTime: metav1.MicroTime{Time: e.time},
-				}
-				_, err := client.CoreV1().Events("default").Create(context.TODO(), event, metav1.CreateOptions{})
-				if err != nil {
-					t.Fatalf("failed to create event: %v", err)
-				}
-			}
+	// Process all work items
+	for p.eventQueue.Len() > 0 {
+		ok := p.processNextWorkItem()
+		if !ok {
+			t.Fatalf("Failed to process next work item")
+		}
+	}
 
-			err := p.gatherScheduleTimes(client, defaultSchedulerName)
-			if (err != nil) != tc.wantErr {
-				t.Errorf("gatherScheduleTimes() error = %v, wantErr %v", err, tc.wantErr)
-				return
-			}
+	// Gather the results
+	summaries, err := p.gather(nil, "test-run", "")
+	if err != nil {
+		t.Fatalf("Gather failed unexpectedly: %v", err)
+	}
 
-			if !tc.wantErr {
-				for key, wantTime := range tc.wantScheduleTimes {
-					gotTime, exists := p.podStartupEntries.Get(key, schedulePhase)
-					if !exists {
-						t.Errorf("schedule time for %s not found", key)
-						continue
-					}
-					if !gotTime.Equal(wantTime) {
-						t.Errorf("schedule time for %s = %v, want %v", key, gotTime, wantTime)
-					}
-				}
-			}
-		})
+	// We expect 3 summaries:
+	// 1. stateless & stateful combined (namePrefix: "")
+	// 2. stateless (namePrefix: "Stateless")
+	// 3. stateful (namePrefix: "Stateful")
+	if len(summaries) != 3 {
+		t.Fatalf("Expected 3 summaries, got %d", len(summaries))
+	}
+
+	summaryMap := make(map[string]string)
+	for _, s := range summaries {
+		summaryMap[s.SummaryName()] = s.SummaryContent()
+	}
+
+	assert.Contains(t, summaryMap, "PodStartupLatency_test-run")
+	assert.Contains(t, summaryMap, "StatelessPodStartupLatency_test-run")
+	assert.Contains(t, summaryMap, "StatefulPodStartupLatency_test-run")
+
+	// Verify stateless pod latencies
+	var statelessData measurementutil.PerfData
+	err = json.Unmarshal([]byte(summaryMap["StatelessPodStartupLatency_test-run"]), &statelessData)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal stateless summary: %v", err)
+	}
+
+	// For a single data point (percentiles 50, 90, 99 should be equal to that data point)
+	// create_to_schedule = 2s (2000ms)
+	// schedule_to_run = 3s (3000ms)
+	// pod_startup = 5s (5000ms)
+	for _, item := range statelessData.DataItems {
+		metric := item.Labels["Metric"]
+		switch metric {
+		case "create_to_schedule":
+			assert.Equal(t, 2000.0, item.Data["Perc50"])
+		case "schedule_to_run":
+			assert.Equal(t, 3000.0, item.Data["Perc50"])
+		case "pod_startup":
+			assert.Equal(t, 5000.0, item.Data["Perc50"])
+		}
+	}
+
+	// Verify stateful pod latencies
+	var statefulData measurementutil.PerfData
+	err = json.Unmarshal([]byte(summaryMap["StatefulPodStartupLatency_test-run"]), &statefulData)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal stateful summary: %v", err)
+	}
+
+	// create_to_schedule = 2s (2000ms)
+	// schedule_to_run = 6s (6000ms)
+	// pod_startup = 8s (8000ms)
+	for _, item := range statefulData.DataItems {
+		metric := item.Labels["Metric"]
+		switch metric {
+		case "create_to_schedule":
+			assert.Equal(t, 2000.0, item.Data["Perc50"])
+		case "schedule_to_run":
+			assert.Equal(t, 6000.0, item.Data["Perc50"])
+		case "pod_startup":
+			assert.Equal(t, 8000.0, item.Data["Perc50"])
+		}
 	}
 }


### PR DESCRIPTION
Issue #3889
