### PR TITLE
clusterloader2: add CL2_TOLERATION override to all workload templates

### DIFF
--- a/clusterloader2/testing/load/modules/reconcile-objects/daemonset.yaml
+++ b/clusterloader2/testing/load/modules/reconcile-objects/daemonset.yaml
@@ -3,6 +3,7 @@
 {{$Env := DefaultParam .Env ""}}
 {{$DaemonSetSurge := DefaultParam .CL2_DS_SURGE (MaxInt 10 (DivideInt .Nodes 20))}} # 5% of nodes, but not less than 10
 {{$RUN_ON_ARM_NODES := DefaultParam .CL2_RUN_ON_ARM_NODES false}}
+{{$TOLERATION := DefaultParam .CL2_TOLERATION ""}}
 
 {{$ENABLE_NETWORK_POLICY_ENFORCEMENT_LATENCY_TEST := DefaultParam .CL2_ENABLE_NETWORK_POLICY_ENFORCEMENT_LATENCY_TEST false}}
 {{$NET_POLICY_ENFORCEMENT_LATENCY_NODE_LABEL_VALUE := DefaultParam .CL2_NET_POLICY_ENFORCEMENT_LATENCY_NODE_LABEL_VALUE "net-policy-client"}}
@@ -53,6 +54,11 @@ spec:
       - key: "kubernetes.io/arch"
         operator: Equal
         value: arm64
+        effect: NoSchedule
+      {{end}}
+      {{if $TOLERATION}}
+      - key: {{$TOLERATION}}
+        operator: Exists
         effect: NoSchedule
       {{end}}
       {{if $ENABLE_NETWORK_POLICY_ENFORCEMENT_LATENCY_TEST}}

--- a/clusterloader2/testing/load/modules/reconcile-objects/deployment.yaml
+++ b/clusterloader2/testing/load/modules/reconcile-objects/deployment.yaml
@@ -8,6 +8,7 @@
 # Guard the new DNS tests. Remove it once it's confirmed that it works on a subset of tests.
 {{$USE_ADVANCED_DNSTEST := DefaultParam .CL2_USE_ADVANCED_DNSTEST false}}
 {{$RUN_ON_ARM_NODES := DefaultParam .CL2_RUN_ON_ARM_NODES false}}
+{{$TOLERATION := DefaultParam .CL2_TOLERATION ""}}
 
 {{$EnableNetworkPolicyEnforcementLatencyTest := DefaultParam .EnableNetworkPolicyEnforcementLatencyTest false}}
 {{$TargetLabelValue := DefaultParam .TargetLabelValue "enforcement-latency"}}
@@ -111,6 +112,11 @@ spec:
       - key: "kubernetes.io/arch"
         operator: Equal
         value: arm64
+        effect: NoSchedule
+      {{end}}
+      {{if $TOLERATION}}
+      - key: {{$TOLERATION}}
+        operator: Exists
         effect: NoSchedule
       {{end}}
       volumes:

--- a/clusterloader2/testing/load/modules/reconcile-objects/job.yaml
+++ b/clusterloader2/testing/load/modules/reconcile-objects/job.yaml
@@ -1,5 +1,6 @@
 {{$HostNetworkMode := DefaultParam .CL2_USE_HOST_NETWORK_PODS false}}
 {{$RUN_ON_ARM_NODES := DefaultParam .CL2_RUN_ON_ARM_NODES false}}
+{{$TOLERATION := DefaultParam .CL2_TOLERATION ""}}
 {{$Image := DefaultParam .Image "registry.k8s.io/pause:3.9"}}
 {{$podPayloadSize := DefaultParam .CL2_JOB_POD_PAYLOAD_SIZE 0}}
 {{$RuntimeClassName := DefaultParam .CL2_RUNTIME_CLASS_NAME nil}}
@@ -58,5 +59,10 @@ spec:
         - key: "kubernetes.io/arch"
           operator: Equal
           value: arm64
+          effect: NoSchedule
+        {{end}}
+        {{if $TOLERATION}}
+        - key: {{$TOLERATION}}
+          operator: Exists
           effect: NoSchedule
         {{end}}

--- a/clusterloader2/testing/load/modules/reconcile-objects/statefulset.yaml
+++ b/clusterloader2/testing/load/modules/reconcile-objects/statefulset.yaml
@@ -1,6 +1,7 @@
 {{$HostNetworkMode := DefaultParam .CL2_USE_HOST_NETWORK_PODS false}}
 {{$EnablePVs := DefaultParam .CL2_ENABLE_PVS true}}
 {{$RUN_ON_ARM_NODES := DefaultParam .CL2_RUN_ON_ARM_NODES false}}
+{{$TOLERATION := DefaultParam .CL2_TOLERATION ""}}
 {{$podPayloadSize := DefaultParam .CL2_STATEFULSET_POD_PAYLOAD_SIZE 0}}
 {{$Image := DefaultParam .Image "registry.k8s.io/pause:3.9"}}
 {{$RuntimeClassName := DefaultParam .CL2_RUNTIME_CLASS_NAME nil}}
@@ -65,6 +66,11 @@ spec:
       - key: "kubernetes.io/arch"
         operator: Equal
         value: arm64
+        effect: NoSchedule
+      {{end}}
+      {{if $TOLERATION}}
+      - key: {{$TOLERATION}}
+        operator: Exists
         effect: NoSchedule
       {{end}}
   {{if $EnablePVs}}

--- a/clusterloader2/testing/load/modules/scheduler-throughput/simple-deployment.yaml
+++ b/clusterloader2/testing/load/modules/scheduler-throughput/simple-deployment.yaml
@@ -6,6 +6,7 @@
 {{$MemoryRequest := DefaultParam .MemoryRequest "20M"}}
 {{$Image := DefaultParam .Image "registry.k8s.io/pause:3.9"}}
 {{$RUN_ON_ARM_NODES := DefaultParam .CL2_RUN_ON_ARM_NODES false}}
+{{$TOLERATION := DefaultParam .CL2_TOLERATION ""}}
 
 apiVersion: apps/v1
 kind: Deployment
@@ -55,5 +56,10 @@ spec:
       - key: "kubernetes.io/arch"
         operator: Equal
         value: arm64
+        effect: NoSchedule
+      {{end}}
+      {{if $TOLERATION}}
+      - key: {{$TOLERATION}}
+        operator: Exists
         effect: NoSchedule
       {{end}}


### PR DESCRIPTION
#### What this PR does / why we need it:
Allows CL2 to run on tainted nodes.

##### Details
Adds a new CL2_TOLERATION parameter that, when set to a non-empty string, adds a toleration, with operator: Exists and effect: NoSchedule, using that string as the key. This allows directing all workloads to tainted nodes.
This feature unblocks the use of Kwok virtual nodes.

Applies to: Deployment, StatefulSet, DaemonSet, Job (reconcile-objects) and simple-deployment (scheduler-throughput / huge-service).

/kind feature