### PR TITLE
feat: support custom Go build tags in clusterloader2 via CL2_BUILD_TAGS env var

### DIFF
--- a/clusterloader2/run-e2e.sh
+++ b/clusterloader2/run-e2e.sh
@@ -117,5 +117,5 @@ users:
 " > "${kubeconfig}"
 export KUBECONFIG=${kubeconfig}
 
-cd "${CLUSTERLOADER_ROOT}"/ && go build -o clusterloader './cmd/'
+cd "${CLUSTERLOADER_ROOT}"/ && go build -tags="${CL2_BUILD_TAGS:-}" -o clusterloader './cmd/'
 ./clusterloader --alsologtostderr --v="${CL2_VERBOSITY:-2}" "$@"


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds `-tags="${CL2_BUILD_TAGS:-}"` to the `go build` command in `clusterloader2/run-e2e.sh` so that Prow jobs can pass Go build tags (e.g. `fieldsv1string`) when building the clusterloader binary. When `CL2_BUILD_TAGS` is unset or empty, behavior is unchanged.

This enables performance testing of build-tag-gated features such as the FieldsV1 string interning optimization (kubernetes/kubernetes#137581), which reduces kube-apiserver memory usage for `managedFields` from O(N) to O(1) using Go 1.23's `unique.Handle[string]`.  This is the related test-infra PR which would set this value: 
- https://github.com/kubernetes/test-infra/pull/36684

#### Which issue(s) this PR fixes:

Related to: kubernetes/kubernetes#137109, https://github.com/kubernetes/test-infra/pull/36684

#### Special notes for your reviewer:

This is a companion PR to a `kubernetes/test-infra` PR (https://github.com/kubernetes/test-infra/pull/36684) that adds a new periodic Prow job (`ci-kubernetes-e2e-gce-scale-performance-100-fieldsv1string`) which uses `CL2_BUILD_TAGS` to run the ClusterLoader2 load test with the `fieldsv1string` build tag against a 100-node cluster.

Related PRs:
- kubernetes/kubernetes#137581 — FieldsV1 string interning implementation
- kubernetes/test-infra#36627 — Existing fieldsv1string correctness tests (unit, integration, e2e-kind)

/sig scalability
/sig api-machinery
