### PR TITLE
fix: correct logic for parsing string values in utils

### DIFF
--- a/clusterloader2/pkg/util/util.go
+++ b/clusterloader2/pkg/util/util.go
@@ -243,7 +243,7 @@ func getInt(dict map[string]interface{}, key string) (int, error) {
 	}
 	stringValue, ok := value.(string)
 	if ok {
-		if i, err := strconv.Atoi(stringValue); err != nil {
+		if i, err := strconv.Atoi(stringValue); err == nil {
 			return i, nil
 		}
 	}
@@ -262,7 +262,7 @@ func getFloat64(dict map[string]interface{}, key string) (float64, error) {
 	}
 	stringValue, ok := value.(string)
 	if ok {
-		if f, err := strconv.ParseFloat(stringValue, 64); err != nil {
+		if f, err := strconv.ParseFloat(stringValue, 64); err == nil {
 			return f, nil
 		}
 	}
@@ -294,7 +294,7 @@ func getBool(dict map[string]interface{}, key string) (bool, error) {
 	}
 	stringValue, ok := value.(string)
 	if ok {
-		if b, err := strconv.ParseBool(stringValue); err != nil {
+		if b, err := strconv.ParseBool(stringValue); err == nil {
 			return b, nil
 		}
 	}

--- a/clusterloader2/pkg/util/util_test.go
+++ b/clusterloader2/pkg/util/util_test.go
@@ -137,3 +137,144 @@ func TestGetLabelSelector(t *testing.T) {
 		})
 	}
 }
+
+func TestGetInt(t *testing.T) {
+	tests := []struct {
+		name    string
+		dict    map[string]interface{}
+		key     string
+		want    int
+		wantErr bool
+	}{
+		{
+			name: "int value",
+			dict: map[string]interface{}{"key": 123},
+			key:  "key",
+			want: 123,
+		},
+		{
+			name: "float64 value",
+			dict: map[string]interface{}{"key": 123.0},
+			key:  "key",
+			want: 123,
+		},
+		{
+			name: "string value success",
+			dict: map[string]interface{}{"key": "123"},
+			key:  "key",
+			want: 123,
+		},
+		{
+			name:    "string value failure",
+			dict:    map[string]interface{}{"key": "abc"},
+			key:     "key",
+			wantErr: true,
+		},
+		{
+			name:    "not found",
+			dict:    map[string]interface{}{},
+			key:     "key",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetInt(tt.dict, tt.key)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetInt() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !tt.wantErr {
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
+func TestGetFloat64(t *testing.T) {
+	tests := []struct {
+		name    string
+		dict    map[string]interface{}
+		key     string
+		want    float64
+		wantErr bool
+	}{
+		{
+			name: "float64 value",
+			dict: map[string]interface{}{"key": 123.45},
+			key:  "key",
+			want: 123.45,
+		},
+		{
+			name: "string value success",
+			dict: map[string]interface{}{"key": "123.45"},
+			key:  "key",
+			want: 123.45,
+		},
+		{
+			name:    "string value failure",
+			dict:    map[string]interface{}{"key": "abc"},
+			key:     "key",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetFloat64(tt.dict, tt.key)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetFloat64() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !tt.wantErr {
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
+func TestGetBool(t *testing.T) {
+	tests := []struct {
+		name    string
+		dict    map[string]interface{}
+		key     string
+		want    bool
+		wantErr bool
+	}{
+		{
+			name: "bool value",
+			dict: map[string]interface{}{"key": true},
+			key:  "key",
+			want: true,
+		},
+		{
+			name: "string value true",
+			dict: map[string]interface{}{"key": "true"},
+			key:  "key",
+			want: true,
+		},
+		{
+			name: "string value false",
+			dict: map[string]interface{}{"key": "false"},
+			key:  "key",
+			want: false,
+		},
+		{
+			name:    "string value failure",
+			dict:    map[string]interface{}{"key": "abc"},
+			key:     "key",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetBool(tt.dict, tt.key)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetBool() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !tt.wantErr {
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Previously, whenever we were converting string value, we returned default value even when conversion succeeded.

