### PR TITLE
watch-list/load-test: wait for the informer pods to be running before starting the load test

### DIFF
--- a/clusterloader2/testing/load/modules/informer/config.yaml
+++ b/clusterloader2/testing/load/modules/informer/config.yaml
@@ -33,3 +33,24 @@ steps:
           objectTemplatePath: /modules/informer/deployment.yaml
           templateFillMap:
             EnableWatchListFeature: "true"
+{{if eq $action "create"}}
+- name: Starting measurement for waiting for informer pods to be running
+  measurements:
+  - Method: WaitForControlledPodsRunning
+    Instances:
+    - Identifier: WaitForRunningInformerDeployments
+      Params:
+        apiVersion: apps/v1
+        kind: Deployment
+    Params:
+      action: start
+      labelSelector: group = informer
+      operationTimeout: 2m
+- name: Waiting for informer pods to be running
+  measurements:
+  - Method: WaitForControlledPodsRunning
+    Instances:
+    - Identifier: WaitForRunningInformerDeployments
+    Params:
+      action: gather
+{{end}}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
While looking into the latency difference between the WatchList ON and the WatchList OFF (standard LIST) for the scalability test ([xref](https://github.com/kubernetes/kubernetes/issues/134375#issuecomment-3992839042))  I realized the comparison isn’t valid because they run under different conditions. 

Both pods (WatchList ON/OFF) are created early in the test, but right after that the test creates a large number of pods without waiting for them to start. Probably this overloads the kubelet on the node. As a result, the OFF pod starts very late (about 71–73 minutes), missing the entire "scale up" phase it’s supposed to measure. The ON pod starts almost immediately and runs during the full "scale up".


This PR adds a step after the informer deployment creation to ensure both pods are running before the "scale up" begins.

An alternative approach would be to start both pods after the "scale up" phase.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

Totally untested. Is there a way to test it before merging ?