### PR TITLE
Cleanup unused CL2_USE_HOST_NETWORK_PODS

### DIFF
--- a/clusterloader2/testing/load/modules/reconcile-objects/daemonset.yaml
+++ b/clusterloader2/testing/load/modules/reconcile-objects/daemonset.yaml
@@ -1,4 +1,3 @@
-{{$HostNetworkMode := DefaultParam .CL2_USE_HOST_NETWORK_PODS false}}
 {{$Image := DefaultParam .Image "registry.k8s.io/pause:3.9"}}
 {{$Env := DefaultParam .Env ""}}
 {{$DaemonSetSurge := DefaultParam .CL2_DS_SURGE (MaxInt 10 (DivideInt .Nodes 20))}} # 5% of nodes, but not less than 10
@@ -31,7 +30,6 @@ spec:
       {{if $RuntimeClassName}}
       runtimeClassName: {{$RuntimeClassName}}
       {{end}}
-      hostNetwork: {{$HostNetworkMode}}
       containers:
       - name: {{.Name}}
         image: {{$Image}}

--- a/clusterloader2/testing/load/modules/reconcile-objects/deployment.yaml
+++ b/clusterloader2/testing/load/modules/reconcile-objects/deployment.yaml
@@ -1,4 +1,3 @@
-{{$HostNetworkMode := DefaultParam .CL2_USE_HOST_NETWORK_PODS false}}
 # Keep the CpuRequest/MemoryRequest request equal percentage of 1-core, 4GB node.
 # For now we're setting it to 0.5%.
 {{$CpuRequest := DefaultParam .CpuRequest "5m"}}
@@ -48,7 +47,6 @@ spec:
       {{if $RuntimeClassName}}
       runtimeClassName: {{$RuntimeClassName}}
       {{end}}
-      hostNetwork: {{$HostNetworkMode}}
       containers:
 {{if .EnableDNSTests}}
 {{if $USE_ADVANCED_DNSTEST}}

--- a/clusterloader2/testing/load/modules/reconcile-objects/job.yaml
+++ b/clusterloader2/testing/load/modules/reconcile-objects/job.yaml
@@ -1,4 +1,3 @@
-{{$HostNetworkMode := DefaultParam .CL2_USE_HOST_NETWORK_PODS false}}
 {{$RUN_ON_ARM_NODES := DefaultParam .CL2_RUN_ON_ARM_NODES false}}
 {{$Image := DefaultParam .Image "registry.k8s.io/pause:3.9"}}
 {{$podPayloadSize := DefaultParam .CL2_JOB_POD_PAYLOAD_SIZE 0}}
@@ -27,7 +26,6 @@ spec:
       {{if $RuntimeClassName}}
       runtimeClassName: {{$RuntimeClassName}}
       {{end}}
-      hostNetwork: {{$HostNetworkMode}}
       containers:
       - name: {{.Name}}
         # TODO(#799): We should test the "run-to-completion" workflow and hence don't use pause pods.

--- a/clusterloader2/testing/load/modules/reconcile-objects/statefulset.yaml
+++ b/clusterloader2/testing/load/modules/reconcile-objects/statefulset.yaml
@@ -1,4 +1,3 @@
-{{$HostNetworkMode := DefaultParam .CL2_USE_HOST_NETWORK_PODS false}}
 {{$EnablePVs := DefaultParam .CL2_ENABLE_PVS true}}
 {{$RUN_ON_ARM_NODES := DefaultParam .CL2_RUN_ON_ARM_NODES false}}
 {{$podPayloadSize := DefaultParam .CL2_STATEFULSET_POD_PAYLOAD_SIZE 0}}
@@ -28,7 +27,6 @@ spec:
       {{if $RuntimeClassName}}
       runtimeClassName: {{$RuntimeClassName}}
       {{end}}
-      hostNetwork: {{$HostNetworkMode}}
       containers:
       - name: {{.Name}}
         image: {{$Image}}

--- a/clusterloader2/testing/load/modules/scheduler-throughput/simple-deployment.yaml
+++ b/clusterloader2/testing/load/modules/scheduler-throughput/simple-deployment.yaml
@@ -1,4 +1,3 @@
-{{$HostNetworkMode := DefaultParam .CL2_USE_HOST_NETWORK_PODS false}}
 # Keep the CpuRequest/MemoryRequest request equal percentage of 1-core, 4GB node.
 # For now we're setting it to 0.5%.
 {{$CpuRequest := DefaultParam .CpuRequest "5m"}}
@@ -27,7 +26,6 @@ spec:
         svc: {{.SvcName}}-{{.Index}}
 {{end}}
     spec:
-      hostNetwork: {{$HostNetworkMode}}
       containers:
       - env:
         - name: ENV_VAR


### PR DESCRIPTION
Not used anywhere https://cs.k8s.io/?q=CL2_USE_HOST_NETWORK_PODS&i=nope&literal=nope&files=&excludeFiles=%5Eclusterloader2%2F&repos=

Cleanup for https://github.com/kubernetes/kubernetes/issues/138415

/cc @mborsz @jprzychodzen