### PR TITLE
Fix resourceFieldRef

### DIFF
--- a/clusterloader2/testing/load/modules/reconcile-objects/deployment.yaml
+++ b/clusterloader2/testing/load/modules/reconcile-objects/deployment.yaml
@@ -101,12 +101,12 @@ spec:
         - name: GOMAXPROCS
           valueFrom:
             resourceFieldRef:
-              container: main
+              containerName: main
               resource: limits.cpu
         - name: MEM_LIMIT_BYTES
           valueFrom:
             resourceFieldRef:
-              container: main
+              containerName: main
               resource: limits.memory
         - name: JAVA_TOOL_OPTIONS
           value: "-XX:MaxRAMPercentage=75.0 -XX:+CrashOnOutOfMemoryError"


### PR DESCRIPTION
Fix `I0421 18:37:38.679807   24137 warnings.go:110] "Warning: unknown field \"spec.template.spec.containers[0].env[4].valueFrom.resourceFieldRef.container\""` in 

https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kubernetes-e2e-gce-scale-resource-size/2046635450986139648

/cc @mborsz @Qqkyu @jprzychodzen 

Part of https://github.com/kubernetes/kubernetes/issues/138415 
