### PR TITLE
Add environment variables to sidecar to increase pod size from 9KB to 10KB to match exactly the non-realistic scenario

### DIFF
--- a/clusterloader2/testing/load/modules/reconcile-objects/deployment.yaml
+++ b/clusterloader2/testing/load/modules/reconcile-objects/deployment.yaml
@@ -103,19 +103,19 @@ spec:
             resourceFieldRef:
               containerName: main
               resource: limits.cpu
-        - name: MEM_LIMIT_BYTES
+        - name: GOMEMLIMIT
           valueFrom:
             resourceFieldRef:
               containerName: main
               resource: limits.memory
         - name: JAVA_TOOL_OPTIONS
-          value: "-XX:MaxRAMPercentage=75.0 -XX:+CrashOnOutOfMemoryError"
+          value: "-XX:MaxRAMPercentage=75.0"
         - name: REDIS_URL
-          value: "redis://redis-master.cache.svc.cluster.local:6379/0"
+          value: "redis://main:6379/0"
         - name: PYTHONUNBUFFERED
           value: "1"
         - name: NODE_ENV
-          value: "production"
+          value: "prod"
         resources:
           requests:
             cpu: 5m
@@ -127,6 +127,45 @@ spec:
           name: secret
       - name: sidecar
         image: registry.k8s.io/pause:3.9
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              containerName: sidecar
+              resource: limits.cpu
+        - name: GOMEMLIMIT
+          valueFrom:
+            resourceFieldRef:
+              containerName: sidecar
+              resource: limits.memory
+        - name: JAVA_TOOL_OPTIONS
+          value: "-XX:MaxRAMPercentage=75.0"
+        - name: REDIS_URL
+          value: "redis://main:6379/0"
+        - name: PYTHONUNBUFFERED
+          value: "1"
+        - name: NODE_ENV
+          value: "prod"
+        resources:
+          requests:
+            cpu: 5m
+            memory: 20M
 {{else}}
       containers:
   {{if .EnableDNSTests}}


### PR DESCRIPTION
Part of https://github.com/kubernetes/kubernetes/issues/138415

/cc @Qqkyu 

This time verified the exact output size.
```
$ kubectl proxy &
$ curl -s -H "Accept: application/vnd.kubernetes.protobuf" http://localhost:8001/api/v1/namespaces/test-vzywmm-1/pods/small-deployment-1-57cb6867cd-v46ws | wc -c
10285
```
