### PR TITLE
Add error logging when availability request is not OK.

### DIFF
--- a/clusterloader2/pkg/measurement/common/api_availability_measurement.go
+++ b/clusterloader2/pkg/measurement/common/api_availability_measurement.go
@@ -115,6 +115,9 @@ func (a *apiAvailabilityMeasurement) updateClusterAvailabilityMetrics(c clientse
 	availability := status == http.StatusOK
 	if !availability {
 		klog.Warningf("cluster not available; HTTP status code: %d", status)
+		if err := result.Error(); err != nil {
+			klog.Warningf("request error: %v", err)
+		}
 	}
 	a.clusterLevelMetrics.update(availability)
 }


### PR DESCRIPTION
#### What this PR does / why we need it:

Log error when cluster availability request is not OK.

#### Which issue(s) this PR fixes:

To see just a status in logs is not informative enough, especially when status = 0

#### Special notes for your reviewer:

