### PR TITLE
watch-list/load-test: Add option to run informer watch-list pods on control-plane node

### DIFF
--- a/clusterloader2/testing/load/modules/informer/config.yaml
+++ b/clusterloader2/testing/load/modules/informer/config.yaml
@@ -1,6 +1,7 @@
 ## Input params
 # Valid actions: "create", "delete"
 {{$action := .action}}
+{{$RunOnControlPlane := DefaultParam .CL2_INFORMER_RUN_ON_CONTROL_PLANE false}}
 
 steps:
 - name: {{$action}} informer role
@@ -33,6 +34,26 @@ steps:
           objectTemplatePath: /modules/informer/deployment.yaml
           templateFillMap:
             EnableWatchListFeature: "true"
+{{if $RunOnControlPlane}}
+    - namespaceList: ["informer-0"]
+      replicasPerNamespace: 1
+      tuningSet: default
+      objectBundle:
+        - basename: informer-watch-list-off-control-plane
+          objectTemplatePath: /modules/informer/deployment.yaml
+          templateFillMap:
+            EnableWatchListFeature: "false"
+            RunOnControlPlane: "true"
+    - namespaceList: ["informer-0"]
+      replicasPerNamespace: 1
+      tuningSet: default
+      objectBundle:
+        - basename: informer-watch-list-on-control-plane
+          objectTemplatePath: /modules/informer/deployment.yaml
+          templateFillMap:
+            EnableWatchListFeature: "true"
+            RunOnControlPlane: "true"
+{{end}}
 {{if eq $action "create"}}
 - name: Starting measurement for waiting for informer pods to be running
   measurements:

--- a/clusterloader2/testing/load/modules/informer/deployment.yaml
+++ b/clusterloader2/testing/load/modules/informer/deployment.yaml
@@ -1,4 +1,5 @@
 {{$TolerateControlPlane := DefaultParam .CL2_INFORMER_TOLERATE_CONTROL_PLANE false}}
+{{$RunOnControlPlane := DefaultParam .RunOnControlPlane false}}
 
 apiVersion: apps/v1
 kind: Deployment
@@ -15,11 +16,15 @@ spec:
       labels:
         group: informer
     spec:
-{{if $TolerateControlPlane}}
+{{if or $TolerateControlPlane $RunOnControlPlane}}
       tolerations:
         - key: node-role.kubernetes.io/control-plane
           operator: Exists
           effect: NoSchedule
+{{end}}
+{{if $RunOnControlPlane}}
+      nodeSelector:
+        node-role.kubernetes.io/control-plane: ""
 {{end}}
       containers:
         - name: {{.Name}}


### PR DESCRIPTION
Add `CL2_INFORMER_RUN_ON_CONTROL_PLANE` toggle to create additional watch-list deployments pinned to the control-plane node via nodeSelector and toleration.

I will open a new PR to test-infra which will set `CL2_INFORMER_RUN_ON_CONTROL_PLANE`  for `pull-perf-tests-gce-master-scale-performance-5000` job (later on we will add the new env var for all related jobs).

This ^ won't break anything and will allow us to test this PR.