### PR TITLE
watch-list: wait for informer pods to be running before starting the load test

### DIFF
--- a/clusterloader2/testing/watch-list/config.yaml
+++ b/clusterloader2/testing/watch-list/config.yaml
@@ -54,6 +54,25 @@ steps:
           templateFillMap:
             Duration: {{$testDuration}}
             EnableWatchListFeature: {{$enableWatchListFeature}}
+- name: Starting measurement for waiting for informer pods to be running
+  measurements:
+  - Method: WaitForControlledPodsRunning
+    Instances:
+    - Identifier: WaitForRunningWatchListJobs
+      Params:
+        apiVersion: batch/v1
+        kind: Job
+    Params:
+      action: start
+      labelSelector: group = watch-list
+      operationTimeout: 2m
+- name: Waiting for informer pods to be running
+  measurements:
+  - Method: WaitForControlledPodsRunning
+    Instances:
+    - Identifier: WaitForRunningWatchListJobs
+    Params:
+      action: gather
 - name: Wait for the secret informer job to finish
   measurements:
     - Identifier: WaitForFinishedJobs


### PR DESCRIPTION
This is the same fix as #3931 but for the standalone watch-list test.

Without this, pods may start at different times due to scheduling delays, making the WatchList vs LIST comparison invalid. For example, in [a recent CI run ](https://storage.googleapis.com/kubernetes-ci-logs/logs/ci-kubernetes-e2e-gci-gce-scalability-watch-list-on/2051978427371622400/artifacts/APIResponsivenessPrometheus_simple_watch-list_2026-05-06T11:07:05Z.json)the LIST pod only recorded 5 API calls vs 498 for WatchList.

```
  {
      "data": {
        "Perc50": 25,
        "Perc90": 45,
        "Perc99": 49.5
      },
      "unit": "ms",
      "labels": {
        "Count": "5",
        "Resource": "secrets",
        "Scope": "namespace",
        "SlowCount": "0",
        "Subresource": "",
        "Verb": "LIST"
      }
    },
 ```

vs

```
 {
      "data": {
        "Perc50": 12843.138758,
        "Perc90": 16153.432877,
        "Perc99": 19615.343287
      },
      "unit": "ms",
      "labels": {
        "Count": "498",
        "Resource": "secrets",
        "Scope": "namespace",
        "SlowCount": "0",
        "Subresource": "",
        "Verb": "WATCHLIST"
      }
    },
 ```