### PR TITLE
Add ObjectCount

### DIFF
--- a/clusterloader2/testing/load/modules/measurements.yaml
+++ b/clusterloader2/testing/load/modules/measurements.yaml
@@ -280,6 +280,21 @@ steps:
         query: quantile_over_time(0.99, sum by (group, resource) (apiserver_resource_size_estimate_bytes / 1024 / 1024)[%v:])
       - name: max
         query: max_over_time(sum by (group, resource) (apiserver_resource_size_estimate_bytes / 1024 / 1024)[%v:])
+  - Identifier: ObjectCount
+    Method: GenericPrometheusQuery
+    Params:
+      action: {{$action}}
+      metricName: ObjectCount
+      metricVersion: v1
+      unit: count
+      dimensions:
+      - resource
+      - group
+      queries:
+      - name: Perc99
+        query: quantile_over_time(0.99, sum by (group, resource) (apiserver_resource_objects)[%v:])
+      - name: max
+        query: max_over_time(sum by (group, resource) (apiserver_resource_objects)[%v:])
 - module:
     path: modules/dns-performance-metrics.yaml
     params:


### PR DESCRIPTION
/kind feature

Fixes https://github.com/kubernetes/perf-tests/issues/3944
Similar to https://github.com/kubernetes/perf-tests/pull/3643

Uses the `apiserver_resource_objects` metric.

Results from the pull-perf-tests-clusterloader2-kubemark presubmit on this PR:
- https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/perf-tests/4017/pull-perf-tests-clusterloader2-kubemark/2052181343244128256
- [GenericPrometheusQuery ObjectCount_load_2026-05-07T00:46:31Z.json](https://storage.googleapis.com/kubernetes-ci-logs/pr-logs/pull/perf-tests/4017/pull-perf-tests-clusterloader2-kubemark/2052181343244128256/artifacts/GenericPrometheusQuery%20ObjectCount_load_2026-05-07T00:46:31Z.json)

```
{
  "version": "v1",
  "dataItems": [
    {
      "data": {
        "Perc99": 1,
        "max": 1
      },
      "unit": "count",
      "labels": {
        "group": "admissionregistration.k8s.io",
        "resource": "mutatingwebhookconfigurations"
      }
    },
    {
      "data": {
        "Perc99": 1,
        "max": 1
      },
      "unit": "count",
      "labels": {
        "group": "",
        "resource": "limitranges"
      }
    },
    {
      "data": {
        "Perc99": 80,
        "max": 80
      },
      "unit": "count",
      "labels": {
        "group": "rbac.authorization.k8s.io",
        "resource": "clusterroles"
      }
    },
    {
      "data": {
        "Perc99": 0,
        "max": 0
      },
      "unit": "count",
      "labels": {
        "group": "resource.k8s.io",
        "resource": "resourceclaimtemplates"
      }
    },
```
