### PR TITLE
watchlist binary on the master node connects to the API server via localhost

### DIFF
--- a/clusterloader2/testing/load/modules/informer/deployment.yaml
+++ b/clusterloader2/testing/load/modules/informer/deployment.yaml
@@ -24,6 +24,7 @@ spec:
           effect: NoSchedule
 {{end}}
 {{if $RunOnControlPlane}}
+      hostNetwork: true
       nodeSelector:
         node-role.kubernetes.io/control-plane: ""
 {{end}}
@@ -37,6 +38,13 @@ spec:
             limits:
               memory: "16Gi"
               cpu: "6"
+{{if $RunOnControlPlane}}
+          env:
+            - name: KUBERNETES_SERVICE_HOST
+              value: "127.0.0.1"
+            - name: KUBERNETES_SERVICE_PORT
+              value: "443"
+{{end}}
           command: [ "watch-list" ]
           args:
             - "--alsologtostderr=true"


### PR DESCRIPTION
earlier we added an option to run watch-list pods on control-plane nodes (#3982).

this pr forces these pods to connect to the kube api over localhost.

this is important when debugging scalability issues where networking is the usual suspect.