### PR TITLE
util-images: pin gcb-docker-gcloud image to current digest

### DIFF
--- a/util-images/cloudbuild.yaml
+++ b/util-images/cloudbuild.yaml
@@ -6,7 +6,7 @@ options:
   machineType: 'N1_HIGHCPU_8'
 
 steps:
-  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20210917-12df099d55'
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud@sha256:ff388e0dc16351e96f8464e2e185b74a7578a5ccb7a112cf3393468e59e6e2d2'  # v20260205-38cfa9523f
     entrypoint: bash
     dir: ./util-images
     env:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Updates util-images/cloudbuild.yaml to use gcr.io/k8s-staging-test-infra/gcb-docker-gcloud pinned by digest (sha256:ff388e0dc16351e96f8464e2e185b74a7578a5ccb7a112cf3393468e59e6e2d2) with a tag comment (v20260205-38cfa9523f). The previous tag was removed by staging registry retention, which causes image push jobs to fail with manifest unknown; digest pinning also reduces the chance of repeat breakage when old tags are GC’d.

#### Which issue(s) this PR fixes:
Related : kubernetes/kubernetes#138936

#### Special notes for your reviewer:
None; single-line image reference change only. Matches the pattern recommended in the issue (digest pin + tag comment).

