### PR TITLE
add watch cache initialization metric to restart test

### DIFF
--- a/clusterloader2/testing/load/modules/restart-apiserver.yaml
+++ b/clusterloader2/testing/load/modules/restart-apiserver.yaml
@@ -20,6 +20,23 @@ steps:
     Params:
       action: pauseSystemPodMetrics
 
+- name: Start WatchCacheInitializationDuration measurement
+  measurements:
+  - Identifier: WatchCacheInitializationDuration
+    Method: GenericPrometheusQuery
+    Params:
+      action: start
+      metricName: Watch Cache Initialization Duration
+      metricVersion: v1
+      unit: s
+      dimensions:
+      - resource
+      queries:
+      - name: Avg
+        query: sum by (resource) (apiserver_watch_cache_initialization_duration_seconds_sum) / (sum by (resource) (apiserver_watch_cache_initialization_duration_seconds_count) > 0)
+      - name: Count
+        query: sum by (resource) (apiserver_watch_cache_initialization_duration_seconds_count)
+
 - name: Restart kube-apiserver and wait for /readyz
   measurements:
   - Identifier: RestartApiserver
@@ -34,6 +51,13 @@ steps:
     Method: Sleep
     Params:
       duration: {{$SETTLE_DURATION}}
+
+- name: Gather WatchCacheInitializationDuration measurement
+  measurements:
+  - Identifier: WatchCacheInitializationDuration
+    Method: GenericPrometheusQuery
+    Params:
+      action: gather
 
 - name: Unpausing SystemPodMetrics restart counts
   measurements:


### PR DESCRIPTION
Verified via testing with default=on.

Metric sample: https://storage.googleapis.com/kubernetes-ci-logs/pr-logs/pull/perf-tests/4027/pull-perf-tests-clusterloader2/2054337704006520832/artifacts/GenericPrometheusQuery%20Watch%20Cache%20Initialization%20Duration_load_2026-05-12T23:24:53Z.json

Uses metric added in https://github.com/kubernetes/kubernetes/pull/138767