### PR TITLE
perfdash: grey out label dropdown values with no data

### DIFF
--- a/perfdash/www/index.html
+++ b/perfdash/www/index.html
@@ -3,6 +3,12 @@
     <link rel="stylesheet" href="https://ajax.googleapis.com/ajax/libs/angular_material/0.9.4/angular-material.min.css">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=RobotoDraft:300,400,500,700,400italic">
     <meta name="viewport" content="initial-scale=1" />
+    <style>
+      md-option.unavailable {
+        opacity: 0.35;
+        pointer-events: none;
+      }
+    </style>
   </head>
   <body>
     <div layout="column" style="margin-top: 20px; width: 80%" offset="10" ng-controller="AppCtrl">
@@ -42,7 +48,8 @@
         <div ng-repeat="(name, items) in controller.labels" ng-model="controller.metricName" ng-change="controller.labelChanged()" style="width: 200px; display: inline-block;">
           <md-input-container>
             <md-select placeholder="name" ng-model="controller.selectedLabels[name]"  ng-change="controller.labelChanged()">
-              <md-option ng-value="item" ng-repeat="item in items">
+              <md-option ng-value="item" ng-repeat="item in items"
+                         ng-class="{'unavailable': !controller.availableLabels[name][item]}">
                 {{item}}
               </md-option>
             </md-select>

--- a/perfdash/www/script.js
+++ b/perfdash/www/script.js
@@ -171,6 +171,26 @@ PerfDashApp.prototype.metricNameChanged = function() {
 // Update the data to graph, using selected labels
 PerfDashApp.prototype.labelChanged = function() {
     this.setURLParameters();
+    var available = {};
+    var selected = this.selectedLabels;
+    angular.forEach(this.data, function(items) {
+        angular.forEach(items, function(item) {
+            if (!item.labels || !item.data) return;
+            for (var name in item.labels) {
+                var matchesOtherSelections = true;
+                for (var other in selected) {
+                    if (other !== name && item.labels[other] !== selected[other]) {
+                        matchesOtherSelections = false;
+                        break;
+                    }
+                }
+                if (!matchesOtherSelections) continue;
+                if (!available[name]) available[name] = {};
+                available[name][item.labels[name]] = true;
+            }
+        });
+    });
+    this.availableLabels = available;
     this.seriesData = [];
     this.series = [];
     result = this.getData(this.selectedLabels);


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

As someone new to using perfdash, I found it really confusing that we have a whole matrix of dropdown options with most of them being noop because there is no data populated.

Want to propose a qol improvement to gray out the the options that have no data and disable clicking them.

Before: 
<img width="1495" height="411" src="https://github.com/user-attachments/assets/e3bb898a-902a-43d5-ad7b-f5c732a83ca7" />

After:
<img width="1520" height="449" src="https://github.com/user-attachments/assets/9bc8ab27-df86-4d36-9dfa-b39d092d6c4b" />

I tested this locally with just the benchmark proto list data. 

