### PR TITLE
cl2/list: fix apiserver memory query to the apiserver container

### DIFF
--- a/clusterloader2/testing/list/modules/measurements.yaml
+++ b/clusterloader2/testing/list/modules/measurements.yaml
@@ -36,7 +36,7 @@ steps:
         query: |
           max_over_time(
           sum(
-            container_memory_working_set_bytes{namespace="monitoring", pod=~"kube-apiserver.*"} 
+            container_memory_working_set_bytes{namespace="monitoring", pod=~"kube-apiserver.*", container="kube-apiserver"}
             / 1024 / 1024
           )[%v:])
         threshold: {{$APISERVER_MEMORY_THRESHOLD_MEGABYTES}}


### PR DESCRIPTION
After adding test for CBOR I noticed [this run](https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kubernetes-benchmark-list-cbor/2055037236440731648) reporting `MaxMemory: 166067 MiB` (~162 GiB) for kube-apiserver. The master is `n2-standard-32` ([job config](https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml#L1148)) which has 128 GiB of RAM, so this number should be impossible...

Most likely scenario is that this is double counting numbers, noticed that `container=""` and `container="kube-apiserver"` provided identical numbers and the metric sums across them, which points to the number being reported 2x what it should be.

This only affects the benchmark list jobs (json, proto, cbor)