### PR TITLE
clusterloader2: add opt-in periodic heap profiling

### DIFF
--- a/clusterloader2/cmd/clusterloader.go
+++ b/clusterloader2/cmd/clusterloader.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/perf-tests/clusterloader2/pkg/execservice"
 	"k8s.io/perf-tests/clusterloader2/pkg/flags"
 	"k8s.io/perf-tests/clusterloader2/pkg/framework"
+	"k8s.io/perf-tests/clusterloader2/pkg/heapprofile"
 	"k8s.io/perf-tests/clusterloader2/pkg/imagepreload"
 	"k8s.io/perf-tests/clusterloader2/pkg/metadata"
 	"k8s.io/perf-tests/clusterloader2/pkg/modifier"
@@ -64,6 +65,7 @@ var (
 	testSuiteConfigPath string
 	port                int
 	dryRun              bool
+	heapProfileInterval time.Duration
 )
 
 func initClusterFlags() {
@@ -132,6 +134,7 @@ func initFlags() {
 	flags.StringArrayVar(&clusterLoaderConfig.OverridePaths, "testoverrides", []string{}, "Paths to the config overrides file. The latter overrides take precedence over changes in former files.")
 	flags.StringVar(&testSuiteConfigPath, "testsuite", "", "Path to the test suite config file")
 	flags.IntVar(&port, "port", 8000, "Port to be used by http server with pprof.")
+	flags.DurationEnvVar(&heapProfileInterval, "heap-profile-interval", "CL2_HEAP_PROFILE_INTERVAL", 0, "Interval between clusterloader2 heap profiles. 0 represents disabled.")
 	flags.BoolVar(&dryRun, "dry-run", false, "Whether to skip running test and only compile test config")
 
 	initClusterFlags()
@@ -149,6 +152,12 @@ func validateFlags() *errors.ErrorList {
 	}
 	if len(testConfigPaths) > 0 && testSuiteConfigPath != "" {
 		errList.Append(fmt.Errorf("test config path and test suite path cannot be provided at the same time"))
+	}
+	if heapProfileInterval < 0 {
+		errList.Append(fmt.Errorf("heap-profile-interval must be non-negative, got %s", heapProfileInterval))
+	}
+	if heapProfileInterval > 0 && clusterLoaderConfig.ReportDir == "" {
+		errList.Append(fmt.Errorf("heap-profile-interval requires --report-dir to be set"))
 	}
 	errList.Concat(validateClusterFlags())
 	errList.Concat(prometheus.ValidatePrometheusFlags(&clusterLoaderConfig.PrometheusConfig))
@@ -320,6 +329,10 @@ func main() {
 
 	if err = createReportDir(); err != nil {
 		klog.Exitf("Cannot create report directory: %v", err)
+	}
+
+	if heapProfileInterval > 0 {
+		heapprofile.Start(clusterLoaderConfig.ReportDir, heapProfileInterval)
 	}
 
 	if err = util.LogClusterNodes(mclient.GetClient()); err != nil {

--- a/clusterloader2/pkg/heapprofile/heapprofile.go
+++ b/clusterloader2/pkg/heapprofile/heapprofile.go
@@ -1,0 +1,59 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package heapprofile periodically dumps the clusterloader2 process heap
+// profile into the report dir for diagnosing runner-pod OOMs. Profiles follow
+// the same <name>_<RFC3339>.pprof naming convention as the KCP profiles
+// collected by pkg/measurement/common/profile.go, so existing artifact tooling
+// picks them up the same way.
+package heapprofile
+
+import (
+	"os"
+	"path"
+	"runtime/pprof"
+	"time"
+
+	"k8s.io/klog/v2"
+)
+
+// Start launches periodic heap profiling.
+func Start(reportDir string, interval time.Duration) {
+	klog.Infof("Heap profiling enabled: writing to %q every %s", reportDir, interval)
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for range ticker.C {
+			writeHeapProfile(reportDir, "periodic")
+		}
+	}()
+}
+
+func writeHeapProfile(reportDir, tag string) {
+	ts := time.Now().Format(time.RFC3339)
+	filePath := path.Join(reportDir, "ClusterLoader2_MemoryProfile_"+tag+"_"+ts+".pprof")
+	f, err := os.Create(filePath)
+	if err != nil {
+		klog.Errorf("Cannot create heap profile %q: %v", filePath, err)
+		return
+	}
+	defer f.Close()
+	if err := pprof.Lookup("heap").WriteTo(f, 0); err != nil {
+		klog.Errorf("Cannot write heap profile %q: %v", filePath, err)
+		return
+	}
+	klog.V(2).Infof("Wrote heap profile %q", filePath)
+}


### PR DESCRIPTION
Adds an opt-in `--heap-profile-interval` (`CL2_HEAP_PROFILE_INTERVAL`) flag to periodically write clusterloader2 heap profiles to the report dir for diagnosing runner-pod OOMs (kubernetes/test-infra#37056).

Test run with CL2 profiles: https://gcsweb.k8s.io/gcs/kubernetes-ci-logs/pr-logs/pull/perf-tests/4057/pull-perf-tests-gce-master-scale-performance-100/2056475433968340992/artifacts/