### PR TITLE
Adding kube-burner version of batch workload

### DIFF
--- a/kube-burner/workloads/batch/config.yaml
+++ b/kube-burner/workloads/batch/config.yaml
@@ -1,0 +1,67 @@
+# kube-burner/workloads/batch/config.yml
+{{- $MODE := default "Indexed" (or .MODE (env "MODE")) }}
+{{- $NODES := int (or (index . "NODES") (env "NODES") "3") }}
+{{- $NODES_PER_NAMESPACE := min (int (default 100 (or (index . "NODES_PER_NAMESPACE") (env "NODES_PER_NAMESPACE")))) $NODES }}
+{{- $PODS_PER_NODE := int (default 30 (or (index . "PODS_PER_NODE") (env "PODS_PER_NODE"))) }}
+{{- $LOAD_TEST_THROUGHPUT := int (default 10 (or (index . "LOAD_TEST_THROUGHPUT") (env "LOAD_TEST_THROUGHPUT"))) }}
+{{- $jobRunningTime := default "30s" (or (index . "CL2_JOB_RUNNING_TIME") (env "CL2_JOB_RUNNING_TIME")) }}
+
+{{- $totalPods := mul $PODS_PER_NODE $NODES }}
+{{- $namespaces := div $NODES $NODES_PER_NAMESPACE }}
+{{- $podsPerNamespace := div $totalPods $namespaces }}
+
+{{- $smallJobSize := 5 }}
+{{- $smallJobsPerNamespace := div $podsPerNamespace (mul 2 $smallJobSize) }}
+{{- $mediumJobSize := 20 }}
+{{- $mediumJobsPerNamespace := div $podsPerNamespace (mul 4 $mediumJobSize) }}
+{{- $largeJobSize := 400 }}
+{{- $largeJobsPerNamespace := div $podsPerNamespace (mul 4 $largeJobSize) }}
+
+global:
+  gc: true
+  measurements:
+    - name: jobLatency
+
+metricsEndpoints:
+  - indexer:
+      type: local
+
+jobs:
+  - name: batch-jobs
+    jobType: create
+    jobIterations: {{ $namespaces }}
+    qps: {{ $LOAD_TEST_THROUGHPUT }}
+    burst: 1  
+    namespace: batch-workload
+    namespacedIterations: true
+    waitWhenFinished: true 
+    verifyObjects: true
+    objects:
+      # Object 1: Small jobs (replicas = jobs per namespace)
+      - objectTemplate: workloads/batch/templates/job-dynamic.yaml
+        replicas: {{ $smallJobsPerNamespace }}
+        inputVars:
+          jobSize: {{ $smallJobSize }}
+          completionMode: {{ $MODE }}
+          sleepDuration: {{ $jobRunningTime }}
+          jobType: small
+
+      # Object 2: Medium jobs
+      - objectTemplate: workloads/batch/templates/job-dynamic.yaml
+        replicas: {{ $mediumJobsPerNamespace }}
+        inputVars:
+          jobSize: {{ $mediumJobSize }}
+          completionMode: {{ $MODE }}
+          sleepDuration: {{ $jobRunningTime }}
+          jobType: medium
+
+{{- if gt $largeJobsPerNamespace 0 }}
+      # Object 3: Large jobs
+      - objectTemplate: workloads/batch/templates/job-dynamic.yaml
+        replicas: {{ $largeJobsPerNamespace }}
+        inputVars:
+          jobSize: {{ $largeJobSize }}
+          completionMode: {{ $MODE }}
+          sleepDuration: {{ $jobRunningTime }}
+          jobType: large
+{{- end }}

--- a/kube-burner/workloads/batch/overrides.yaml
+++ b/kube-burner/workloads/batch/overrides.yaml
@@ -1,0 +1,1 @@
+MODE: "Indexed"

--- a/kube-burner/workloads/batch/templates/job-dynamic.yaml
+++ b/kube-burner/workloads/batch/templates/job-dynamic.yaml
@@ -1,0 +1,23 @@
+# kube-burner/workloads/batch/templates/job-dynamic.yml
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{.jobType}}-job-{{ sub .Replica 1 }}
+  labels:
+    group: test-job
+spec:
+  parallelism: {{.jobSize}}
+  completions: {{.jobSize}}
+  completionMode: {{.completionMode}}
+  template:
+    metadata:
+      labels:
+        group: test-pod
+    spec:
+      containers:
+      - name: {{.jobType}}-job-{{ sub .Replica 1 }}
+        image: gcr.io/k8s-staging-perf-tests/sleep:v0.0.3
+        args:
+          - {{.sleepDuration}}
+      restartPolicy: Never


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
This PR is for onboarding kube-burner tests as per the plan [here](https://docs.google.com/document/d/1pNeAwIZhJQTVtYYIG-efI8xor96Q1--eSgTeXlj6cuA/edit?tab=t.0#heading=h.f8n3iqwtmmra), following up on the discussion on [03/12/2026](https://docs.google.com/document/d/1hEpf25qifVWztaeZPFmjNiJvPo-5JX1z0LSvvVY5G2g/edit?tab=t.0#bookmark=kix.smc701j2n5ll) to start with a simple workload.

#### What this PR does / why we need it:
We need this PR so that we can use this configs to run kube-burner from the CI.

#### Special notes for your reviewer:
Initial PR to add kube-burner configs for the existing batch workload.

#### Testing
Tested an verified in local cluster
```
vchalla@vchalla-mac kube-burner % /Users/vchalla/myforks/kube-burner/bin/arm64/kube-burner init -c workloads/batch/config.yaml --user-data workloads/batch/overrides.yaml
time="2026-05-18 18:38:57" level=info msg="📁 Creating local indexer: indexer-0" file="metrics.go:82"
time="2026-05-18 18:38:57" level=info msg="🔥 Starting kube-burner (main@20be8b96410e9e35dd3eea9f7db779365f250beb) with UUID bba10b87-750f-485d-ab57-eaa046363333" file="job.go:86"
time="2026-05-18 18:38:58" level=info msg="Pre-load: images from job batch-jobs" file="pre_load.go:78"
time="2026-05-18 18:38:58" level=info msg="Pre-load: Creating DaemonSet using images [gcr.io/k8s-staging-perf-tests/sleep:v0.0.3] in namespace preload-kube-burner-80375" file="pre_load.go:293"
time="2026-05-18 18:38:58" level=info msg="Pre-load: Waiting for images to be pulled on 3 nodes (timeout 10m0s)" file="pre_load.go:96"
time="2026-05-18 18:39:04" level=info msg="Pre-load: All images pulled on 3 nodes" file="pre_load.go:134"
time="2026-05-18 18:39:04" level=info msg="Deleting 1 namespaces with label: kube-burner.io/job=preload" file="namespaces.go:65"
time="2026-05-18 18:39:11" level=info msg="Cleaning up previous runs for job: batch-jobs" file="job.go:102"
time="2026-05-18 18:39:11" level=info msg="Initializing measurements for job: batch-jobs" file="factory.go:104"
time="2026-05-18 18:39:11" level=info msg="Registered measurement: jobLatency" file="factory.go:139"
time="2026-05-18 18:39:12" level=info msg="Creating batch/v1, Resource=jobs latency watcher for batch-jobs using selector [kube-burner.io/runid=14754612-b910-4d87-8322-a2175a97f1c6]" file="base_measurement.go:81"
time="2026-05-18 18:39:12" level=info msg="Triggering job: batch-jobs" file="job.go:139"
time="2026-05-18 18:39:13" level=info msg="Waiting up to 4h0m0s for actions to be completed" file="create.go:270"
time="2026-05-18 18:39:49" level=info msg="Actions in namespace batch-workload-0 completed" file="waiters.go:77"
time="2026-05-18 18:39:49" level=info msg="Verifying created objects" file="utils.go:161"
time="2026-05-18 18:39:49" level=info msg="Job batch-jobs took 37s" file="job.go:234"
time="2026-05-18 18:39:49" level=info msg="Stopping measurement: jobLatency" file="factory.go:168"
time="2026-05-18 18:39:49" level=info msg="batch-jobs: StartTime 99th: 0 ms max: 0 ms avg: 0 ms" file="base_measurement.go:125"
time="2026-05-18 18:39:49" level=info msg="batch-jobs: Complete 99th: 35000 ms max: 35000 ms avg: 34700 ms" file="base_measurement.go:125"
time="2026-05-18 18:39:49" level=info msg="Indexing collected data from measurement: jobLatency" file="factory.go:180"
time="2026-05-18 18:39:49" level=info msg="Indexing metric jobLatencyMeasurement" file="base_measurement.go:158"
time="2026-05-18 18:39:49" level=info msg="File collected-metrics-bba10b87-750f-485d-ab57-eaa046363333/jobLatencyMeasurement-batch-jobs.json now contains 10 documents" file="base_measurement.go:167"
time="2026-05-18 18:39:49" level=info msg="Indexing metric jobLatencyQuantilesMeasurement" file="base_measurement.go:158"
time="2026-05-18 18:39:49" level=info msg="File collected-metrics-bba10b87-750f-485d-ab57-eaa046363333/jobLatencyQuantilesMeasurement-batch-jobs.json now contains 2 documents" file="base_measurement.go:167"
time="2026-05-18 18:39:49" level=info msg="Indexing job summaries" file="metadata.go:49"
time="2026-05-18 18:39:49" level=info msg="File collected-metrics-bba10b87-750f-485d-ab57-eaa046363333/jobSummary.json now contains 1 documents" file="metadata.go:66"
time="2026-05-18 18:39:49" level=info msg="Finished execution with UUID: bba10b87-750f-485d-ab57-eaa046363333" file="job.go:316"
time="2026-05-18 18:39:49" level=info msg="Waiting for garbage collection to finish" file="job.go:341"
time="2026-05-18 18:39:49" level=info msg="Deleting 1 namespaces with label: kube-burner.io/job=batch-jobs" file="namespaces.go:65"
time="2026-05-18 18:39:59" level=info msg="👋 Exiting kube-burner bba10b87-750f-485d-ab57-eaa046363333" file="kube-burner.go:89"
```