### PR TITLE
remove stale CL2_LIST_CONCURRENCY doc reference

### DIFF
--- a/clusterloader2/testing/list/README.md
+++ b/clusterloader2/testing/list/README.md
@@ -8,7 +8,6 @@ List load test perform the following steps:
 - Create lister pods using deployment in a separate namespace to list configmaps and secrets.
   - The namespace is created using `namespace.yaml` as a template, but its lifecycle is managed by CL2.
   - The number of replicas for the lister pods can be specified using `CL2_LIST_BENCHMARK_PODS`.
-  - Each lister pod will maintain `CL2_LIST_CONCURRENCY` number of inflight list requests.
 - Measurement uses [`APIResponsivenessPrometheusSimple`](https://github.com/kubernetes/perf-tests/blob/master/clusterloader2/README.md) to meansure API latency for list configmaps and secrets calls.
 
 The lister pods leverage https://github.com/kubernetes/perf-tests/tree/master/util-images/request-benchmark to create in-cluster list load.


### PR DESCRIPTION
remove stale CL2_LIST_CONCURRENCY doc reference. Unused anywhere: https://github.com/search?q=repo%3Akubernetes%2Fperf-tests%20CL2_LIST_CONCURRENCY&type=code