### PR TITLE
agents/skills: add download-ci-artifacts skill

### DIFF
--- a/.agents/skills/download-ci-artifacts/SKILL.md
+++ b/.agents/skills/download-ci-artifacts/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: download-ci-artifacts
+description: Download artifacts from a CI run's GCS bucket to local disk.
+---
+# Task
+Download artifacts from a CI run's GCS bucket to a local directory. Accept a URI and a list of files or patterns to download. Do not decide what to download. Download only what the user requests.
+
+# Workflow
+## 1. Parse URI
+- **URI normalization**: Accept gcsweb URLs (`https://gcsweb.k8s.io/gcs/...`), raw `gs://` paths, or Prow job URLs (`https://prow.k8s.io/view/gs/...`).
+  Convert to GCS paths by replacing `https://gcsweb.k8s.io/gcs/` or `https://prow.k8s.io/view/gs/` with `gs://`.
+
+## 2. Create Local Directory
+- **Output path**: If an output directory is provided, use it. Otherwise create a local directory using an identifier extracted from the URI (e.g., the Prow build ID).
+
+## 3. Download
+- **Targeted download**: Download only the files or patterns the user specified (e.g., `kube-apiserver.log*`, `*.json`, `junit.xml`).
+- **Parallel transfer**: Use `gcloud storage cp` for downloads.
+
+## 4. Report
+- **Summary**: List the files downloaded and their sizes.


### PR DESCRIPTION
 Add a general purpose `download-ci-artifacts` skill to `.agents/skills`.

The skill is a dumb downloader. No opinions about what's useful, no hardcoded output path, no test specific logic. It accepts a URI, downloads what the user asks for, and reports what it got.

The domain knowledge about what to download (which artifacts matter) will live in a separate "explore-ci-artifacts" skill or in a coordinator.

Tested with Claude by
1. adding a `.claude/skills` symlink pointing to `.agents/skills`
2. typing `/download-ci-artifacts Download junit.xml from https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/138327/pull-kubernetes-gce-master-scale-performance-5000/2056034689277235200` in the prompt. 
3. got:
```
❯ /download-ci-artifacts Download junit.xml from https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/138327/pull-kubernetes-gce-master-scale-performance-5000/2056034689277235200

⏺ Downloading junit.xml from the specified Prow job.

⏺ Bash(mkdir -p /Users/lukasz/go/src/k8s.io/perf-tests/2056034689277235200)
  ⎿  Done

⏺ Bash(gcloud storage cp 'gs://kubernetes-ci-logs/pr-logs/pull/138327/pull-kubernetes-gce-master-scale-performance-5000/2056034689277235200/**/junit*.xml' /Users/luka…)
  ⎿  Copying gs://kubernetes-ci-logs/pr-logs/pull/138327/pull-kubernetes-gce-master-scale-performance-5000/2056034689277235200/artifacts/junit_runner.xml to file:///Users/lukasz/go/src/k8s.io/perf-tests/2056034689277235200
     /junit_runner.xml

     .....

  Listed 1 directory (ctrl+o to expand)

⏺ Downloaded 1 file to 2056034689277235200/:

  ┌──────────────────┬───────┐
  │       File       │ Size  │
  ├──────────────────┼───────┤
  │ junit_runner.xml │ 585 B │
  └──────────────────┴───────┘
  ```
  