### PR TITLE
cl2: strip managedFields from pod informers to cut memory

### DIFF
--- a/clusterloader2/pkg/measurement/common/wait_for_controlled_pods.go
+++ b/clusterloader2/pkg/measurement/common/wait_for_controlled_pods.go
@@ -86,7 +86,7 @@ func (s *sharedPodIndexerFactory) PodsIndexer(c clientset.Interface) (*measureme
 
 func (s *sharedPodIndexerFactory) start(c clientset.Interface) (*measurementutil.ControlledPodsIndexer, error) {
 	ctx := context.Background()
-	informerFactory := informers.NewSharedInformerFactory(c, 0)
+	informerFactory := informers.NewSharedInformerFactoryWithOptions(c, 0, informers.WithTransform(informer.TrimManagedFields))
 	podsIndexer, err := measurementutil.NewControlledPodsIndexer(
 		informerFactory.Core().V1().Pods(),
 		informerFactory.Apps().V1().ReplicaSets(),

--- a/clusterloader2/pkg/measurement/util/informer/informer.go
+++ b/clusterloader2/pkg/measurement/util/informer/informer.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"time"
 
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
@@ -29,12 +30,22 @@ import (
 	"k8s.io/perf-tests/clusterloader2/pkg/util"
 )
 
+func TrimManagedFields(obj interface{}) (interface{}, error) {
+	if accessor, err := meta.Accessor(obj); err == nil && accessor.GetManagedFields() != nil {
+		accessor.SetManagedFields(nil)
+	}
+	return obj, nil
+}
+
 // NewInformer creates a new informer.
 func NewInformer(
 	lw cache.ListerWatcher,
 	handleObj func(interface{}, interface{}),
 ) cache.SharedInformer {
 	informer := cache.NewSharedInformer(lw, nil, 0)
+	if err := informer.SetTransform(TrimManagedFields); err != nil {
+		klog.Errorf("cannot set transform: %v", err)
+	}
 	addEventHandler(informer, handleObj)
 	return informer
 }
@@ -55,6 +66,9 @@ func NewDynamicInformer(
 	dInformerFactory := dynamicinformer.NewFilteredDynamicSharedInformerFactory(c, 0, selector.Namespace, tweakListOptions)
 
 	informer := dInformerFactory.ForResource(gvr).Informer()
+	if err := informer.SetTransform(TrimManagedFields); err != nil {
+		klog.Errorf("cannot set transform: %v", err)
+	}
 	addEventHandler(informer, handleObj)
 	return informer
 }


### PR DESCRIPTION
Strip `.metadata.managedFields` from CL2's pod informers, matching kube-apiserver/KCM/scheduler.