### PR TITLE
CL2: Optimize memory usage for pods

### DIFF
--- a/clusterloader2/pkg/measurement/common/wait_for_controlled_pods.go
+++ b/clusterloader2/pkg/measurement/common/wait_for_controlled_pods.go
@@ -19,6 +19,7 @@ package common
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -65,6 +66,8 @@ const (
 
 var podIndexerFactory = &sharedPodIndexerFactory{}
 
+var automanagedNamespaceID = regexp.MustCompile(`^test-[a-z0-9]+-[0-9]+$`)
+
 func init() {
 	if err := measurement.Register(waitForControlledPodsRunningName, createWaitForControlledPodsRunningMeasurement); err != nil {
 		klog.Fatalf("Cannot register %s: %v", waitForControlledPodsRunningName, err)
@@ -86,7 +89,29 @@ func (s *sharedPodIndexerFactory) PodsIndexer(c clientset.Interface) (*measureme
 
 func (s *sharedPodIndexerFactory) start(c clientset.Interface) (*measurementutil.ControlledPodsIndexer, error) {
 	ctx := context.Background()
-	informerFactory := informers.NewSharedInformerFactoryWithOptions(c, 0, informers.WithTransform(informer.TrimManagedFields))
+	trimFn := func(obj interface{}) (interface{}, error) {
+		if accessor, err := meta.Accessor(obj); err == nil && accessor.GetManagedFields() != nil {
+			accessor.SetManagedFields(nil)
+		}
+		pod, ok := obj.(*v1.Pod)
+		if !ok {
+			return obj, nil
+		}
+		if automanagedNamespaceID.MatchString(pod.Namespace) {
+			// For pods managed by the clusterloader, we need to keep the full pod.Spec for checkIfPodsAreUpdated feature.
+			return obj, nil
+		}
+
+		pod.Spec = v1.PodSpec{
+			NodeName: pod.Spec.NodeName,
+		}
+		pod.Status = v1.PodStatus{
+			Phase:      pod.Status.Phase,
+			Conditions: pod.Status.Conditions,
+		}
+		return pod, nil
+	}
+	informerFactory := informers.NewSharedInformerFactoryWithOptions(c, 0, informers.WithTransform(trimFn))
 	podsIndexer, err := measurementutil.NewControlledPodsIndexer(
 		informerFactory.Core().V1().Pods(),
 		informerFactory.Apps().V1().ReplicaSets(),

--- a/clusterloader2/pkg/measurement/util/runtimeobjects/runtimeobjects.go
+++ b/clusterloader2/pkg/measurement/util/runtimeobjects/runtimeobjects.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"sync"
 
 	goerrors "github.com/go-errors/errors"
 	gocmp "github.com/google/go-cmp/cmp"
@@ -33,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/dynamic"
 	clientset "k8s.io/client-go/kubernetes"
 	corev1helpers "k8s.io/component-helpers/scheduling/corev1"
@@ -100,6 +102,11 @@ func (lsde *lazySpecDiffError) Error() string {
 	return fmt.Sprintf("Not matching templates, diff: %v", gocmp.Diff(lsde.templateSpec, lsde.podSpec))
 }
 
+type podCacheKey struct {
+	uid types.UID
+	rv  string
+}
+
 func getIsPodUpdatedPodPredicateFromUnstructured(obj *unstructured.Unstructured) (func(_ *corev1.Pod) error, error) {
 	templateMap, ok, err := unstructured.NestedMap(obj.UnstructuredContent(), "spec", "template")
 	if err != nil {
@@ -110,14 +117,30 @@ func getIsPodUpdatedPodPredicateFromUnstructured(obj *unstructured.Unstructured)
 	}
 	template := corev1.PodTemplateSpec{}
 	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(templateMap, &template); err != nil {
-		return nil, goerrors.Errorf("failed to parse spec.teemplate as v1.PodTemplateSpec")
+		return nil, goerrors.Errorf("failed to parse spec.template as v1.PodTemplateSpec")
 	}
 
+	cache := make(map[podCacheKey]error)
+	var mu sync.Mutex
+
 	return func(pod *corev1.Pod) error {
-		if !equality.Semantic.DeepDerivative(template.Spec, pod.Spec) {
-			return &lazySpecDiffError{template.Spec, pod.Spec}
+		key := podCacheKey{uid: pod.UID, rv: pod.ResourceVersion}
+		mu.Lock()
+		if cachedErr, exists := cache[key]; exists {
+			mu.Unlock()
+			return cachedErr
 		}
-		return nil
+		mu.Unlock()
+
+		var err error
+		if !equality.Semantic.DeepDerivative(template.Spec, pod.Spec) {
+			err = &lazySpecDiffError{template.Spec, pod.Spec}
+		}
+
+		mu.Lock()
+		cache[key] = err
+		mu.Unlock()
+		return err
 	}, nil
 }
 


### PR DESCRIPTION
#### What type of PR is this?
Attempt to optimize memory usage for CL2: The current state:
* Most of the allocations are done by temporary allocations done by runtime.DefaultUnstructuredConverter.FromUnstructured in getIsPodUpdatedPodPredicateFromUnstructured
* Most of the inuse_space is pods' spec.

We cannot simply drop pod spec as getIsPodUpdatedPodPredicateFromUnstructured requires it, but we can drop it for pods that are not managed by us (e.g. in non-managed namespaces).

Two optimizations:
* Drop pod.Spec for pods in non-managed namespaces (the ones where we never isPodUpdated), e.g. daemonsets that can be massive for large clusters -- hope to help with inuse memory
* Cache DefaultUnstructuredConverter.FromUnstructured results to avoid constant calling in a hot loop. This aims to reduce an alloc rate and gc pressure.

/kind feature

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

