### PR TITLE
CL2: Override default 1s API Responsivness latency

### DIFF
--- a/clusterloader2/pkg/measurement/common/slos/api_responsiveness_prometheus.go
+++ b/clusterloader2/pkg/measurement/common/slos/api_responsiveness_prometheus.go
@@ -39,8 +39,8 @@ const (
 
 	// Thresholds for API call latency as defined in the official K8s SLO
 	// https://github.com/kubernetes/community/blob/master/sig-scalability/slos/api_call_latency.md
-	singleResourceThreshold    time.Duration = 1 * time.Second
-	multipleResourcesThreshold time.Duration = 30 * time.Second
+	defaultSingleResourceThreshold    time.Duration = 1 * time.Second
+	defaultMultipleResourcesThreshold time.Duration = 30 * time.Second
 
 	currentAPICallMetricsVersion = "v1"
 
@@ -147,7 +147,12 @@ func (a *apiResponsivenessGatherer) Gather(executor common.QueryExecutor, startT
 		return nil, err
 	}
 
-	badMetrics := a.validateAPICalls(config.Identifier, allowedSlowCalls, apiCalls, customThresholds)
+	singleResourceThreshold, err := util.GetDurationOrDefault(config.Params, "singleResourceThreshold", defaultSingleResourceThreshold)
+	if err != nil {
+		klog.V(1).Infof("WARNING: invalid singleResourceThreshold value: %v, defaulting to %v", err, defaultSingleResourceThreshold)
+	}
+
+	badMetrics := a.validateAPICalls(config.Identifier, allowedSlowCalls, apiCalls, customThresholds, singleResourceThreshold, defaultMultipleResourcesThreshold)
 	if len(badMetrics) > 0 {
 		err = errors.NewMetricViolationError("top latency metric", fmt.Sprintf("there should be no high-latency requests, but: %v", badMetrics))
 	}
@@ -273,7 +278,7 @@ func getCustomThresholds(config *measurement.Config, metrics *apiCallMetrics) (c
 	return customThresholds, nil
 }
 
-func (a *apiResponsivenessGatherer) validateAPICalls(identifier string, allowedSlowCalls int, metrics *apiCallMetrics, customThresholds customThresholds) []error {
+func (a *apiResponsivenessGatherer) validateAPICalls(identifier string, allowedSlowCalls int, metrics *apiCallMetrics, customThresholds customThresholds, singleResourceThreshold, multipleResourcesThreshold time.Duration) []error {
 	badMetrics := make([]error, 0)
 	top := topToPrint
 
@@ -282,7 +287,11 @@ func (a *apiResponsivenessGatherer) validateAPICalls(identifier string, allowedS
 		if customThreshold, ok := customThresholds[apiCall.getKey()]; ok {
 			threshold = customThreshold
 		} else {
-			threshold = apiCall.getSLOThreshold()
+			if apiCall.Scope == "resource" {
+				threshold = singleResourceThreshold
+			} else {
+				threshold = multipleResourcesThreshold
+			}
 		}
 		var err error
 		if err = apiCall.Validate(allowedSlowCalls, threshold); err != nil {
@@ -428,11 +437,4 @@ func (ap *apiCallMetric) Validate(allowedSlowCalls int, threshold time.Duration)
 		return fmt.Errorf("got: %+v; expected perc99 <= %v", ap, threshold)
 	}
 	return nil
-}
-
-func (ap *apiCallMetric) getSLOThreshold() time.Duration {
-	if ap.Scope == "resource" {
-		return singleResourceThreshold
-	}
-	return multipleResourcesThreshold
 }

--- a/clusterloader2/pkg/measurement/common/slos/api_responsiveness_prometheus_test.go
+++ b/clusterloader2/pkg/measurement/common/slos/api_responsiveness_prometheus_test.go
@@ -768,3 +768,144 @@ func TestAPIResponsivenessCustomThresholds(t *testing.T) {
 		})
 	}
 }
+
+func TestAPIResponsivenessSingleResourceThresholdOverride(t *testing.T) {
+	cases := []struct {
+		name             string
+		config           *measurement.Config
+		metricSamples    map[string][]*sample
+		hasError         bool
+		expectedMessages []string
+	}{
+		{
+			name: "no_override_pass",
+			config: &measurement.Config{
+				Params: map[string]interface{}{},
+			},
+			metricSamples: map[string][]*sample{
+				"apiserver_request_sli_latency": {
+					{
+						resource: "pods",
+						verb:     "POST",
+						scope:    "resource",
+						latency:  0.8,
+					},
+				},
+				"apiserver_request_sli_duration_seconds": {},
+				"apiserver_watch_list_duration_seconds":  {},
+			},
+			hasError: false,
+		},
+		{
+			name: "no_override_fail",
+			config: &measurement.Config{
+				Params: map[string]interface{}{},
+			},
+			metricSamples: map[string][]*sample{
+				"apiserver_request_sli_latency": {
+					{
+						resource: "pods",
+						verb:     "POST",
+						scope:    "resource",
+						latency:  1.5,
+					},
+				},
+				"apiserver_request_sli_duration_seconds": {},
+				"apiserver_watch_list_duration_seconds":  {},
+			},
+			hasError: true,
+		},
+		{
+			name: "override_pass",
+			config: &measurement.Config{
+				Params: map[string]interface{}{
+					"singleResourceThreshold": "2s",
+				},
+			},
+			metricSamples: map[string][]*sample{
+				"apiserver_request_sli_latency": {
+					{
+						resource: "pods",
+						verb:     "POST",
+						scope:    "resource",
+						latency:  1.5,
+					},
+				},
+				"apiserver_request_sli_duration_seconds": {},
+				"apiserver_watch_list_duration_seconds":  {},
+			},
+			hasError: false,
+		},
+		{
+			name: "override_fail",
+			config: &measurement.Config{
+				Params: map[string]interface{}{
+					"singleResourceThreshold": "2s",
+				},
+			},
+			metricSamples: map[string][]*sample{
+				"apiserver_request_sli_latency": {
+					{
+						resource: "pods",
+						verb:     "POST",
+						scope:    "resource",
+						latency:  2.5,
+					},
+				},
+				"apiserver_request_sli_duration_seconds": {},
+				"apiserver_watch_list_duration_seconds":  {},
+			},
+			hasError: true,
+		},
+		{
+			name: "override_invalid_fallback_fail",
+			config: &measurement.Config{
+				Params: map[string]interface{}{
+					"singleResourceThreshold": "invalid_duration",
+				},
+			},
+			metricSamples: map[string][]*sample{
+				"apiserver_request_sli_latency": {
+					{
+						resource: "pods",
+						verb:     "POST",
+						scope:    "resource",
+						latency:  1.5,
+					},
+				},
+				"apiserver_request_sli_duration_seconds": {},
+				"apiserver_watch_list_duration_seconds":  {},
+			},
+			hasError: true,
+			expectedMessages: []string{
+				"invalid singleResourceThreshold value",
+			},
+		},
+	}
+
+	klog.LogToStderr(false)
+	defer klog.LogToStderr(true)
+	changeLoggingVerbosity(t, "2")
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			buf := bytes.NewBuffer(nil)
+			klog.SetOutput(buf)
+
+			executor := &fakeQueryExecutor{metricSamples: tc.metricSamples}
+			gatherer := &apiResponsivenessGatherer{}
+
+			_, err := gatherer.Gather(executor, time.Now(), time.Now(), tc.config)
+			klog.Flush()
+			if tc.hasError {
+				assert.NotNil(t, err, "expected an error, but got none")
+			} else {
+				assert.Nil(t, err, "expected no error, but got %v", err)
+			}
+
+			for _, msg := range tc.expectedMessages {
+				assert.Contains(t, buf.String(), msg)
+			}
+		})
+	}
+}

--- a/clusterloader2/testing/huge-service/modules/measurements.yaml
+++ b/clusterloader2/testing/huge-service/modules/measurements.yaml
@@ -22,6 +22,7 @@
 {{$ALLOWED_CONTAINER_RESTARTS := DefaultParam .CL2_ALLOWED_CONTAINER_RESTARTS 1}}
 {{$CUSTOM_ALLOWED_CONTAINER_RESTARTS := DefaultParam .CL2_CUSTOM_ALLOWED_CONTAINER_RESTARTS ""}}
 {{$PROBE_MEASUREMENTS_PING_SLEEP_DURATION := DefaultParam .CL2_PROBE_MEASUREMENTS_PING_SLEEP_DURATION "1s"}}
+{{$SINGLE_RESOURCE_API_LATENCY_THRESHOLD := DefaultParam .CL2_SINGLE_RESOURCE_API_LATENCY_THRESHOLD "1s"}}
 
 {{$allowedSlowCalls := AddInt $ALLOWED_SLOW_API_CALLS $HUGE_SERVICE_ALLOWED_SLOW_API_CALLS}}
 
@@ -43,6 +44,7 @@ steps:
       enableViolations: {{$ENABLE_VIOLATIONS_FOR_API_CALL_PROMETHEUS}}
       allowedSlowCalls: {{$allowedSlowCalls}}
       customThresholds: {{YamlQuote $CUSTOM_API_CALL_THRESHOLDS 4}}
+      singleResourceThreshold: {{$SINGLE_RESOURCE_API_LATENCY_THRESHOLD}}
 {{end}}
   - Identifier: APIResponsivenessPrometheusSimple
     Method: APIResponsivenessPrometheus
@@ -53,6 +55,7 @@ steps:
       summaryName: APIResponsivenessPrometheus_simple
       allowedSlowCalls: {{$allowedSlowCalls}}
       customThresholds: {{YamlQuote $CUSTOM_API_CALL_THRESHOLDS 4}}
+      singleResourceThreshold: {{$SINGLE_RESOURCE_API_LATENCY_THRESHOLD}}
   - Identifier: TestMetrics
     Method: TestMetrics
     Params:

--- a/clusterloader2/testing/load/modules/measurements.yaml
+++ b/clusterloader2/testing/load/modules/measurements.yaml
@@ -44,6 +44,7 @@
 {{$ENABLE_VIOLATIONS_FOR_NETWORK_PROGRAMMING_LATENCIES := DefaultParam .CL2_ENABLE_VIOLATIONS_FOR_NETWORK_PROGRAMMING_LATENCIES false}}
 {{$NETWORK_PROGRAMMING_LATENCY_THRESHOLD := DefaultParam .CL2_NETWORK_PROGRAMMING_LATENCY_THRESHOLD "30s"}}
 {{$NETWORK_LATENCY_THRESHOLD := DefaultParam .CL2_NETWORK_LATENCY_THRESHOLD "0s"}}
+{{$SINGLE_RESOURCE_API_LATENCY_THRESHOLD := DefaultParam .CL2_SINGLE_RESOURCE_API_LATENCY_THRESHOLD "1s"}}
 
 # Probe measurements shared parameter
 {{$PROBE_MEASUREMENTS_CHECK_PROBES_READY_TIMEOUT := DefaultParam .CL2_PROBE_MEASUREMENTS_CHECK_PROBES_READY_TIMEOUT "15m"}}
@@ -59,6 +60,7 @@ steps:
       enableViolations: {{$ENABLE_VIOLATIONS_FOR_API_CALL_PROMETHEUS}}
       allowedSlowCalls: {{$ALLOWED_SLOW_API_CALLS}}
       customThresholds: {{YamlQuote $CUSTOM_API_CALL_THRESHOLDS 4}}
+      singleResourceThreshold: {{$SINGLE_RESOURCE_API_LATENCY_THRESHOLD}}
 {{end}}
   - Identifier: APIResponsivenessPrometheusSimple
     Method: APIResponsivenessPrometheus
@@ -69,6 +71,7 @@ steps:
       summaryName: APIResponsivenessPrometheus_simple
       allowedSlowCalls: {{$ALLOWED_SLOW_API_CALLS}}
       customThresholds: {{YamlQuote $CUSTOM_API_CALL_THRESHOLDS 4}}
+      singleResourceThreshold: {{$SINGLE_RESOURCE_API_LATENCY_THRESHOLD}}
   - Identifier: CreatePhasePodStartupLatency
     Method: PodStartupLatency
     Params:

--- a/clusterloader2/testing/watch-list/config.yaml
+++ b/clusterloader2/testing/watch-list/config.yaml
@@ -1,6 +1,7 @@
 {{$enableWatchListFeature := DefaultParam .CL2_ENABLE_WATCH_LIST_FEATURE false}}
 {{$testDuration := "5m"}}
 {{$customApiCallThresholds := DefaultParam .CUSTOM_API_CALL_THRESHOLDS ""}}
+{{$SINGLE_RESOURCE_API_LATENCY_THRESHOLD := DefaultParam .CL2_SINGLE_RESOURCE_API_LATENCY_THRESHOLD "1s"}}
 name: watch-list
 namespace:
   number: 1
@@ -75,3 +76,4 @@ steps:
         useSimpleLatencyQuery: true
         summaryName: APIResponsivenessPrometheus_simple
         customThresholds: {{YamlQuote $customApiCallThresholds 4}}
+        singleResourceThreshold: {{$SINGLE_RESOURCE_API_LATENCY_THRESHOLD}}


### PR DESCRIPTION
API Responsiveness is set to follow [kubernetes sig-scalability SLO](https://github.com/kubernetes/community/blob/main/sig-scalability/slos/api_call_latency.md), but some team might want to adjust this threshold for their needs, this PR allows that.