### PR TITLE
[WIP] CL2: Introduce --hash-based-pod-comparison

### DIFF
--- a/clusterloader2/cmd/clusterloader.go
+++ b/clusterloader2/cmd/clusterloader.go
@@ -95,6 +95,7 @@ func initClusterFlags() {
 	flags.StringEnvVar(&clusterLoaderConfig.ClusterConfig.MasterDNSEndpoint, "master-endpoint", "MASTER_DNS_ENDPOINT", "", "Endpoint of the master node, exclusive with --masterip and --master-internal-ips")
 	flags.BoolEnvVar(&clusterLoaderConfig.ClusterConfig.APIServerPprofByClientEnabled, "apiserver-pprof-by-client-enabled", "APISERVER_PPROF_BY_CLIENT_ENABLED", true, "Whether apiserver pprof endpoint can be accessed by Kubernetes client.")
 	flags.BoolVar(&clusterLoaderConfig.ClusterConfig.SkipClusterVerification, "skip-cluster-verification", false, "Whether to skip the cluster verification, which expects at least one schedulable node in the cluster")
+	flags.BoolVar(&clusterLoaderConfig.ClusterConfig.HashBasedPodComparison, "hash-based-pod-comparison", true, "Whether to use hash-based pod comparison to verify pod updates, enabling aggressive memory stripping of cached pods")
 
 	flags.StringEnvVar(&providerInitOptions.ProviderName, "provider", "PROVIDER", "", "Cluster provider name")
 	flags.StringSliceEnvVar(&providerInitOptions.ProviderConfigs, "provider-configs", "PROVIDER_CONFIGS", nil, "Cluster provider configurations")

--- a/clusterloader2/pkg/config/cluster.go
+++ b/clusterloader2/pkg/config/cluster.go
@@ -57,6 +57,7 @@ type ClusterConfig struct {
 	KubeletPort                   int
 	K8SClientsNumber              int
 	SkipClusterVerification       bool
+	HashBasedPodComparison        bool
 }
 
 // ExecServiceConfig represents all flags used by service config.

--- a/clusterloader2/pkg/measurement/common/wait_for_controlled_pods.go
+++ b/clusterloader2/pkg/measurement/common/wait_for_controlled_pods.go
@@ -19,11 +19,13 @@ package common
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -65,6 +67,8 @@ const (
 
 var podIndexerFactory = &sharedPodIndexerFactory{}
 
+var automanagedNamespaceID = regexp.MustCompile(`^test-[a-z0-9]+-[0-9]+$`)
+
 func init() {
 	if err := measurement.Register(waitForControlledPodsRunningName, createWaitForControlledPodsRunningMeasurement); err != nil {
 		klog.Fatalf("Cannot register %s: %v", waitForControlledPodsRunningName, err)
@@ -77,19 +81,48 @@ type sharedPodIndexerFactory struct {
 	once        sync.Once
 }
 
-func (s *sharedPodIndexerFactory) PodsIndexer(c clientset.Interface) (*measurementutil.ControlledPodsIndexer, error) {
+func (s *sharedPodIndexerFactory) PodsIndexer(c clientset.Interface, hashBasedComparison bool) (*measurementutil.ControlledPodsIndexer, error) {
 	s.once.Do(func() {
-		s.podsIndexer, s.err = s.start(c)
+		s.podsIndexer, s.err = s.start(c, hashBasedComparison)
 	})
 	return s.podsIndexer, s.err
 }
 
-func (s *sharedPodIndexerFactory) start(c clientset.Interface) (*measurementutil.ControlledPodsIndexer, error) {
+func (s *sharedPodIndexerFactory) start(c clientset.Interface, hashBasedComparison bool) (*measurementutil.ControlledPodsIndexer, error) {
 	ctx := context.Background()
-	informerFactory := informers.NewSharedInformerFactoryWithOptions(c, 0, informers.WithTransform(informer.TrimManagedFields))
+	trimFn := func(obj interface{}) (interface{}, error) {
+		if accessor, err := meta.Accessor(obj); err == nil && accessor.GetManagedFields() != nil {
+			accessor.SetManagedFields(nil)
+		}
+		pod, ok := obj.(*v1.Pod)
+		if !ok {
+			return obj, nil
+		}
+		if hashBasedComparison {
+			// Strip Spec and Status completely, keeping only fields needed for ControlledPodsIndexer, WaitForPods, and Hash-Based comparison.
+			pod.Spec = v1.PodSpec{
+				NodeName: pod.Spec.NodeName,
+			}
+			pod.Status = v1.PodStatus{
+				Phase:      pod.Status.Phase,
+				Conditions: pod.Status.Conditions,
+			}
+		} else if !automanagedNamespaceID.MatchString(pod.Namespace) {
+			pod.Spec = v1.PodSpec{
+				NodeName: pod.Spec.NodeName,
+			}
+			pod.Status = v1.PodStatus{
+				Phase:      pod.Status.Phase,
+				Conditions: pod.Status.Conditions,
+			}
+		}
+		return pod, nil
+	}
+	informerFactory := informers.NewSharedInformerFactoryWithOptions(c, 0, informers.WithTransform(trimFn))
 	podsIndexer, err := measurementutil.NewControlledPodsIndexer(
 		informerFactory.Core().V1().Pods(),
 		informerFactory.Apps().V1().ReplicaSets(),
+		informerFactory.Apps().V1().ControllerRevisions(),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize controlledPodsIndexer: %w", err)
@@ -264,7 +297,8 @@ func (w *waitForControlledPodsRunningMeasurement) start() error {
 
 	w.isRunning = true
 	w.stopCh = make(chan struct{})
-	podsIndexer, err := podIndexerFactory.PodsIndexer(w.clusterFramework.GetClientSets().GetClient())
+	hashBasedComparison := w.clusterFramework.GetClusterConfig().HashBasedPodComparison
+	podsIndexer, err := podIndexerFactory.PodsIndexer(w.clusterFramework.GetClientSets().GetClient(), hashBasedComparison)
 	if err != nil {
 		return err
 	}
@@ -571,13 +605,6 @@ func (w *waitForControlledPodsRunningMeasurement) waitForRuntimeObject(obj runti
 	if err != nil {
 		return nil, err
 	}
-	var isPodUpdated func(*v1.Pod) error
-	if w.checkIfPodsAreUpdated {
-		isPodUpdated, err = runtimeobjects.GetIsPodUpdatedPredicateFromRuntimeObject(obj)
-		if err != nil {
-			return nil, err
-		}
-	}
 	if isDeleted {
 		runtimeObjectReplicas = &runtimeobjects.ConstReplicas{
 			ReplicasCount: 0,
@@ -606,9 +633,52 @@ func (w *waitForControlledPodsRunningMeasurement) waitForRuntimeObject(obj runti
 		}
 		if err := runtimeObjectReplicas.Start(ctx.Done()); err != nil {
 			klog.Errorf("%s: error while starting runtimeObjectReplicas: %v", key, err)
+			o.lock.Lock()
 			o.err = fmt.Errorf("failed to start runtimeObjectReplicas: %v", err)
+			o.lock.Unlock()
 			return
 		}
+
+		var isPodUpdated func(*v1.Pod) error
+		if w.checkIfPodsAreUpdated {
+			if w.clusterFramework.GetClusterConfig().HashBasedPodComparison {
+				var hashLabel, hashValue string
+				err = wait.PollImmediate(500*time.Millisecond, 15*time.Second, func() (bool, error) {
+					var err error
+					hashLabel, hashValue, err = w.resolveExpectedHash(obj)
+					if err != nil {
+						klog.V(4).Infof("Failed to resolve expected hash for %s, retrying: %v", key, err)
+						return false, nil
+					}
+					return true, nil
+				})
+				if err != nil {
+					klog.Errorf("%s: failed to resolve expected hash: %v", key, err)
+					o.lock.Lock()
+					o.err = fmt.Errorf("failed to resolve expected hash: %w", err)
+					o.status = failed
+					o.lock.Unlock()
+					return
+				}
+				isPodUpdated = func(pod *v1.Pod) error {
+					if pod.Labels[hashLabel] != hashValue {
+						return fmt.Errorf("hash mismatch on label %s: expected %s, got %s", hashLabel, hashValue, pod.Labels[hashLabel])
+					}
+					return nil
+				}
+			} else {
+				isPodUpdated, err = runtimeobjects.GetIsPodUpdatedPredicateFromRuntimeObject(obj)
+				if err != nil {
+					klog.Errorf("%s: failed to get predicate: %v", key, err)
+					o.lock.Lock()
+					o.err = err
+					o.status = failed
+					o.lock.Unlock()
+					return
+				}
+			}
+		}
+
 		options := &measurementutil.WaitForPodOptions{
 			DesiredPodCount:     runtimeObjectReplicas.Replicas,
 			CountErrorMargin:    w.countErrorMargin,
@@ -698,4 +768,82 @@ func (o *objectChecker) getStatus() (objectStatus, error) {
 	o.lock.Lock()
 	defer o.lock.Unlock()
 	return o.status, o.err
+}
+
+
+
+func (w *waitForControlledPodsRunningMeasurement) resolveExpectedHash(obj runtime.Object) (string, string, error) {
+	metaAccessor, err := meta.Accessor(obj)
+	if err != nil {
+		return "", "", fmt.Errorf("object has no meta: %w", err)
+	}
+	typeAccessor, err := meta.TypeAccessor(obj)
+	if err != nil {
+		return "", "", fmt.Errorf("object has unknown type: %w", err)
+	}
+
+	unstructuredObj, ok := obj.(*unstructured.Unstructured)
+	if !ok {
+		return "", "", fmt.Errorf("expected *unstructured.Unstructured; got: %T", obj)
+	}
+
+	switch typeAccessor.GetKind() {
+	case "Deployment":
+		templateMap, ok, err := unstructured.NestedMap(unstructuredObj.UnstructuredContent(), "spec", "template")
+		if err != nil || !ok {
+			return "", "", fmt.Errorf("failed to get pod template from Deployment: %w", err)
+		}
+		template := &v1.PodTemplateSpec{}
+		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(templateMap, template); err != nil {
+			return "", "", fmt.Errorf("failed to parse spec.template: %w", err)
+		}
+
+		replicaSets, err := w.podsIndexer.ReplicaSetsControlledBy(metaAccessor.GetUID())
+		if err != nil {
+			return "", "", fmt.Errorf("failed to get replica sets for deployment %s: %w", metaAccessor.GetName(), err)
+		}
+
+		rs, err := runtimeobjects.FindMatchingReplicaSet(replicaSets, template)
+		if err != nil {
+			return "", "", fmt.Errorf("failed to find matching ReplicaSet: %w", err)
+		}
+
+		hash, ok := rs.Labels["pod-template-hash"]
+		if !ok || hash == "" {
+			return "", "", fmt.Errorf("ReplicaSet %s has no pod-template-hash label", rs.Name)
+		}
+		return "pod-template-hash", hash, nil
+
+	case "StatefulSet", "DaemonSet":
+		templateMap, ok, err := unstructured.NestedMap(unstructuredObj.UnstructuredContent(), "spec", "template")
+		if err != nil || !ok {
+			return "", "", fmt.Errorf("failed to get pod template from %s: %w", typeAccessor.GetKind(), err)
+		}
+		template := &v1.PodTemplateSpec{}
+		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(templateMap, template); err != nil {
+			return "", "", fmt.Errorf("failed to parse spec.template: %w", err)
+		}
+
+		revisions, err := w.podsIndexer.ControllerRevisionsControlledBy(metaAccessor.GetUID())
+		if err != nil {
+			return "", "", fmt.Errorf("failed to get controller revisions for %s %s: %w", typeAccessor.GetKind(), metaAccessor.GetName(), err)
+		}
+
+		rev, err := runtimeobjects.FindMatchingControllerRevision(revisions, template)
+		if err != nil {
+			return "", "", fmt.Errorf("failed to find matching ControllerRevision: %w", err)
+		}
+
+		return "controller-revision-hash", rev.Name, nil
+
+	case "Job":
+		uid, found, err := unstructured.NestedString(unstructuredObj.UnstructuredContent(), "metadata", "uid")
+		if err != nil || !found || uid == "" {
+			return "", "", fmt.Errorf("failed to get UID from Job: %w", err)
+		}
+		return "controller-uid", uid, nil
+
+	default:
+		return "", "", fmt.Errorf("hash-based pod comparison not supported for kind: %s", typeAccessor.GetKind())
+	}
 }

--- a/clusterloader2/pkg/measurement/common/wait_for_controlled_pods.go
+++ b/clusterloader2/pkg/measurement/common/wait_for_controlled_pods.go
@@ -19,7 +19,6 @@ package common
 import (
 	"context"
 	"fmt"
-	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -66,8 +65,6 @@ const (
 
 var podIndexerFactory = &sharedPodIndexerFactory{}
 
-var automanagedNamespaceID = regexp.MustCompile(`^test-[a-z0-9]+-[0-9]+$`)
-
 func init() {
 	if err := measurement.Register(waitForControlledPodsRunningName, createWaitForControlledPodsRunningMeasurement); err != nil {
 		klog.Fatalf("Cannot register %s: %v", waitForControlledPodsRunningName, err)
@@ -89,29 +86,7 @@ func (s *sharedPodIndexerFactory) PodsIndexer(c clientset.Interface) (*measureme
 
 func (s *sharedPodIndexerFactory) start(c clientset.Interface) (*measurementutil.ControlledPodsIndexer, error) {
 	ctx := context.Background()
-	trimFn := func(obj interface{}) (interface{}, error) {
-		if accessor, err := meta.Accessor(obj); err == nil && accessor.GetManagedFields() != nil {
-			accessor.SetManagedFields(nil)
-		}
-		pod, ok := obj.(*v1.Pod)
-		if !ok {
-			return obj, nil
-		}
-		if automanagedNamespaceID.MatchString(pod.Namespace) {
-			// For pods managed by the clusterloader, we need to keep the full pod.Spec for checkIfPodsAreUpdated feature.
-			return obj, nil
-		}
-
-		pod.Spec = v1.PodSpec{
-			NodeName: pod.Spec.NodeName,
-		}
-		pod.Status = v1.PodStatus{
-			Phase:      pod.Status.Phase,
-			Conditions: pod.Status.Conditions,
-		}
-		return pod, nil
-	}
-	informerFactory := informers.NewSharedInformerFactoryWithOptions(c, 0, informers.WithTransform(trimFn))
+	informerFactory := informers.NewSharedInformerFactoryWithOptions(c, 0, informers.WithTransform(informer.TrimManagedFields))
 	podsIndexer, err := measurementutil.NewControlledPodsIndexer(
 		informerFactory.Core().V1().Pods(),
 		informerFactory.Apps().V1().ReplicaSets(),

--- a/clusterloader2/pkg/measurement/util/controlled_pods_indexer.go
+++ b/clusterloader2/pkg/measurement/util/controlled_pods_indexer.go
@@ -39,11 +39,13 @@ const (
 // ControlledPodsIndexer is able to efficiently find pods with ownerReference pointing a given controller object.
 // For Deployments, it performs indirect lookup with ReplicaSets in the middle.
 type ControlledPodsIndexer struct {
-	podsIndexer cache.Indexer
-	podsSynced  cache.InformerSynced
-	rsSynced    cache.InformerSynced
+	podsIndexer     cache.Indexer
+	podsSynced      cache.InformerSynced
+	rsSynced        cache.InformerSynced
+	revisionsSynced cache.InformerSynced
 
-	rsIndexer cache.Indexer
+	rsIndexer        cache.Indexer
+	revisionsIndexer cache.Indexer
 
 	// lock is a lock for accessing rsPendingDeletion.
 	lock sync.Mutex
@@ -72,9 +74,13 @@ func deletionHandlingUIDKeyFunc(obj interface{}) (string, error) {
 }
 
 // NewControlledPodsIndexer creates a new ControlledPodsIndexer instance.
-func NewControlledPodsIndexer(podsInformer coreinformers.PodInformer, rsInformer appsinformers.ReplicaSetInformer) (*ControlledPodsIndexer, error) {
+func NewControlledPodsIndexer(podsInformer coreinformers.PodInformer, rsInformer appsinformers.ReplicaSetInformer, revisionsInformer appsinformers.ControllerRevisionInformer) (*ControlledPodsIndexer, error) {
 	if err := podsInformer.Informer().AddIndexers(cache.Indexers{controllerUIDIndex: controllerUIDIndexFunc}); err != nil {
 		return nil, fmt.Errorf("failed to register indexer: %w", err)
+	}
+
+	if err := revisionsInformer.Informer().AddIndexers(cache.Indexers{controllerUIDIndex: controllerUIDIndexFunc}); err != nil {
+		return nil, fmt.Errorf("failed to register revisions indexer: %w", err)
 	}
 
 	// We need a separate storage from rsInformer as we postpone deletion until all pods are removed.
@@ -85,6 +91,8 @@ func NewControlledPodsIndexer(podsInformer coreinformers.PodInformer, rsInformer
 		podsSynced:        podsInformer.Informer().HasSynced,
 		rsIndexer:         rsIndexer,
 		rsSynced:          rsInformer.Informer().HasSynced,
+		revisionsIndexer:  revisionsInformer.Informer().GetIndexer(),
+		revisionsSynced:   revisionsInformer.Informer().HasSynced,
 		rsPendingDeletion: make(map[types.UID]bool),
 	}
 
@@ -205,7 +213,7 @@ func controllerUIDIndexFunc(obj interface{}) ([]string, error) {
 
 // WaitForCacheSync waits for all required informers to be initialized.
 func (p *ControlledPodsIndexer) WaitForCacheSync(ctx context.Context) bool {
-	return cache.WaitForNamedCacheSync("PodsIndexer", ctx.Done(), p.podsSynced, p.rsSynced)
+	return cache.WaitForNamedCacheSync("PodsIndexer", ctx.Done(), p.podsSynced, p.rsSynced, p.revisionsSynced)
 }
 
 // PodsControlledBy returns pods controlled by a given controller object.
@@ -260,6 +268,32 @@ func (p *ControlledPodsIndexer) appendPodsControlledBy(res []*corev1.Pod, uid ty
 			return nil, fmt.Errorf("expected *corev1.Pod; got: %T", obj)
 		}
 		res = append(res, pod)
+	}
+	return res, nil
+}
+
+// ReplicaSetsControlledBy returns ReplicaSets controlled by a given Deployment.
+func (p *ControlledPodsIndexer) ReplicaSetsControlledBy(deploymentUID types.UID) ([]*appsv1.ReplicaSet, error) {
+	replicaSets, err := p.rsIndexer.ByIndex(controllerUIDIndex, string(deploymentUID))
+	if err != nil {
+		return nil, err
+	}
+	res := make([]*appsv1.ReplicaSet, len(replicaSets))
+	for i, obj := range replicaSets {
+		res[i] = obj.(*appsv1.ReplicaSet)
+	}
+	return res, nil
+}
+
+// ControllerRevisionsControlledBy returns ControllerRevisions controlled by a given controller (StatefulSet/DaemonSet).
+func (p *ControlledPodsIndexer) ControllerRevisionsControlledBy(controllerUID types.UID) ([]*appsv1.ControllerRevision, error) {
+	revisions, err := p.revisionsIndexer.ByIndex(controllerUIDIndex, string(controllerUID))
+	if err != nil {
+		return nil, err
+	}
+	res := make([]*appsv1.ControllerRevision, len(revisions))
+	for i, obj := range revisions {
+		res[i] = obj.(*appsv1.ControllerRevision)
 	}
 	return res, nil
 }

--- a/clusterloader2/pkg/measurement/util/controlled_pods_indexer_test.go
+++ b/clusterloader2/pkg/measurement/util/controlled_pods_indexer_test.go
@@ -144,7 +144,8 @@ func newMockedControlledPodsIndexer(ctx context.Context, t *testing.T, client *f
 	informerFactory := informers.NewSharedInformerFactory(client, 0 /* resyncPeriod */)
 	podsInformer := informerFactory.Core().V1().Pods()
 	rsInformer := informerFactory.Apps().V1().ReplicaSets()
-	p, err := NewControlledPodsIndexer(podsInformer, rsInformer)
+	revisionsInformer := informerFactory.Apps().V1().ControllerRevisions()
+	p, err := NewControlledPodsIndexer(podsInformer, rsInformer, revisionsInformer)
 	if err != nil {
 		t.Fatalf("failed to create ControlledPodsIndexer instance: %v", err)
 	}

--- a/clusterloader2/pkg/measurement/util/runtimeobjects/runtimeobjects.go
+++ b/clusterloader2/pkg/measurement/util/runtimeobjects/runtimeobjects.go
@@ -18,6 +18,7 @@ package runtimeobjects
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"sync"
@@ -38,6 +39,7 @@ import (
 	"k8s.io/client-go/dynamic"
 	clientset "k8s.io/client-go/kubernetes"
 	corev1helpers "k8s.io/component-helpers/scheduling/corev1"
+	"k8s.io/klog/v2"
 	"k8s.io/perf-tests/clusterloader2/pkg/framework/client"
 )
 
@@ -435,4 +437,51 @@ func podMatchesNodeAffinity(affinity *corev1.Affinity, node *corev1.Node) (bool,
 		return corev1helpers.MatchNodeSelectorTerms(node, nodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution)
 	}
 	return true, nil
+}
+
+// FindMatchingReplicaSet returns the ReplicaSet whose Spec.Template matches the expected template.
+func FindMatchingReplicaSet(replicaSets []*appsv1.ReplicaSet, template *corev1.PodTemplateSpec) (*appsv1.ReplicaSet, error) {
+	for _, rs := range replicaSets {
+		if equality.Semantic.DeepDerivative(template.Spec, rs.Spec.Template.Spec) {
+			return rs, nil
+		}
+	}
+	return nil, fmt.Errorf("no matching ReplicaSet found")
+}
+
+// FindMatchingControllerRevision returns the ControllerRevision whose Data matches the expected template.
+func FindMatchingControllerRevision(revisions []*appsv1.ControllerRevision, template *corev1.PodTemplateSpec) (*appsv1.ControllerRevision, error) {
+	for _, rev := range revisions {
+		revTemplate, err := getTemplateFromRevision(rev.Data.Raw)
+		if err != nil {
+			klog.V(4).Infof("Failed to parse template from revision %s: %v", rev.Name, err)
+			continue
+		}
+		if equality.Semantic.DeepDerivative(template.Spec, revTemplate.Spec) {
+			return rev, nil
+		}
+	}
+	return nil, fmt.Errorf("no matching ControllerRevision found")
+}
+
+func getTemplateFromRevision(raw []byte) (*corev1.PodTemplateSpec, error) {
+	var objMap map[string]interface{}
+	if err := json.Unmarshal(raw, &objMap); err != nil {
+		return nil, err
+	}
+	if spec, ok := objMap["spec"].(map[string]interface{}); ok {
+		if template, ok := spec["template"].(map[string]interface{}); ok {
+			return convertToTemplate(template)
+		}
+	}
+	if template, ok := objMap["template"].(map[string]interface{}); ok {
+		return convertToTemplate(template)
+	}
+	return convertToTemplate(objMap)
+}
+
+func convertToTemplate(m map[string]interface{}) (*corev1.PodTemplateSpec, error) {
+	template := &corev1.PodTemplateSpec{}
+	err := runtime.DefaultUnstructuredConverter.FromUnstructured(m, template)
+	return template, err
 }


### PR DESCRIPTION


#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
Introduces a new flag hash-based-pod-comparison that, when enabled (default false), it changes a semantics of IsPodUpdates to allow memory optimizations of pod informer.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

