### PR TITLE
CL2: Partially revert 4068

### DIFF
--- a/clusterloader2/pkg/measurement/common/wait_for_controlled_pods.go
+++ b/clusterloader2/pkg/measurement/common/wait_for_controlled_pods.go
@@ -19,7 +19,6 @@ package common
 import (
 	"context"
 	"fmt"
-	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -66,8 +65,6 @@ const (
 
 var podIndexerFactory = &sharedPodIndexerFactory{}
 
-var automanagedNamespaceID = regexp.MustCompile(`^test-[a-z0-9]+-[0-9]+$`)
-
 func init() {
 	if err := measurement.Register(waitForControlledPodsRunningName, createWaitForControlledPodsRunningMeasurement); err != nil {
 		klog.Fatalf("Cannot register %s: %v", waitForControlledPodsRunningName, err)
@@ -89,29 +86,7 @@ func (s *sharedPodIndexerFactory) PodsIndexer(c clientset.Interface) (*measureme
 
 func (s *sharedPodIndexerFactory) start(c clientset.Interface) (*measurementutil.ControlledPodsIndexer, error) {
 	ctx := context.Background()
-	trimFn := func(obj interface{}) (interface{}, error) {
-		if accessor, err := meta.Accessor(obj); err == nil && accessor.GetManagedFields() != nil {
-			accessor.SetManagedFields(nil)
-		}
-		pod, ok := obj.(*v1.Pod)
-		if !ok {
-			return obj, nil
-		}
-		if automanagedNamespaceID.MatchString(pod.Namespace) {
-			// For pods managed by the clusterloader, we need to keep the full pod.Spec for checkIfPodsAreUpdated feature.
-			return obj, nil
-		}
-
-		pod.Spec = v1.PodSpec{
-			NodeName: pod.Spec.NodeName,
-		}
-		pod.Status = v1.PodStatus{
-			Phase:      pod.Status.Phase,
-			Conditions: pod.Status.Conditions,
-		}
-		return pod, nil
-	}
-	informerFactory := informers.NewSharedInformerFactoryWithOptions(c, 0, informers.WithTransform(trimFn))
+	informerFactory := informers.NewSharedInformerFactoryWithOptions(c, 0, informers.WithTransform(informer.TrimManagedFields))
 	podsIndexer, err := measurementutil.NewControlledPodsIndexer(
 		informerFactory.Core().V1().Pods(),
 		informerFactory.Apps().V1().ReplicaSets(),


### PR DESCRIPTION
Breaks namespaceList feature which can watch pods in  non-managed namespaces.