### PR TITLE
fix(request-benchmark): use resilient Content-Type parsing to ignore charset

### DIFF
--- a/util-images/request-benchmark/main.go
+++ b/util-images/request-benchmark/main.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"mime"
 	"net/http"
 	"net/url"
 	"os"
@@ -186,8 +187,15 @@ func sendRequest(ctx context.Context, client *http.Client, url url.URL, rateLimi
 		log.Printf("Got bad status code: %v\n", resp.Status)
 		return false
 	}
-	if resp.Header.Get("Content-Type") != contentType {
-		log.Printf("Got bad content type: %q, expected %q\n", resp.Header.Get("Content-Type"), contentType)
+	respContentType := resp.Header.Get("Content-Type")
+	mediaType, _, err := mime.ParseMediaType(respContentType)
+	if err != nil {
+		log.Printf("Got invalid Content-Type header %q: %v\n", respContentType, err)
+		return false
+	}
+	expectedMediaType, _, _ := mime.ParseMediaType(contentType)
+	if mediaType != expectedMediaType {
+		log.Printf("Got bad content type: %q, expected %q\n", mediaType, expectedMediaType)
 		return false
 	}
 	written, err := io.Copy(io.Discard, resp.Body)


### PR DESCRIPTION
Fixes a CI timeout failure by making `request-benchmark`'s `Content-Type` validation resilient to optional parameters like `charset=utf-8`.

In GCE CI runs, intermediate network proxies or the Go runtime can append `; charset=utf-8` to JSON response headers. The previous strict string comparison failed in these cases, causing the tool to panic and crash-loop during its startup health check.

This change uses `mime.ParseMediaType` to validate only the core media type, ignoring extra parameters.

Ref: https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kubernetes-benchmark-list-json-pretty/2060011128372596736

Gemini figured this out, I've verified the issue in the logs, but didn't find exactly how the charset gets added. I believe it's through the proxy.
