### PR TITLE
cl2/restart-apiserver: restart a random master apiserver

### DIFF
--- a/clusterloader2/pkg/measurement/common/restart_apiserver.go
+++ b/clusterloader2/pkg/measurement/common/restart_apiserver.go
@@ -19,6 +19,7 @@ package common
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"strings"
 	"time"
 
@@ -71,10 +72,9 @@ func (r *restartApiserverMeasurement) Execute(config *measurement.Config) ([]mea
 		return nil, fmt.Errorf("%s: MasterIPs not configured", r)
 	}
 
-	for _, masterIP := range cc.MasterIPs {
-		if err := r.restartOne(masterIP, cc.Provider, downSeconds, readyTimeout); err != nil {
-			return nil, err
-		}
+	masterIP := cc.MasterIPs[rand.Intn(len(cc.MasterIPs))]
+	if err := r.restartOne(masterIP, cc.Provider, downSeconds, readyTimeout); err != nil {
+		return nil, err
 	}
 	return nil, nil
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Restart a randomly chosen master apiserver in multi-master scenarios.