### PR TITLE
clusterloader2: make PROMETHEUS_SCRAPE_APISERVER_ONLY overridable

### DIFF
--- a/clusterloader2/pkg/config/cluster.go
+++ b/clusterloader2/pkg/config/cluster.go
@@ -76,6 +76,7 @@ type ModifierConfig struct {
 
 // PrometheusConfig represents all flags used by prometheus.
 type PrometheusConfig struct {
+	ScrapeApiserverOnly        string
 	TearDownServer             bool
 	EnableServer               bool
 	EnablePushgateway          bool

--- a/clusterloader2/pkg/prometheus/prometheus.go
+++ b/clusterloader2/pkg/prometheus/prometheus.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+	"strconv"
 	"sync"
 	"time"
 
@@ -89,6 +90,7 @@ func InitFlags(p *config.PrometheusConfig) {
 	flags.BoolEnvVar(&p.ScrapeKubelets, "prometheus-scrape-kubelets", "PROMETHEUS_SCRAPE_KUBELETS", false, "Whether to scrape kubelets (nodes + master). Experimental, may not work in larger clusters. Requires heapster node to be at least n1-standard-4, which needs to be provided manually.")
 	flags.BoolEnvVar(&p.ScrapeMasterKubelets, "prometheus-scrape-master-kubelets", "PROMETHEUS_SCRAPE_MASTER_KUBELETS", false, "Whether to scrape kubelets running on master nodes.")
 	flags.BoolEnvVar(&p.ScrapeKubeProxy, "prometheus-scrape-kube-proxy", "PROMETHEUS_SCRAPE_KUBE_PROXY", true, "Whether to scrape kube proxy.")
+	flags.StringEnvVar(&p.ScrapeApiserverOnly, "prometheus-scrape-apiserver-only", "PROMETHEUS_SCRAPE_APISERVER_ONLY", "", "Override scraping only the apiserver among master components (\"true\"/\"false\"). Empty uses the provider default.")
 	flags.StringEnvVar(&p.KubeProxySelectorKey, "prometheus-kube-proxy-selector-key", "PROMETHEUS_KUBE_PROXY_SELECTOR_KEY", "component", "Label key used to scrape kube proxy.")
 	flags.BoolEnvVar(&p.ScrapeKubeStateMetrics, "prometheus-scrape-kube-state-metrics", "PROMETHEUS_SCRAPE_KUBE_STATE_METRICS", false, "Whether to scrape kube-state-metrics. Only run occasionally.")
 	flags.BoolEnvVar(&p.ScrapeMetricsServerMetrics, "prometheus-scrape-metrics-server", "PROMETHEUS_SCRAPE_METRICS_SERVER_METRICS", false, "Whether to scrape metrics-server. Only run occasionally.")
@@ -166,7 +168,11 @@ func NewController(clusterLoaderConfig *config.ClusterLoaderConfig) (pc *Control
 		}
 	}
 	if _, exists := mapping["PROMETHEUS_SCRAPE_APISERVER_ONLY"]; !exists {
-		mapping["PROMETHEUS_SCRAPE_APISERVER_ONLY"] = clusterLoaderConfig.ClusterConfig.Provider.Features().ShouldPrometheusScrapeApiserverOnly
+		if v, err := strconv.ParseBool(clusterLoaderConfig.PrometheusConfig.ScrapeApiserverOnly); err == nil {
+			mapping["PROMETHEUS_SCRAPE_APISERVER_ONLY"] = v
+		} else {
+			mapping["PROMETHEUS_SCRAPE_APISERVER_ONLY"] = clusterLoaderConfig.ClusterConfig.Provider.Features().ShouldPrometheusScrapeApiserverOnly
+		}
 	}
 	// TODO: Change to pure assignments when overrides are not used.
 	if _, exists := mapping["PROMETHEUS_SCRAPE_ETCD"]; !exists {


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Adds `--prometheus-scrape-apiserver-only` / `PROMETHEUS_SCRAPE_APISERVER_ONLY` to override the per-provider `Features().ShouldPrometheusScrapeApiserverOnly` default. Empty keeps the provider default (no change for existing jobs); kops self-managed AWS jobs can set `false` to also scrape kube-scheduler and kube-controller-manager, which the `aws` provider otherwise drops (leaving `PrometheusSchedulingMetrics` empty, unlike GCE).

#### Special notes for your reviewer:
Default is preserved for all providers; a companion test-infra change opts the EC2 DRA jobs in.