### PR TITLE
cl2/restart-apiserver: report watch cache init duration per apiserver instance

### DIFF
--- a/clusterloader2/testing/load/modules/restart-apiserver.yaml
+++ b/clusterloader2/testing/load/modules/restart-apiserver.yaml
@@ -31,11 +31,12 @@ steps:
       unit: s
       dimensions:
       - resource
+      - instance
       queries:
-      - name: Avg
-        query: sum by (resource) (apiserver_watch_cache_initialization_duration_seconds_sum) / (sum by (resource) (apiserver_watch_cache_initialization_duration_seconds_count) > 0)
-      - name: Count
-        query: sum by (resource) (apiserver_watch_cache_initialization_duration_seconds_count)
+      - name: InitDuration
+        query: sum by (resource, instance) (apiserver_watch_cache_initialization_duration_seconds_sum) / (sum by (resource, instance) (apiserver_watch_cache_initialization_duration_seconds_count) > 0)
+      - name: InitCount
+        query: sum by (resource, instance) (apiserver_watch_cache_initialization_duration_seconds_count)
 
 - name: Restart kube-apiserver and wait for /readyz
   measurements:


### PR DESCRIPTION
/kind cleanup

Group watch cache init duration by `(resource, instance)` so the restarted apiserver is reported separately instead of averaged across all instances. Otherwise it reports a single blended number (54.36 ms) instead of the three below.

([prow run](https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/139476/pull-kubernetes-gce-master-scale-performance-100-apiserver-restart/2062247362662764544)), numbers for watch cache init for pods:
- `10.128.0.102`: 0.53 ms
- `10.128.0.104`: 0.65 ms
- `10.128.0.105`: 161.89 ms (restarted)
