### PR TITLE
cl2: scrape etcd pprof over the insecure client-http port

### DIFF
--- a/clusterloader2/cmd/clusterloader.go
+++ b/clusterloader2/cmd/clusterloader.go
@@ -75,6 +75,7 @@ func initClusterFlags() {
 	flags.StringEnvVar(&clusterLoaderConfig.ClusterConfig.EtcdCertificatePath, "etcd-certificate", "ETCD_CERTIFICATE", "/etc/srv/kubernetes/pki/etcd-apiserver-server.crt", "Path to the etcd certificate on the master machine")
 	flags.StringEnvVar(&clusterLoaderConfig.ClusterConfig.EtcdKeyPath, "etcd-key", "ETCD_KEY", "/etc/srv/kubernetes/pki/etcd-apiserver-server.key", "Path to the etcd key on the master machine")
 	flags.IntEnvVar(&clusterLoaderConfig.ClusterConfig.EtcdInsecurePort, "etcd-insecure-port", "ETCD_INSECURE_PORT", 2382, "Inscure http port")
+	flags.IntEnvVar(&clusterLoaderConfig.ClusterConfig.EtcdPprofPort, "etcd-pprof-port", "ETCD_PPROF_PORT", 2385, "Insecure http port serving etcd /debug/pprof (etcd --listen-client-http-urls)")
 	flags.BoolEnvVar(&clusterLoaderConfig.ClusterConfig.DeleteStaleNamespaces, "delete-stale-namespaces", "DELETE_STALE_NAMESPACES", false, "DEPRECATED: Whether to delete all stale namespaces before the test execution.")
 	err := flags.MarkDeprecated("delete-stale-namespaces", "specify deleteStaleNamespaces in testconfig file instead.")
 	if err != nil {

--- a/clusterloader2/pkg/config/cluster.go
+++ b/clusterloader2/pkg/config/cluster.go
@@ -43,6 +43,7 @@ type ClusterConfig struct {
 	EtcdCertificatePath string
 	EtcdKeyPath         string
 	EtcdInsecurePort    int
+	EtcdPprofPort       int
 	MasterIPs           []string
 	MasterInternalIPs   []string
 	MasterName          string

--- a/clusterloader2/pkg/measurement/common/profile.go
+++ b/clusterloader2/pkg/measurement/common/profile.go
@@ -232,9 +232,7 @@ func (p *profileMeasurement) getProfileCommand(config *measurement.Config) (stri
 
 	var command string
 	if p.config.componentName == "etcd" {
-		etcdCert := config.ClusterFramework.GetClusterConfig().EtcdCertificatePath
-		etcdKey := config.ClusterFramework.GetClusterConfig().EtcdKeyPath
-		command = fmt.Sprintf("curl -s -k --cert %s --key %s %slocalhost:%v/debug/pprof/%s", etcdCert, etcdKey, profileProtocol, profilePort, p.config.kind)
+		command = fmt.Sprintf("curl -s http://localhost:%d/debug/pprof/%s", config.ClusterFramework.GetClusterConfig().EtcdPprofPort, p.config.kind)
 	} else {
 		command = fmt.Sprintf("curl -s -k %slocalhost:%v/debug/pprof/%s", profileProtocol, profilePort, p.config.kind)
 	}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
kubernetes/kops#18370 moved etcd /debug/pprof to a separate client-http listener, so scrape it on ETCD_PPROF_PORT (default 2385) instead of 2379.

Otherwise we don't get pprof data (eg: https://gcsweb.k8s.io/gcs/kubernetes-ci-logs/logs/ci-kubernetes-e2e-gce-scale-performance-5000/2062218224480555008/artifacts/)

#### Does this PR introduce a user-facing change?
```release-note
NONE
```