### PR TITLE
dra: bump testing/dra config timeouts for 5k scale

### DIFF
--- a/clusterloader2/pkg/measurement/common/wait_for_jobs.go
+++ b/clusterloader2/pkg/measurement/common/wait_for_jobs.go
@@ -217,13 +217,14 @@ func (w *waitForFinishedJobsMeasurement) handleObject(oldObj, newObj interface{}
 		klog.Errorf("Failed obtaining meta key for Job: %v", err)
 		return
 	}
-	completed, condition := finishedJobCondition(newJob)
+	completed, condition := finishedJobCondition(handleJob)
 
 	w.lock.Lock()
 	defer w.lock.Unlock()
 	if completed {
 		w.finishedJobs[key] = condition
-	} else {
+	} else if _, alreadyFinished := w.finishedJobs[key]; !alreadyFinished {
+		// Keep finished jobs deleted via ttlSecondsAfterFinished.
 		delete(w.finishedJobs, key)
 	}
 }

--- a/clusterloader2/testing/dra/config.yaml
+++ b/clusterloader2/testing/dra/config.yaml
@@ -210,7 +210,7 @@ steps:
       Params:
         action: gather
         labelSelector: job-type = short-lived
-        timeout: 15m
+        timeout: 30m
 - name: Measure scheduler metrics
   measurements:
     - Identifier: ChurnSchedulingMetrics


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Fixes `WaitForFinishedJobs` undercounting at scale. When churn jobs are deleted by `ttlSecondsAfterFinished` before the measurement gathers, `handleObject` read completion from `newJob` (nil on delete) and dropped the key, so the finished count never reached the target and the measurement timed out at 5k. Use `handleJob` (the surviving object) and keep already-finished entries on delete. Also bumps the DRA churn `WaitForFinishedJobs` timeout 15m→30m.

#### Special notes for your reviewer:
Lands the fix from `alaypatel07:dra-scalability-bump-timeout` so the GCE/EC2 5k DRA jobs can use `kubernetes/perf-tests@master` instead of the fork branch.