### PR TITLE
clusterloader2: scale Prometheus memory with node count when scraping kubelets

### DIFF
--- a/clusterloader2/pkg/prometheus/manifests/prometheus-prometheus.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/prometheus-prometheus.yaml
@@ -8,6 +8,7 @@
 {{$PROMETHEUS_PVC_ENABLED := DefaultParam .CL2_PROMETHEUS_PVC_ENABLED (not $PROMETHEUS_TOLERATE_MASTER)}}
 {{$PROMETHEUS_PVC_STORAGE_CLASS := DefaultParam .PROMETHEUS_PVC_STORAGE_CLASS "ssd"}}
 {{$PROMETHEUS_MEMORY_REQUEST := DefaultParam .PROMETHEUS_MEMORY_REQUEST "10Gi"}}
+{{$PROMETHEUS_KUBELET_MEMORY_SCALE_FACTOR := DefaultParam .CL2_PROMETHEUS_KUBELET_MEMORY_SCALE_FACTOR 10}}
 
 apiVersion: monitoring.coreos.com/v1
 kind: Prometheus
@@ -28,14 +29,16 @@ spec:
     requests:
       cpu: {{AddInt 200 (MultiplyInt $PROMETHEUS_CPU_SCALE_FACTOR 500 (DivideInt .Nodes 1000))}}m
       {{if $PROMETHEUS_SCRAPE_KUBELETS}}
-      memory: {{$PROMETHEUS_MEMORY_REQUEST}}
+      # Kubelet + cAdvisor scraping is memory-heavy; scale ~10Gi per 1K nodes (10Gi floor below 1K).
+      memory: {{MultiplyInt $PROMETHEUS_KUBELET_MEMORY_SCALE_FACTOR (AddInt 1 (DivideInt .Nodes 1000))}}Gi
       {{else}}
       # Start with 2Gi and add 2Gi for each 1K nodes.
       memory: {{MultiplyInt $PROMETHEUS_MEMORY_SCALE_FACTOR (AddInt 1 (DivideInt .Nodes 1000))}}Gi
       {{end}}
     limits:
       {{if $PROMETHEUS_SCRAPE_KUBELETS}}
-      memory: 10Gi
+      # Kubelet + cAdvisor scraping is memory-heavy; scale ~10Gi per 1K nodes (10Gi floor below 1K).
+      memory: {{MultiplyInt $PROMETHEUS_KUBELET_MEMORY_SCALE_FACTOR (AddInt 1 (DivideInt .Nodes 1000))}}Gi
       {{else}}
       # Default: Start with 2Gi and add 2Gi for each 1K nodes.
       memory: {{MultiplyInt $PROMETHEUS_MEMORY_SCALE_FACTOR (AddInt 1 (DivideInt .Nodes 1000))}}Gi


### PR DESCRIPTION
Context: trying to fix failure in https://testgrid.k8s.io/sig-scalability-aws#ec2-dra-with-workload-master-scalability-5000

Slack thread: https://kubernetes.slack.com/archives/C09QZTRH7/p1780922057989349?thread_ts=1780498344.087259&cid=C09QZTRH7

pods yaml [snippet](https://storage.googleapis.com/kubernetes-ci-logs/logs/ci-kubernetes-e2e-kops-aws-5000-node-dra-with-workload-amazonvpc-using-cl2/2063154346484305920/artifacts/cluster-info/monitoring/pods.yaml):
```
- allocatedResources:
        cpu: 2700m
        memory: 10Gi
      containerID: containerd://c276b217e183eec71fa8651d55d1151616826ef26fe7db92d138d7dab882ee38
      image: gcr.io/k8s-testimages/quay.io/prometheus/prometheus:v2.40.0
      imageID: gcr.io/k8s-testimages/quay.io/prometheus/prometheus@sha256:eff669d70ee485a191a645caa269530fc4930d0b6c178390c1e1bb378fd200fc
      lastState:
        terminated:
          containerID: containerd://c276b217e183eec71fa8651d55d1151616826ef26fe7db92d138d7dab882ee38
          exitCode: 137
          finishedAt: "2026-06-06T07:49:52Z"
          message: |
            eout=6m51s&timeoutSeconds=411&watch=true 200 OK in 0 milliseconds"
            ts=2026-06-06T07:49:26.422Z caller=klog.go:84 level=debug component=k8s_client_runtime func=Infof msg="GET [https://100.64.0.1:443/api/v1/namespaces/monitoring/services?allowWatchBookmarks=true&resourceVersion=986563&timeout=6m0s&timeoutSeconds=360&watch=true](https://100.64.0.1/api/v1/namespaces/monitoring/services?allowWatchBookmarks=true&resourceVersion=986563&timeout=6m0s&timeoutSeconds=360&watch=true) 200 OK in 0 milliseconds"
            ts=2026-06-06T07:49:26.423Z caller=klog.go:84 level=debug component=k8s_client_runtime func=Infof msg="GET [https://100.64.0.1:443/api/v1/namespaces/monitoring/pods?allowWatchBookmarks=true&resourceVersion=1005881&timeout=9m29s&timeoutSeconds=569&watch=true](https://100.64.0.1/api/v1/namespaces/monitoring/pods?allowWatchBookmarks=true&resourceVersion=1005881&timeout=9m29s&timeoutSeconds=569&watch=true) 200 OK in 0 milliseconds"
            ts=2026-06-06T07:49:26.432Z caller=klog.go:96 level=warn component=k8s_client_runtime func=Warning msg="v1 Endpoints is deprecated in v1.33+; use discovery.k8s.io/v1 EndpointSlice"
            ts=2026-06-06T07:49:26.435Z caller=klog.go:84 level=debug component=k8s_client_runtime func=Infof msg="GET [https://100.64.0.1:443/api/v1/namespaces/kube-system/endpoints?allowWatchBookmarks=true&resourceVersion=976618&timeout=7m35s&timeoutSeconds=455&watch=true](https://100.64.0.1/api/v1/namespaces/kube-system/endpoints?allowWatchBookmarks=true&resourceVersion=976618&timeout=7m35s&timeoutSeconds=455&watch=true) 200 OK in 0 milliseconds"
            ts=2026-06-06T07:49:26.435Z caller=klog.go:96 level=warn component=k8s_client_runtime func=Warning msg="v1 Endpoints is deprecated in v1.33+; use discovery.k8s.io/v1 EndpointSlice"
            ts=2026-06-06T07:49:26.519Z caller=klog.go:55 level=debug component=k8s_client_runtime func=Verbose.Infof msg="caches populated"
            ts=2026-06-06T07:49:26.621Z caller=klog.go:84 level=debug component=k8s_client_runtime func=Infof msg="GET [https://100.64.0.1:443/api/v1/namespaces/kube-system/pods?limit=500&resourceVersion=0](https://100.64.0.1/api/v1/namespaces/kube-system/pods?limit=500&resourceVersion=0) 200 OK in 202 milliseconds"
            ts=2026-06-06T07:49:27.836Z caller=klog.go:84 level=debug component=k8s_client_runtime func=Infof msg="GET [https://100.64.0.1:443/api/v1/namespaces/kube-system/pods?allowWatchBookmarks=true&resourceVersion=1005881&timeout=9m32s&timeoutSeconds=572&watch=true](https://100.64.0.1/api/v1/namespaces/kube-system/pods?allowWatchBookmarks=true&resourceVersion=1005881&timeout=9m32s&timeoutSeconds=572&watch=true) 200 OK in 1 milliseconds"
            ts=2026-06-06T07:49:27.919Z caller=klog.go:55 level=debug component=k8s_client_runtime func=Verbose.Infof msg="caches populated"
          reason: OOMKilled
          startedAt: "2026-06-06T07:49:23Z"
```

When PROMETHEUS_SCRAPE_KUBELETS is enabled, the Prometheus memory request/limit was hardcoded to 10Gi regardless of cluster size. At 5000 nodes (~10k kubelet+cAdvisor scrape targets) Prometheus OOMs and CrashLoopBackOffs during monitoring-stack setup, so ClusterLoader2 fails before any workload runs.

Scale the kubelet-scrape branch with node count (~10Gi per 1K nodes) via a new overridable CL2_PROMETHEUS_KUBELET_MEMORY_SCALE_FACTOR (default 10), matching the shape of the non-kubelet branch. Clusters below 1K nodes are unchanged at 10Gi; 5000 nodes -> 60Gi.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind failing-test

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

