### PR TITLE
Do not log prometheus response for failed targets check

### DIFF
--- a/clusterloader2/pkg/measurement/common/probes/probes.go
+++ b/clusterloader2/pkg/measurement/common/probes/probes.go
@@ -324,8 +324,11 @@ func (p *probesMeasurement) checkProbesReady(ctx context.Context) (bool, error) 
 		}
 		return false
 	}
+
+	// do not log prometheus error for large clusters
+	logPrometheusError := p.framework.GetClusterConfig().Nodes < 5000
 	expectedTargets := p.replicasPerProbe * len(p.config.ProbeLabelValues)
-	return prometheus.CheckAllTargetsReady(ctx, p.framework.GetClientSets().GetClient(), selector, expectedTargets)
+	return prometheus.CheckAllTargetsReady(ctx, p.framework.GetClientSets().GetClient(), selector, expectedTargets, logPrometheusError)
 }
 
 func (p *probesMeasurement) createSummary(latency measurementutil.LatencyMetric) (measurement.Summary, error) {

--- a/clusterloader2/pkg/prometheus/prometheus.go
+++ b/clusterloader2/pkg/prometheus/prometheus.go
@@ -591,6 +591,9 @@ func (pc *Controller) waitForPrometheusToBeHealthy() error {
 }
 
 func (pc *Controller) isPrometheusReady(ctx context.Context) (bool, error) {
+	// do not log prometheus error for large clusters
+	logPrometheusError := pc.clusterLoaderConfig.ClusterConfig.Nodes < 5000
+
 	// TODO(mm4tt): Re-enable kube-proxy monitoring and expect more targets.
 	// This is a safeguard from a race condition where the prometheus server is started before
 	// targets are registered. These 4 targets are always expected, in all possible configurations:
@@ -605,7 +608,7 @@ func (pc *Controller) isPrometheusReady(ctx context.Context) (bool, error) {
 		ok, err := CheckAllTargetsReady(ctx, // All non-etcd targets should be ready.
 			pc.framework.GetClientSets().GetClient(),
 			func(t Target) bool { return !isEtcdEndpoint(t.Labels["endpoint"]) },
-			expectedTargets)
+			expectedTargets, logPrometheusError)
 		if err != nil || !ok {
 			return ok, err
 		}
@@ -613,12 +616,13 @@ func (pc *Controller) isPrometheusReady(ctx context.Context) (bool, error) {
 			pc.framework.GetClientSets().GetClient(),
 			func(t Target) bool { return isEtcdEndpoint(t.Labels["endpoint"]) },
 			2, // expected targets: etcd-2379 and etcd-2382
-			1) // one of them should be healthy
+			1, // one of them should be healthy
+			logPrometheusError)
 	}
 	return CheckAllTargetsReady(ctx,
 		pc.framework.GetClientSets().GetClient(),
 		func(Target) bool { return true }, // All targets.
-		expectedTargets)
+		expectedTargets, logPrometheusError)
 }
 
 func retryCreateFunctionWithResponse(f func() (string, error)) (string, error) {

--- a/clusterloader2/pkg/prometheus/util.go
+++ b/clusterloader2/pkg/prometheus/util.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"regexp"
 
@@ -53,29 +54,40 @@ type Target struct {
 
 // CheckAllTargetsReady returns true iff there is at least minActiveTargets matching the selector and
 // all of them are ready.
-func CheckAllTargetsReady(ctx context.Context, k8sClient kubernetes.Interface, selector func(Target) bool, minActiveTargets int) (bool, error) {
-	return CheckTargetsReady(ctx, k8sClient, selector, minActiveTargets, allTargets)
+func CheckAllTargetsReady(ctx context.Context, k8sClient kubernetes.Interface, selector func(Target) bool, minActiveTargets int, logPrometheusError bool) (bool, error) {
+	return CheckTargetsReady(ctx, k8sClient, selector, minActiveTargets, allTargets, logPrometheusError)
 }
 
 // CheckTargetsReady returns true iff there is at least minActiveTargets matching the selector and
 // at least minReadyTargets of them are ready.
-func CheckTargetsReady(ctx context.Context, k8sClient kubernetes.Interface, selector func(Target) bool, minActiveTargets, minReadyTargets int) (bool, error) {
-
-	raw, err := k8sClient.CoreV1().
+func CheckTargetsReady(ctx context.Context, k8sClient kubernetes.Interface, selector func(Target) bool, minActiveTargets, minReadyTargets int, logPrometheusError bool) (bool, error) {
+	reader, err := k8sClient.CoreV1().
 		Services(namespace).
 		ProxyGet("http", "prometheus-k8s", "9090", "api/v1/targets", nil /*params*/).
-		DoRaw(ctx)
+		Stream(ctx)
 	if err != nil {
-		response := "(empty)"
-		if raw != nil {
-			response = string(raw)
-		}
 		// This might happen if prometheus server is temporary down, log error but don't return it.
-		klog.Warningf("error while calling prometheus api: %v, response: %v", err, response)
+		if !logPrometheusError || reader == nil {
+			// Prometheus response might be very long, especially during large scale tests.
+			// If we don't log it, we avoid dumping large responses into the log.
+			klog.Warningf("error while getting prometheus targets: %v", err)
+			return false, nil
+		}
+		defer reader.Close()
+
+		resp, readErr := io.ReadAll(reader)
+		if readErr != nil {
+			klog.Warningf("error while calling prometheus api: %v, could not read response: %v", err, readErr)
+			return false, nil
+		}
+
+		klog.Warningf("error while calling prometheus api: %v, response: %s", err, string(resp))
 		return false, nil
 	}
+	defer reader.Close()
+
 	var response targetsResponse
-	if err := json.Unmarshal(raw, &response); err != nil {
+	if err := json.NewDecoder(reader).Decode(&response); err != nil {
 		return false, err // This shouldn't happen, return error.
 	}
 	nReady, nTotal := 0, 0


### PR DESCRIPTION
For huge clusters, reading and logging the Prometheus response on the `api/v1/targets` call in the `CheckTargetsReady function` might cause memory issues, because prometheus dumps whole configuration during this call. It also bloats logs, making them unreadable or too large for some tools to consume or display.