### PR TITLE
perfdash: add watch cache init duration max metric

### DIFF
--- a/perfdash/config.go
+++ b/perfdash/config.go
@@ -215,6 +215,11 @@ var (
 				OutputFilePrefix: "MetricsForE2E",
 				Parser:           parseApiserverInitEventsCount,
 			}},
+			"LoadWatchCacheInitializationDurationMax": []TestDescription{{
+				Name:             "load",
+				OutputFilePrefix: "GenericPrometheusQuery Watch Cache Initialization Duration Max",
+				Parser:           parsePerfData,
+			}},
 			"Responsiveness": []TestDescription{{
 				OutputFilePrefix: "APIResponsiveness",
 				Parser:           parsePerfData,


### PR DESCRIPTION
Adds the perfdash config entry for the Watch Cache Initialization Duration Max metric produced by https://github.com/kubernetes/perf-tests/pull/4082.