### PR TITLE
clusterloader2: limit kubelet scrape cardinality and record Prometheus RSS

### DIFF
--- a/clusterloader2/pkg/prometheus/manifests/default/prometheus-serviceMonitorKubelet.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/default/prometheus-serviceMonitorKubelet.yaml
@@ -1,4 +1,5 @@
 {{$PROMETHEUS_SCRAPE_KUBELETS := DefaultParam .PROMETHEUS_SCRAPE_KUBELETS false}}
+{{$KEEP_ONLY_DRA := DefaultParam .CL2_PROMETHEUS_KUBELET_KEEP_ONLY_DRA false}}
 
 {{if $PROMETHEUS_SCRAPE_KUBELETS}}
 apiVersion: monitoring.coreos.com/v1
@@ -19,6 +20,16 @@ spec:
     bearerTokenSecret:
       name: prometheus-token
       key: token
+    {{if $KEEP_ONLY_DRA}}
+    # DRA scale tests only query the kubelet DRA-plugin metrics (dra_*). Keeping just those
+    # drops the per-node go_*/process_*/rest_client_*/workqueue_*/apiserver_* series
+    # (x node count), which bounds Prometheus memory at 5k+ nodes. DRA-specific: enabled
+    # only via CL2_PROMETHEUS_KUBELET_KEEP_ONLY_DRA so other kubelet-scraping uses are unaffected.
+    metricRelabelings:
+      - sourceLabels: [__name__]
+        regex: 'dra_.*|up'
+        action: keep
+    {{end}}
   - port: https-metrics
     scheme: https
     path: /metrics/cadvisor

--- a/clusterloader2/testing/dra/config.yaml
+++ b/clusterloader2/testing/dra/config.yaml
@@ -100,6 +100,23 @@ steps:
             query: histogram_quantile(0.99, sum(rate(dra_grpc_operations_duration_seconds_bucket{method_name=~".*NodePrepareResources"}[%v])) by (le))
           - name: p99_dra_grpc_node_unprepare_resources
             query: histogram_quantile(0.99, sum(rate(dra_grpc_operations_duration_seconds_bucket{method_name=~".*NodeUnprepareResources"}[%v])) by (le))
+    # Calibration: Prometheus memory + cardinality over the run. Uses prometheus self-scrape
+    # and TSDB meta (not cAdvisor), so it survives the cardinality relabeling. Lets us size
+    # CL2_PROMETHEUS_KUBELET_MEMORY_SCALE_FACTOR and see which scrape job drives cardinality.
+    - Identifier: PrometheusMemory
+      Method: GenericPrometheusQuery
+      Params:
+        action: start
+        metricName: prometheus_memory
+        metricVersion: v1
+        unit: bytes
+        queries:
+          - name: prometheus_rss_peak_bytes
+            query: max_over_time(process_resident_memory_bytes{job="prometheus-k8s"}[%v])
+          - name: prometheus_head_series_peak
+            query: max_over_time(prometheus_tsdb_head_series{job="prometheus-k8s"}[%v])
+          - name: ingested_samples_by_job
+            query: sum by (job) (max_over_time(scrape_samples_post_metric_relabeling[%v]))
 {{if not $ENABLE_EXTENDED_RESOURCES}}
 - name: Create ResourceClaimTemplates in namespaces
   phases:
@@ -223,6 +240,10 @@ steps:
       Params:
         action: gather
     - Identifier: ChurnDRAMetrics
+      Method: GenericPrometheusQuery
+      Params:
+        action: gather
+    - Identifier: PrometheusMemory
       Method: GenericPrometheusQuery
       Params:
         action: gather


### PR DESCRIPTION
At 5000 nodes the DRA jobs can OOM Prometheus: the kubelet `/metrics` endpoint ingests per-node `go_*/process_*/rest_client_*/workqueue_*/apiserver_*` series across every node, none of which the DRA measurements query (they use `dra_*` and `scheduler_*`).

- Add an **opt-in** `CL2_PROMETHEUS_KUBELET_KEEP_ONLY_DRA` that keeps only `dra_*|up` on the kubelet `/metrics` endpoint (default off, so other kubelet-scraping uses are unaffected).
- cAdvisor scraping is **unchanged** — the existing `test-*` drop already removes workload-pod series, and control-plane container metrics are kept.
- Add a `PrometheusMemory` calibration measurement (peak RSS, peak TSDB head series, ingested samples by job) to size the memory factor from data.

#### What type of PR is this?
/kind failing-test

#### What this PR does / why we need it:
Bounds DRA kubelet-scrape cardinality (opt-in) and records Prometheus memory/cardinality so the memory factor can be set from data.

#### Which issue(s) this PR fixes:
NONE
