### PR TITLE
perfdash: build for linux/amd64 by default (override with PLATFORM)

### DIFF
--- a/perfdash/Makefile
+++ b/perfdash/Makefile
@@ -6,6 +6,9 @@ TAG?=2.59
 WWW_VERSION=$(shell cat www/VERSION)
 
 REPO?=gcr.io/k8s-staging-perf-tests
+# Image platform. Defaults to linux/amd64 (perfdash runs on amd64 nodes); override
+# to build another arch, e.g. make push PLATFORM=linux/arm64
+PLATFORM?=linux/amd64
 
 .PHONY: test
 test: WWW_VERSION = $(shell cat www/VERSION)
@@ -33,11 +36,11 @@ run: perfdash
 # Use buildkit to have "COPY --chmod=" support (availability of it in "regular" docker build depends on docker version).
 .PHONY: container
 container:
-	DOCKER_BUILDKIT=1 docker build --pull -t $(REPO)/perfdash:$(TAG) .
+	DOCKER_BUILDKIT=1 docker build --platform=$(PLATFORM) --pull -t $(REPO)/perfdash:$(TAG) .
 
 .PHONY: push
 push: container
-	gcloud docker -s $(REPO) -- push $(REPO)/perfdash:$(TAG)
+	docker push $(REPO)/perfdash:$(TAG)
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The perfdash image build was not pinned to an architecture: `make container` built for the host platform and `make push` used the deprecated `gcloud docker ... push`. Building from a non-amd64 host (for example an arm64 laptop) therefore produced an arm64 image, which cannot run on the amd64 nodes the perfdash deployment lands on.

This pins the image platform explicitly and defaults it to `linux/amd64` via a `PLATFORM` variable, applied to **both** the `container` (build) and `push` targets, and replaces `gcloud docker push` with `docker push`. Another architecture can be built on demand:

    make push PLATFORM=linux/arm64

#### Special notes for your reviewer: