### PR TITLE
perfdash: preserve pod name prefixes during normalization

### DIFF
--- a/perfdash/pod_names.go
+++ b/perfdash/pod_names.go
@@ -31,7 +31,8 @@ func RemoveDisambiguationInfixes(podAndContainer string) string {
 	pieces := strings.Split(pod, "-")
 	var last string
 	for i, piece := range pieces {
-		if looksLikeHash(piece) || versionRegexp.MatchString(piece) {
+		// Only strip version/hash segments after we've already seen a stable pod-name prefix.
+		if i > 0 && (looksLikeHash(piece) || versionRegexp.MatchString(piece)) {
 			break
 		}
 		last = strings.Join(pieces[:i+1], "-")

--- a/perfdash/pod_names_test.go
+++ b/perfdash/pod_names_test.go
@@ -36,6 +36,8 @@ func TestRemoveDisambiguationInfixes(t *testing.T) {
 		{"l7-default-backend-6d477bf555-jfmgt/default-http-backend", "l7-default-backend/default-http-backend"},
 		{"l7-lb-controller-v0.9.7-e2e-scalability-master/l7-lb-controller", "l7-lb-controller/l7-lb-controller"},
 		{"kube-proxy-e2e-scalability-minion-group-2mh1/kube-proxy", "kube-proxy-e2e-scalability-minion-group/kube-proxy"},
+		{"v2-controller-6d4f5d4b7f-zx9pl/controller", "v2-controller/controller"},
+		{"cdbf-agent-6d4f5d4b7f-zx9pl/agent", "cdbf-agent/agent"},
 	}
 	for _, testCase := range testCases {
 		v := RemoveDisambiguationInfixes(testCase.Input)


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
perfdash can strip the whole pod prefix when the first segment looks like a version or hash.

before:
`v2-controller-6d4f5d4b7f-zx9pl/controller` -> `/controller`
`cdbf-agent-6d4f5d4b7f-zx9pl/agent` -> `/agent`

that's a real edge case, not just theory. Kubernetes object names can start with alphanumeric chars, and controllers append generated suffixes to valid prefixes, so names like `v2-controller-...` are legal and reachable.

this change only starts stripping version or hash looking pieces after we already kept one stable prefix segment. existing cases like `kube-dns-74dbf45884-7gkmp/dnsmasq` still normalize the same.

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
repro:
`go test -run TestRemoveDisambiguationInfixes -v`

new test cases cover the broken outputs above. full `go test ./...` also passes in `perfdash`.
