### PR TITLE
Point request-benchmark image at the staging registry

### DIFF
--- a/clusterloader2/testing/list/deployment.yaml
+++ b/clusterloader2/testing/list/deployment.yaml
@@ -1,5 +1,5 @@
 # The source of the image is at https://github.com/kubernetes/perf-tests/tree/master/util-images/request-benchmark
-{{$image := DefaultParam .CL2_BENCHMARK_IMAGE "gcr.io/k8s-testimages/perf-tests-util/request-benchmark:latest"}}
+{{$image := DefaultParam .CL2_BENCHMARK_IMAGE "gcr.io/k8s-staging-perf-tests/perf-tests-util/request-benchmark:v0.0.10"}}
 {{$cpu := DefaultParam .cpu "1250m"}}
 {{$memory := DefaultParam .memory "32Mi"}}
 

--- a/clusterloader2/testing/request-benchmark/deployment.yaml
+++ b/clusterloader2/testing/request-benchmark/deployment.yaml
@@ -1,4 +1,4 @@
-{{$image := DefaultParam .CL2_BENCHMARK_IMAGE "gcr.io/k8s-testimages/perf-tests-util/request-benchmark:latest"}}
+{{$image := DefaultParam .CL2_BENCHMARK_IMAGE "gcr.io/k8s-staging-perf-tests/perf-tests-util/request-benchmark:v0.0.10"}}
 {{$cpu := DefaultParam .CL2_BENCHMARK_POD_CPU (AddInt .Inflight 1)}}
 {{$memory := DefaultParam .CL2_BENCHMARK_POD_MEMORY "100Mi"}}
 


### PR DESCRIPTION
/kind failing-test

#### What this PR does / why we need it:

Repoint the request-benchmark image from the legacy `k8s-testimages` registry to `gcr.io/k8s-staging-perf-tests/perf-tests-util/request-benchmark:v0.0.10` (where #4072 shipped), matching other util-images already on the new registry ([watch-list](https://github.com/kubernetes/perf-tests/blob/8c7151d276796ab25e209f7a8bddc076e024c74c/clusterloader2/testing/watch-list/job.yaml#L15)).

#### Does this PR introduce a user-facing change?
```
NONE
```
