### PR TITLE
CL2: API latency override in in access-tokens scenario

### DIFF
--- a/clusterloader2/testing/access-tokens/config.yaml
+++ b/clusterloader2/testing/access-tokens/config.yaml
@@ -43,6 +43,8 @@
 # Configs
 {{$ALLOWED_SLOW_API_CALLS := DefaultParam .CL2_ALLOWED_SLOW_API_CALLS 0}}
 
+{{$SINGLE_RESOURCE_API_LATENCY_THRESHOLD := DefaultParam .CL2_SINGLE_RESOURCE_API_LATENCY_THRESHOLD "1s"}}
+
 name: access-tokens
 namespace:
   number: {{$namespaces}}
@@ -172,6 +174,7 @@ steps:
       Params:
         action: gather
         enableViolations: true
+        singleResourceThreshold: {{$SINGLE_RESOURCE_API_LATENCY_THRESHOLD}}
     - Identifier: TestMetrics
       Method: TestMetrics
       Params:


### PR DESCRIPTION
This PR follows https://github.com/kubernetes/perf-tests/pull/4069 and adds newly added param to override default 1s API latency to access-tokens scenario