### PR TITLE
prometheus: wait for first consumer

### DIFF
--- a/clusterloader2/pkg/prometheus/manifests/0ssd-storage-class.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/0ssd-storage-class.yaml
@@ -11,12 +11,12 @@ parameters:
   kind: Managed
   storageaccounttype: {{$PROMETHEUS_STORAGE_CLASS_VOLUME_TYPE}}
   cachingmode: ReadOnly
-volumeBindingMode: WaitForFirstConsumer
 allowVolumeExpansion: true
 {{else}}
 parameters:
   type: {{$PROMETHEUS_STORAGE_CLASS_VOLUME_TYPE}}
 {{end}}
+volumeBindingMode: WaitForFirstConsumer
 {{if .RetainPD}}
 reclaimPolicy: Retain
 {{end}}


### PR DESCRIPTION
Prevent disk mismatches when running nodes only in a subset of test's zones.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
Bug fix.

#### What this PR does / why we need it:

Makes disks be provisioned only when consumers appear. This prevents a mismatch between disks in zone X and nodes in zone Y when it so happens (not very common most likely, but got a case like that).

This is already done for Azure disks. Would like for all others if I'm not missing anything.