### PR TITLE
prometheus-operator: make memory request scale with number of nodes

### DIFF
--- a/clusterloader2/pkg/prometheus/manifests/0prometheus-operator-deployment.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/0prometheus-operator-deployment.yaml
@@ -1,6 +1,7 @@
 {{$PROMETHEUS_SCRAPE_KUBELETS := DefaultParam .PROMETHEUS_SCRAPE_KUBELETS false}}
 {{$PROMETHEUS_NODE_SELECTOR := DefaultParam .CL2_PROMETHEUS_NODE_SELECTOR ""}}
 {{$PROMETHEUS_TOLERATE_MASTER := DefaultParam .CL2_PROMETHEUS_TOLERATE_MASTER false}}
+{{$PROMETHEUS_OPERATOR_MEM_REQUEST := DefaultParam .CL2_PROMETHEUS_OPERATOR_MEM_REQUEST (printf "%dMi" (IfThenElse (lt .Nodes 500) 200 400))}}
 
 apiVersion: apps/v1
 kind: Deployment
@@ -46,10 +47,10 @@ spec:
         resources:
           limits:
             cpu: 200m
-            memory: {{AddInt 100 (DivideInt .Nodes 2)}}Mi
+            memory: {{$PROMETHEUS_OPERATOR_MEM_REQUEST}}
           requests:
             cpu: 200m
-            memory: {{AddInt 100 (DivideInt .Nodes 2)}}Mi
+            memory: {{$PROMETHEUS_OPERATOR_MEM_REQUEST}}
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/clusterloader2/pkg/prometheus/manifests/0prometheus-operator-deployment.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/0prometheus-operator-deployment.yaml
@@ -46,10 +46,10 @@ spec:
         resources:
           limits:
             cpu: 200m
-            memory: {{IfThenElse (lt .Nodes 500) 200 400}}Mi
+            memory: {{AddInt 100 (DivideInt .Nodes 2)}}Mi
           requests:
             cpu: 200m
-            memory: {{IfThenElse (lt .Nodes 500) 200 400}}Mi
+            memory: {{AddInt 100 (DivideInt .Nodes 2)}}Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

For a 10k cluster, this component was OOMing. It's weird that it requests a static amount of memory that's not scaled with number of nodes above 500 or 1k.

`100 + x/2` is a rough estimate that more or less fits with what was stated before.