### PR TITLE
Add CL2_INFORMER_ENABLE_WATCHLIST toggle to load test informer module

### DIFF
--- a/clusterloader2/testing/load/modules/informer/config.yaml
+++ b/clusterloader2/testing/load/modules/informer/config.yaml
@@ -2,6 +2,7 @@
 # Valid actions: "create", "delete"
 {{$action := .action}}
 {{$RunOnControlPlane := DefaultParam .CL2_INFORMER_RUN_ON_CONTROL_PLANE false}}
+{{$EnableWatchList := DefaultParam .CL2_INFORMER_ENABLE_WATCHLIST true}}
 
 steps:
 - name: {{$action}} informer role
@@ -26,6 +27,7 @@ steps:
           objectTemplatePath: /modules/informer/deployment.yaml
           templateFillMap:
             EnableWatchListFeature: "false"
+{{if $EnableWatchList}}
     - namespaceList: ["informer-0"]
       replicasPerNamespace: 1
       tuningSet: default
@@ -34,6 +36,7 @@ steps:
           objectTemplatePath: /modules/informer/deployment.yaml
           templateFillMap:
             EnableWatchListFeature: "true"
+{{end}}
 {{if $RunOnControlPlane}}
     - namespaceList: ["informer-0"]
       replicasPerNamespace: 1
@@ -45,6 +48,7 @@ steps:
             EnableWatchListFeature: "false"
             RunOnControlPlane: "true"
             DisableCompression: "true"
+{{if $EnableWatchList}}
     - namespaceList: ["informer-0"]
       replicasPerNamespace: 1
       tuningSet: default
@@ -55,6 +59,7 @@ steps:
             EnableWatchListFeature: "true"
             RunOnControlPlane: "true"
             DisableCompression: "true"
+{{end}}
 {{end}}
 {{if eq $action "create"}}
 - name: Starting measurement for waiting for informer pods to be running


### PR DESCRIPTION
Add CL2_INFORMER_ENABLE_WATCHLIST toggle to load test informer module. Allows us to disable watchlist testing, I'd like to stabilize our 5k jobs. 