### PR TITLE
Add optional Pods LIST benchmark scenario

### DIFF
--- a/clusterloader2/testing/list/README.md
+++ b/clusterloader2/testing/list/README.md
@@ -4,11 +4,14 @@ List load test perform the following steps:
 - Create configmaps.
   - The namespaces used here are managed by CL2.
   - The size and number of configmaps can be specified using `CL2_LIST_CONFIG_MAP_BYTES` and `CL2_LIST_CONFIG_MAP_NUMBER`.
+- Optionally create pods.
+  - The number of pods can be specified using `CL2_LIST_POD_NUMBER`.
+  - The pod list benchmark is skipped by default unless `CL2_LIST_POD_NUMBER` is greater than 0.
 - Create RBAC rules to allow lister pods to access these configmaps
-- Create lister pods using deployment in a separate namespace to list configmaps and secrets.
+- Create lister pods using deployment in a separate namespace to list configured resources.
   - The namespace is created using `namespace.yaml` as a template, but its lifecycle is managed by CL2.
   - The number of replicas for the lister pods can be specified using `CL2_LIST_BENCHMARK_PODS`.
-- Measurement uses [`APIResponsivenessPrometheusSimple`](https://github.com/kubernetes/perf-tests/blob/master/clusterloader2/README.md) to meansure API latency for list configmaps and secrets calls.
+- Measurement uses [`APIResponsivenessPrometheusSimple`](https://github.com/kubernetes/perf-tests/blob/master/clusterloader2/README.md) to measure API latency for list calls.
 
 The lister pods leverage https://github.com/kubernetes/perf-tests/tree/master/util-images/request-benchmark to create in-cluster list load.
 

--- a/clusterloader2/testing/list/README.md
+++ b/clusterloader2/testing/list/README.md
@@ -7,7 +7,7 @@ List load test perform the following steps:
 - Optionally create pods.
   - The number of pods can be specified using `CL2_LIST_POD_NUMBER`.
   - The pod list benchmark is skipped by default unless `CL2_LIST_POD_NUMBER` is greater than 0.
-  - The exemplar pod shape can be enabled using `CL2_REALISTIC_POD`.
+  - Pods use the exemplar pod shape from reconcile-objects to measure realistic per-pod list cost.
 - Create RBAC rules to allow lister pods to access these configmaps
 - Create lister pods using deployment in a separate namespace to list configured resources.
   - The namespace is created using `namespace.yaml` as a template, but its lifecycle is managed by CL2.

--- a/clusterloader2/testing/list/README.md
+++ b/clusterloader2/testing/list/README.md
@@ -7,6 +7,7 @@ List load test perform the following steps:
 - Optionally create pods.
   - The number of pods can be specified using `CL2_LIST_POD_NUMBER`.
   - The pod list benchmark is skipped by default unless `CL2_LIST_POD_NUMBER` is greater than 0.
+  - The exemplar pod shape can be enabled using `CL2_REALISTIC_POD`.
 - Create RBAC rules to allow lister pods to access these configmaps
 - Create lister pods using deployment in a separate namespace to list configured resources.
   - The namespace is created using `namespace.yaml` as a template, but its lifecycle is managed by CL2.

--- a/clusterloader2/testing/list/config.yaml
+++ b/clusterloader2/testing/list/config.yaml
@@ -58,40 +58,6 @@ steps:
         bytes: {{$configMapBytes}}
         group: {{$configMapGroup}}
 
-{{if $podNumber}}
-- name: Create pods
-  phases:
-  - namespaceRange:
-      min: 1
-      max: 1
-    tuningSet: Sequence
-    replicasPerNamespace: {{$podNumber}}
-    objectBundle:
-    - basename: {{$podGroup}}
-      objectTemplatePath: pod.yaml
-      templateFillMap:
-        group: {{$podGroup}}
-
-- name: Waiting for pods to be running
-  measurements:
-  - Identifier: WaitForListBenchmarkPods
-    Method: WaitForRunningPods
-    Params:
-      action: gather
-      timeout: 10m
-      desiredPodCount: {{$podNumber}}
-      labelSelector: group = {{$podGroup}}
-
-- module:
-    path: modules/list-benchmark.yaml
-    params:
-      namePrefix: "list-pods-"
-      replicas: {{$listReplicas}}
-      uri: /api/v1/pods?resourceVersion=0
-      namespaced: false
-      contentType: {{$contentType}}
-{{end}}
-
 - module:
     path: modules/list-benchmark.yaml
     params:
@@ -104,7 +70,7 @@ steps:
     path: /modules/measurements.yaml
     params:
       action: start
-- name: Wait 5 minutes
+- name: Wait 5 minutes for configmap list benchmark
   measurements:
     - Identifier: Wait
       Method: Sleep
@@ -119,7 +85,43 @@ steps:
     params:
       namePrefix: "list-configmaps-"
       replicas: 0
+
 {{if $podNumber}}
+- name: Create pods
+  phases:
+  - namespaceRange:
+      min: 1
+      max: 1
+    tuningSet: Sequence
+    replicasPerNamespace: {{$podNumber}}
+    objectBundle:
+    - basename: {{$podGroup}}
+      objectTemplatePath: pod.yaml
+      templateFillMap:
+        group: {{$podGroup}}
+
+- module:
+    path: modules/list-benchmark.yaml
+    params:
+      namePrefix: "list-pods-"
+      replicas: {{$listReplicas}}
+      uri: /api/v1/pods?resourceVersion=0
+      namespaced: false
+      contentType: {{$contentType}}
+- module:
+    path: /modules/measurements.yaml
+    params:
+      action: start
+- name: Wait 5 minutes for pod list benchmark
+  measurements:
+    - Identifier: Wait
+      Method: Sleep
+      Params:
+        duration: 5m
+- module:
+    path: /modules/measurements.yaml
+    params:
+      action: gather
 - module:
     path: modules/list-benchmark.yaml
     params:

--- a/clusterloader2/testing/list/config.yaml
+++ b/clusterloader2/testing/list/config.yaml
@@ -87,6 +87,20 @@ steps:
       replicas: 0
 
 {{if $podNumber}}
+- name: Delete configmaps before pod list benchmark
+  phases:
+  - namespaceRange:
+      min: 1
+      max: 1
+    tuningSet: Sequence
+    replicasPerNamespace: 0
+    objectBundle:
+    - basename: {{$configMapGroup}}
+      objectTemplatePath: configmap.yaml
+      templateFillMap:
+        bytes: {{$configMapBytes}}
+        group: {{$configMapGroup}}
+
 - name: Create pods
   phases:
   - namespaceRange:

--- a/clusterloader2/testing/list/config.yaml
+++ b/clusterloader2/testing/list/config.yaml
@@ -2,6 +2,8 @@
 {{$configMapBytes := DefaultParam .CL2_LIST_CONFIG_MAP_BYTES 100000}}
 {{$configMapNumber := DefaultParam .CL2_LIST_CONFIG_MAP_NUMBER 10000}}
 {{$configMapGroup := DefaultParam .CL2_LIST_CONFIG_MAP_GROUP "list-configmap"}}
+{{$podNumber := DefaultParam .CL2_LIST_POD_NUMBER 0}}
+{{$podGroup := DefaultParam .CL2_LIST_POD_GROUP "list-pod"}}
 
 {{$listReplicas := DefaultParam .CL2_LIST_BENCHMARK_PODS 1}}
 {{$contentType := DefaultParam .CL2_LIST_BENCHMARK_CONTENT_TYPE "json"}}
@@ -56,6 +58,40 @@ steps:
         bytes: {{$configMapBytes}}
         group: {{$configMapGroup}}
 
+{{if $podNumber}}
+- name: Create pods
+  phases:
+  - namespaceRange:
+      min: 1
+      max: 1
+    tuningSet: Sequence
+    replicasPerNamespace: {{$podNumber}}
+    objectBundle:
+    - basename: {{$podGroup}}
+      objectTemplatePath: pod.yaml
+      templateFillMap:
+        group: {{$podGroup}}
+
+- name: Waiting for pods to be running
+  measurements:
+  - Identifier: WaitForListBenchmarkPods
+    Method: WaitForRunningPods
+    Params:
+      action: gather
+      timeout: 10m
+      desiredPodCount: {{$podNumber}}
+      labelSelector: group = {{$podGroup}}
+
+- module:
+    path: modules/list-benchmark.yaml
+    params:
+      namePrefix: "list-pods-"
+      replicas: {{$listReplicas}}
+      uri: /api/v1/pods?resourceVersion=0
+      namespaced: false
+      contentType: {{$contentType}}
+{{end}}
+
 - module:
     path: modules/list-benchmark.yaml
     params:
@@ -83,3 +119,10 @@ steps:
     params:
       namePrefix: "list-configmaps-"
       replicas: 0
+{{if $podNumber}}
+- module:
+    path: modules/list-benchmark.yaml
+    params:
+      namePrefix: "list-pods-"
+      replicas: 0
+{{end}}

--- a/clusterloader2/testing/list/pod.yaml
+++ b/clusterloader2/testing/list/pod.yaml
@@ -1,0 +1,12 @@
+{{$group := DefaultParam .group .Name}}
+
+apiVersion: v1
+kind: Pod
+metadata:
+  generateName: list-pod-
+  labels:
+    group: {{$group}}
+spec:
+  containers:
+  - image: registry.k8s.io/pause:3.9
+    name: pause

--- a/clusterloader2/testing/list/pod.yaml
+++ b/clusterloader2/testing/list/pod.yaml
@@ -1,5 +1,4 @@
 {{$group := DefaultParam .group .Name}}
-{{$RealisticPod := DefaultParam .CL2_REALISTIC_POD false}}
 
 apiVersion: v1
 kind: Pod
@@ -7,7 +6,6 @@ metadata:
   generateName: list-pod-
   labels:
     group: {{$group}}
-{{if $RealisticPod}}
     app.kubernetes.io/name: "payment-service"
     app.kubernetes.io/instance: "payment-service-primary"
     app.kubernetes.io/version: "v2.1.4"
@@ -26,9 +24,7 @@ metadata:
     fluentbit.io/parser: "json"
     argocd.argoproj.io/hook: "PreSync"
     argocd.argoproj.io/hook-delete-policy: "HookSucceeded"
-{{end}}
 spec:
-{{if $RealisticPod}}
   initContainers:
   - name: init-0
     image: registry.k8s.io/e2e-test-images/agnhost:2.53
@@ -133,8 +129,3 @@ spec:
     secret:
       secretName: {{.Name}}
       optional: true
-{{else}}
-  containers:
-  - image: registry.k8s.io/pause:3.9
-    name: pause
-{{end}}

--- a/clusterloader2/testing/list/pod.yaml
+++ b/clusterloader2/testing/list/pod.yaml
@@ -1,4 +1,5 @@
 {{$group := DefaultParam .group .Name}}
+{{$RealisticPod := DefaultParam .CL2_REALISTIC_POD false}}
 
 apiVersion: v1
 kind: Pod
@@ -6,7 +7,134 @@ metadata:
   generateName: list-pod-
   labels:
     group: {{$group}}
+{{if $RealisticPod}}
+    app.kubernetes.io/name: "payment-service"
+    app.kubernetes.io/instance: "payment-service-primary"
+    app.kubernetes.io/version: "v2.1.4"
+    app.kubernetes.io/component: "backend"
+    app.kubernetes.io/part-of: "ecommerce-platform"
+    env: "production"
+    track: "canary"
+  annotations:
+    prometheus.io/scrape: "false"
+    prometheus.io/port: "8080"
+    prometheus.io/path: "/metrics"
+    sidecar.istio.io/inject: "false"
+    cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
+    vault.hashicorp.com/agent-inject: "false"
+    vault.hashicorp.com/role: "my-app-db-role"
+    fluentbit.io/parser: "json"
+    argocd.argoproj.io/hook: "PreSync"
+    argocd.argoproj.io/hook-delete-policy: "HookSucceeded"
+{{end}}
 spec:
+{{if $RealisticPod}}
+  initContainers:
+  - name: init-0
+    image: registry.k8s.io/e2e-test-images/agnhost:2.53
+    command: ["/bin/sh", "-c", "sleep 1"]
+  - name: init-1
+    image: registry.k8s.io/e2e-test-images/agnhost:2.53
+    command: ["/bin/sh", "-c", "sleep 1"]
+  containers:
+  - name: main
+    image: registry.k8s.io/pause:3.9
+    env:
+    - name: POD_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.name
+    - name: POD_NAMESPACE
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
+    - name: NODE_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: spec.nodeName
+    - name: POD_IP
+      valueFrom:
+        fieldRef:
+          fieldPath: status.podIP
+    - name: GOMAXPROCS
+      valueFrom:
+        resourceFieldRef:
+          containerName: main
+          resource: limits.cpu
+    - name: GOMEMLIMIT
+      valueFrom:
+        resourceFieldRef:
+          containerName: main
+          resource: limits.memory
+    - name: JAVA_TOOL_OPTIONS
+      value: "-XX:MaxRAMPercentage=75.0"
+    - name: REDIS_URL
+      value: "redis://main:6379/0"
+    - name: PYTHONUNBUFFERED
+      value: "1"
+    - name: NODE_ENV
+      value: "prod"
+    resources:
+      requests:
+        cpu: 5m
+        memory: 20M
+    volumeMounts:
+    - mountPath: /var/configmap
+      name: configmap
+    - mountPath: /var/secret
+      name: secret
+  - name: sidecar
+    image: registry.k8s.io/pause:3.9
+    env:
+    - name: POD_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.name
+    - name: POD_NAMESPACE
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
+    - name: NODE_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: spec.nodeName
+    - name: POD_IP
+      valueFrom:
+        fieldRef:
+          fieldPath: status.podIP
+    - name: GOMAXPROCS
+      valueFrom:
+        resourceFieldRef:
+          containerName: sidecar
+          resource: limits.cpu
+    - name: GOMEMLIMIT
+      valueFrom:
+        resourceFieldRef:
+          containerName: sidecar
+          resource: limits.memory
+    - name: JAVA_TOOL_OPTIONS
+      value: "-XX:MaxRAMPercentage=75.0"
+    - name: REDIS_URL
+      value: "redis://main:6379/0"
+    - name: PYTHONUNBUFFERED
+      value: "1"
+    - name: NODE_ENV
+      value: "prod"
+    resources:
+      requests:
+        cpu: 5m
+        memory: 20M
+  volumes:
+  - name: configmap
+    configMap:
+      name: {{.Name}}
+      optional: true
+  - name: secret
+    secret:
+      secretName: {{.Name}}
+      optional: true
+{{else}}
   containers:
   - image: registry.k8s.io/pause:3.9
     name: pause
+{{end}}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This adds optional LIST benchmark coverage for Pods, following the existing ConfigMaps benchmark structure.

The Pods benchmark is gated behind `CL2_LIST_POD_NUMBER`, so existing LIST benchmark jobs keep their current behavior by default.

This avoids YAML/Table/json-pretty content-type benchmark work because those jobs are being removed in kubernetes/test-infra#37268.

#### Which issue(s) this PR fixes:

Addresses part of kubernetes/kubernetes#130169

#### Special notes for your reviewer:

I could not run the Go test suite locally because Go is not installed on my machine. I did run `git diff --check`.