### PR TITLE
clusterloader2: stop loading Prometheus test rules from GOPATH

### DIFF
--- a/clusterloader2/pkg/measurement/common/executors/promql_executor.go
+++ b/clusterloader2/pkg/measurement/common/executors/promql_executor.go
@@ -26,10 +26,12 @@ import (
 	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/rules"
 	"gopkg.in/yaml.v2"
+
+	cl2prometheus "k8s.io/perf-tests/clusterloader2/pkg/prometheus"
 )
 
 const (
-	pathToPrometheusRules = "$GOPATH/src/k8s.io/perf-tests/clusterloader2/pkg/prometheus/manifests/prometheus-rules.yaml"
+	prometheusRulesManifestPath = "prometheus-rules.yaml"
 )
 
 func toModelSample(s promql.Sample) *model.Sample {
@@ -113,10 +115,15 @@ func NewPromqlExecutor(timeSeriesFile string) (*PromqlExecutor, error) {
 	}
 	m := rules.NewManager(opts)
 
-	rulesFile, err := createRulesFile(os.ExpandEnv(pathToPrometheusRules))
+	rulesManifest, err := cl2prometheus.ReadManifest(prometheusRulesManifestPath)
+	if err != nil {
+		return nil, fmt.Errorf("could not read embedded rules manifest: %v", err)
+	}
+	rulesFile, err := createRulesFile(rulesManifest)
 	if err != nil {
 		return nil, fmt.Errorf("could not create rules file: %v", err)
 	}
+	defer rulesFile.Close()
 	defer os.Remove(rulesFile.Name())
 	groupsMap, ers := m.LoadGroups(interval, nil, rulesFile.Name())
 	if ers != nil {

--- a/clusterloader2/pkg/measurement/common/executors/promql_executor_test.go
+++ b/clusterloader2/pkg/measurement/common/executors/promql_executor_test.go
@@ -1,0 +1,40 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package executors
+
+import (
+	"os"
+	"testing"
+)
+
+func TestNewPromqlExecutorIgnoresGOPATHForRulesManifest(t *testing.T) {
+	originalGoPath := os.Getenv("GOPATH")
+	t.Cleanup(func() {
+		if err := os.Setenv("GOPATH", originalGoPath); err != nil {
+			t.Fatalf("failed to restore GOPATH: %v", err)
+		}
+	})
+	if err := os.Setenv("GOPATH", "/tmp/definitely-not-the-perf-tests-repo"); err != nil {
+		t.Fatalf("failed to override GOPATH: %v", err)
+	}
+
+	executor, err := NewPromqlExecutor("../testdata/container_restarts/no_restarts.yaml")
+	if err != nil {
+		t.Fatalf("expected embedded rules manifest lookup to succeed: %v", err)
+	}
+	executor.Close()
+}

--- a/clusterloader2/pkg/measurement/common/executors/utils.go
+++ b/clusterloader2/pkg/measurement/common/executors/utils.go
@@ -43,14 +43,9 @@ type prometheusRuleManifest struct {
 	} `yaml:"spec"`
 }
 
-func createRulesFile(rulesManifestFile string) (*os.File, error) {
-	r, err := os.ReadFile(rulesManifestFile)
-	if err != nil {
-		return nil, err
-	}
-
+func createRulesFile(rulesManifestContent []byte) (*os.File, error) {
 	rulesManifest := new(prometheusRuleManifest)
-	err = yaml.Unmarshal(r, rulesManifest)
+	err := yaml.Unmarshal(rulesManifestContent, rulesManifest)
 	if err != nil {
 		return nil, err
 	}

--- a/clusterloader2/pkg/prometheus/prometheus.go
+++ b/clusterloader2/pkg/prometheus/prometheus.go
@@ -79,6 +79,11 @@ func init() {
 	}
 }
 
+// ReadManifest returns a file from the embedded Prometheus manifests bundle.
+func ReadManifest(path string) ([]byte, error) {
+	return fs.ReadFile(manifestsFS, path)
+}
+
 // InitFlags initializes prometheus flags.
 func InitFlags(p *config.PrometheusConfig) {
 	flags.BoolEnvVar(&p.EnableServer, "enable-prometheus-server", "ENABLE_PROMETHEUS_SERVER", false, "Whether to set-up the prometheus server in the cluster.")


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/kind failing-test

#### What this PR does / why we need it:
`NewPromqlExecutor` still reads `prometheus-rules.yaml` from `$GOPATH/src/...`.
That makes `clusterloader2` unit tests fail in a normal Go modules checkout, which is pretty annoying.

This switches that path to the embedded Prometheus manifests and adds a regression test, so checkout location stops mattering.

#### Which issue(s) this PR fixes:
Fixes #
Related to #2058
Related to #2059
Related to #2200

#### Special notes for your reviewer:
Repro on current `master` from a non-GOPATH checkout:
`cd clusterloader2 && go test ./pkg/measurement/common ./pkg/measurement/common/slos`

Or force it a bit harder:
`cd clusterloader2 && GOPATH=/tmp/nope go test ./pkg/measurement/common/executors ./pkg/measurement/common ./pkg/measurement/common/slos`
