### PR TITLE
Customise OOM tracker to not fail on OOMs

### DIFF
--- a/clusterloader2/docs/oom_detection.md
+++ b/clusterloader2/docs/oom_detection.md
@@ -53,6 +53,11 @@ set the value of `clusterOOMsIgnoredProcesses` TestMetrics parameter to a
 sequence of comma-separated processes names. The OOMs from the mentioned
 processes will still be included in the measurement summary.
 
+Alternatively, you can prevent any OOM from failing the test entirely while still
+tracking and recording them in the measurement summary. To do so, set the
+`clusterOOMsFailureEnabled` TestMetrics parameter to `false`. By default, this
+is `true` and the test will fail if any non-ignored OOM is detected.
+
 ## Further debugging steps
 
 `ClusterOOMsTracker` watches for events emitted by `node-problem-detector` when

--- a/clusterloader2/pkg/measurement/common/ooms_tracker.go
+++ b/clusterloader2/pkg/measurement/common/ooms_tracker.go
@@ -42,6 +42,7 @@ const (
 	clusterOOMsTrackerEnabledParamName   = "clusterOOMsTrackerEnabled"
 	clusterOOMsTrackerName               = "ClusterOOMsTracker"
 	clusterOOMsIgnoredProcessesParamName = "clusterOOMsIgnoredProcesses"
+	clusterOOMsFailureEnabledParamName   = "clusterOOMsFailureEnabled"
 	informerTimeout                      = time.Minute
 	oomEventReason                       = "OOMKilling"
 	initialListPageSize                  = 10000
@@ -107,7 +108,7 @@ func (m *clusterOOMsTrackerMeasurement) Execute(config *measurement.Config) ([]m
 	case "gather":
 		m.lock.Lock()
 		defer m.lock.Unlock()
-		return m.gather()
+		return m.gather(config)
 	default:
 		return nil, fmt.Errorf("unknown action %v", action)
 	}
@@ -229,7 +230,7 @@ func (m *clusterOOMsTrackerMeasurement) stop() {
 	}
 }
 
-func (m *clusterOOMsTrackerMeasurement) gather() ([]measurement.Summary, error) {
+func (m *clusterOOMsTrackerMeasurement) gather(config *measurement.Config) ([]measurement.Summary, error) {
 	klog.V(2).Infof("%s: gathering cluster OOMs tracking measurement", clusterOOMsTrackerName)
 	if !m.isRunning {
 		return nil, fmt.Errorf("measurement %s has not been started", clusterOOMsTrackerName)
@@ -261,7 +262,15 @@ func (m *clusterOOMsTrackerMeasurement) gather() ([]measurement.Summary, error) 
 
 	summary := measurement.CreateSummary(clusterOOMsTrackerName, "json", content)
 	if oomFailures := oomData["failures"]; len(oomFailures) > 0 {
-		err = fmt.Errorf("OOMs recorded: %+v", oomFailures)
+		failOnOOMs, failOnOOMsErr := util.GetBoolOrDefault(config.Params, clusterOOMsFailureEnabledParamName, true)
+		if failOnOOMsErr != nil {
+			return []measurement.Summary{summary}, fmt.Errorf("problem with getting %s param: %w", clusterOOMsFailureEnabledParamName, failOnOOMsErr)
+		}
+		if failOnOOMs {
+			err = fmt.Errorf("OOMs recorded: %+v", oomFailures)
+		} else {
+			klog.Warningf("OOMs recorded but %s is false: %+v", clusterOOMsFailureEnabledParamName, oomFailures)
+		}
 	}
 	return []measurement.Summary{summary}, err
 }

--- a/clusterloader2/pkg/measurement/common/ooms_tracker_test.go
+++ b/clusterloader2/pkg/measurement/common/ooms_tracker_test.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/perf-tests/clusterloader2/pkg/measurement"
+)
+
+func TestClusterOOMsTrackerMeasurementGather(t *testing.T) {
+	cases := []struct {
+		name          string
+		config        *measurement.Config
+		ooms          []oomEvent
+		expectedError bool
+	}{
+		{
+			name: "no ooms",
+			config: &measurement.Config{
+				Params: map[string]interface{}{},
+			},
+			ooms:          []oomEvent{},
+			expectedError: false,
+		},
+		{
+			name: "ooms with failure enabled (default)",
+			config: &measurement.Config{
+				Params: map[string]interface{}{},
+			},
+			ooms: []oomEvent{
+				{
+					Process: "test-process",
+					Time:    time.Now().Add(time.Minute), // future time so it's not "past"
+				},
+			},
+			expectedError: true,
+		},
+		{
+			name: "ooms with failure disabled",
+			config: &measurement.Config{
+				Params: map[string]interface{}{
+					"clusterOOMsFailureEnabled": false,
+				},
+			},
+			ooms: []oomEvent{
+				{
+					Process: "test-process",
+					Time:    time.Now().Add(time.Minute),
+				},
+			},
+			expectedError: false,
+		},
+		{
+			name: "ignored processes don't cause failure",
+			config: &measurement.Config{
+				Params: map[string]interface{}{},
+			},
+			ooms: []oomEvent{
+				{
+					Process: "ignored-process",
+					Time:    time.Now().Add(time.Minute),
+				},
+			},
+			expectedError: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := &clusterOOMsTrackerMeasurement{
+				isRunning: true,
+				startTime: time.Now(),
+				stopCh:    make(chan struct{}),
+				processIgnored: map[string]bool{
+					"ignored-process": true,
+				},
+				ooms: tc.ooms,
+			}
+
+			summaries, err := m.gather(tc.config)
+			if tc.expectedError {
+				assert.NotNil(t, err)
+			} else {
+				assert.Nil(t, err)
+			}
+			assert.Len(t, summaries, 1)
+			assert.Equal(t, clusterOOMsTrackerName, summaries[0].SummaryName())
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR introduces a new clusterOOMsFailureEnabled parameter (defaulting to true) to the ClusterOOMsTracker measurement. When set to false, the measurement will log a warning instead of returning an error when OOMs are detected.

Why we need it: Currently, any OOM event that is not explicitly ignored via the exact-match clusterOOMsIgnoredProcesses list causes the entire test to fail. This makes it difficult to globally track and record OOMs for observability without destabilizing CI jobs. This flag allows test owners to run the measurement in a "record-only" mode, ensuring all OOMs are still properly tracked and exported to the ClusterOOMsTracker.json artifact without explicitly failing the Prow job.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

