### PR TITLE
Shrink exemplar pod: drop sidecar env padding added in #3978

### DIFF
--- a/clusterloader2/testing/load/modules/reconcile-objects/daemonset.yaml
+++ b/clusterloader2/testing/load/modules/reconcile-objects/daemonset.yaml
@@ -103,41 +103,6 @@ spec:
             memory: 20M
       - name: sidecar
         image: registry.k8s.io/pause:3.9
-        env:
-        - name: POD_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.name
-        - name: POD_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        - name: NODE_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.nodeName
-        - name: POD_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              containerName: sidecar
-              resource: limits.cpu
-        - name: GOMEMLIMIT
-          valueFrom:
-            resourceFieldRef:
-              containerName: sidecar
-              resource: limits.memory
-        - name: JAVA_TOOL_OPTIONS
-          value: "-XX:MaxRAMPercentage=75.0"
-        - name: REDIS_URL
-          value: "redis://main:6379/0"
-        - name: PYTHONUNBUFFERED
-          value: "1"
-        - name: NODE_ENV
-          value: "prod"
         resources:
           requests:
             cpu: 5m

--- a/clusterloader2/testing/load/modules/reconcile-objects/deployment.yaml
+++ b/clusterloader2/testing/load/modules/reconcile-objects/deployment.yaml
@@ -127,41 +127,6 @@ spec:
           name: secret
       - name: sidecar
         image: registry.k8s.io/pause:3.9
-        env:
-        - name: POD_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.name
-        - name: POD_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        - name: NODE_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.nodeName
-        - name: POD_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              containerName: sidecar
-              resource: limits.cpu
-        - name: GOMEMLIMIT
-          valueFrom:
-            resourceFieldRef:
-              containerName: sidecar
-              resource: limits.memory
-        - name: JAVA_TOOL_OPTIONS
-          value: "-XX:MaxRAMPercentage=75.0"
-        - name: REDIS_URL
-          value: "redis://main:6379/0"
-        - name: PYTHONUNBUFFERED
-          value: "1"
-        - name: NODE_ENV
-          value: "prod"
         resources:
           requests:
             cpu: 5m

--- a/clusterloader2/testing/load/modules/reconcile-objects/job.yaml
+++ b/clusterloader2/testing/load/modules/reconcile-objects/job.yaml
@@ -99,41 +99,6 @@ spec:
             memory: 20M
       - name: sidecar
         image: registry.k8s.io/pause:3.9
-        env:
-        - name: POD_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.name
-        - name: POD_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        - name: NODE_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.nodeName
-        - name: POD_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              containerName: sidecar
-              resource: limits.cpu
-        - name: GOMEMLIMIT
-          valueFrom:
-            resourceFieldRef:
-              containerName: sidecar
-              resource: limits.memory
-        - name: JAVA_TOOL_OPTIONS
-          value: "-XX:MaxRAMPercentage=75.0"
-        - name: REDIS_URL
-          value: "redis://main:6379/0"
-        - name: PYTHONUNBUFFERED
-          value: "1"
-        - name: NODE_ENV
-          value: "prod"
         resources:
           requests:
             cpu: 5m

--- a/clusterloader2/testing/load/modules/reconcile-objects/statefulset.yaml
+++ b/clusterloader2/testing/load/modules/reconcile-objects/statefulset.yaml
@@ -108,41 +108,6 @@ spec:
         {{end}}
       - name: sidecar
         image: registry.k8s.io/pause:3.9
-        env:
-        - name: POD_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.name
-        - name: POD_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        - name: NODE_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.nodeName
-        - name: POD_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        - name: GOMAXPROCS
-          valueFrom:
-            resourceFieldRef:
-              containerName: sidecar
-              resource: limits.cpu
-        - name: GOMEMLIMIT
-          valueFrom:
-            resourceFieldRef:
-              containerName: sidecar
-              resource: limits.memory
-        - name: JAVA_TOOL_OPTIONS
-          value: "-XX:MaxRAMPercentage=75.0"
-        - name: REDIS_URL
-          value: "redis://main:6379/0"
-        - name: PYTHONUNBUFFERED
-          value: "1"
-        - name: NODE_ENV
-          value: "prod"
         resources:
           requests:
             cpu: 5m


### PR DESCRIPTION
/kind cleanup

Reduces the load test exemplar pod from 10KB back to 9KB, undoing the sidecar env padding added in #3978. The goal is to stabilize 5k scale tests.