### PR TITLE
Enable allNamespaces watch in WaitForGenericK8sObjects measurement

### DIFF
--- a/clusterloader2/pkg/measurement/common/wait_for_generic_k8s_object.go
+++ b/clusterloader2/pkg/measurement/common/wait_for_generic_k8s_object.go
@@ -141,6 +141,12 @@ func getNamespaces(namespacesPrefix string, params map[string]interface{}) (meas
 		}
 		return measurementutil.NamespacesRange{}, err
 	}
+	allNamespaces, err := util.GetBool(namespaceRange, "allNamespaces")
+	if err == nil && allNamespaces {
+		return measurementutil.NamespacesRange{
+			AllNamespaces: true,
+		}, nil
+	}
 	minParam, err := util.GetInt(namespaceRange, "min")
 	if err != nil {
 		return measurementutil.NamespacesRange{}, err
@@ -149,9 +155,16 @@ func getNamespaces(namespacesPrefix string, params map[string]interface{}) (meas
 	if err != nil {
 		return measurementutil.NamespacesRange{}, err
 	}
-
+	prefix, err := util.GetString(namespaceRange, "prefix")
+	if err != nil {
+		return measurementutil.NamespacesRange{
+			Prefix: namespacesPrefix,
+			Min:    minParam,
+			Max:    maxParam,
+		}, nil
+	}
 	return measurementutil.NamespacesRange{
-		Prefix: namespacesPrefix,
+		Prefix: prefix,
 		Min:    minParam,
 		Max:    maxParam,
 	}, nil

--- a/clusterloader2/pkg/measurement/common/wait_for_generic_k8s_object_test.go
+++ b/clusterloader2/pkg/measurement/common/wait_for_generic_k8s_object_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/clusterloader2/pkg/measurement/common/wait_for_generic_k8s_object_test.go
+++ b/clusterloader2/pkg/measurement/common/wait_for_generic_k8s_object_test.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	measurementutil "k8s.io/perf-tests/clusterloader2/pkg/measurement/util"
+)
+
+func TestGetNamespaces_AllNamespaces(t *testing.T) {
+	testCases := []struct {
+		name             string
+		namespacesPrefix string
+		params           map[string]interface{}
+		want             measurementutil.NamespacesRange
+		wantErr          bool
+	}{
+		{
+			name:             "allNamespaces true",
+			namespacesPrefix: "default-prefix",
+			params: map[string]interface{}{
+				"namespaceRange": map[string]interface{}{
+					"allNamespaces": true,
+				},
+			},
+			want: measurementutil.NamespacesRange{
+				AllNamespaces: true,
+			},
+		},
+		{
+			name:             "allNamespaces false with min and max",
+			namespacesPrefix: "default-prefix",
+			params: map[string]interface{}{
+				"namespaceRange": map[string]interface{}{
+					"allNamespaces": false,
+					"min":           1,
+					"max":           5,
+					"prefix":        "custom-ns",
+				},
+			},
+			want: measurementutil.NamespacesRange{
+				AllNamespaces: false,
+				Prefix:        "custom-ns",
+				Min:           1,
+				Max:           5,
+			},
+		},
+		{
+			name:             "allNamespaces omitted with min and max and default prefix",
+			namespacesPrefix: "default-prefix",
+			params: map[string]interface{}{
+				"namespaceRange": map[string]interface{}{
+					"min": 2,
+					"max": 4,
+				},
+			},
+			want: measurementutil.NamespacesRange{
+				AllNamespaces: false,
+				Prefix:        "default-prefix",
+				Min:           2,
+				Max:           4,
+			},
+		},
+		{
+			name:             "no namespaceRange provided (cluster-scoped)",
+			namespacesPrefix: "default-prefix",
+			params:           map[string]interface{}{},
+			want: measurementutil.NamespacesRange{
+				Prefix: "",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := getNamespaces(tc.namespacesPrefix, tc.params)
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.want, got)
+			}
+		})
+	}
+}

--- a/clusterloader2/pkg/measurement/util/object_store_dynamic.go
+++ b/clusterloader2/pkg/measurement/util/object_store_dynamic.go
@@ -43,7 +43,8 @@ const (
 // DynamicObjectStore is a convenient wrapper around cache.GenericLister.
 type DynamicObjectStore struct {
 	cache.GenericLister
-	namespaces map[string]bool
+	namespaces    map[string]bool
+	allNamespaces bool
 }
 
 // NewDynamicObjectStore creates DynamicObjectStore based on given object version resource and selector.
@@ -56,6 +57,7 @@ func NewDynamicObjectStore(ctx context.Context, dynamicClient dynamic.Interface,
 	return &DynamicObjectStore{
 		GenericLister: lister,
 		namespaces:    namespaces,
+		allNamespaces: len(namespaces) == 0,
 	}, nil
 }
 
@@ -72,7 +74,7 @@ func (s *DynamicObjectStore) ListObjectSimplifications() ([]ObjectSimplification
 		if err != nil {
 			return nil, err
 		}
-		if !s.namespaces[os.Metadata.Namespace] {
+		if !s.allNamespaces && !s.namespaces[os.Metadata.Namespace] {
 			continue
 		}
 		result = append(result, os)

--- a/clusterloader2/pkg/measurement/util/object_store_dynamic_test.go
+++ b/clusterloader2/pkg/measurement/util/object_store_dynamic_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/clusterloader2/pkg/measurement/util/object_store_dynamic_test.go
+++ b/clusterloader2/pkg/measurement/util/object_store_dynamic_test.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic/fake"
+)
+
+func TestDynamicObjectStore_AllNamespaces(t *testing.T) {
+	gvr := schema.GroupVersionResource{
+		Group:    "test.group",
+		Version:  "v1",
+		Resource: "items",
+	}
+
+	obj1 := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"name":      "item-1",
+				"namespace": "ns-1",
+			},
+			"status": map[string]interface{}{
+				"conditions": []interface{}{},
+			},
+		},
+	}
+	obj2 := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"name":      "item-2",
+				"namespace": "ns-2",
+			},
+			"status": map[string]interface{}{
+				"conditions": []interface{}{},
+			},
+		},
+	}
+
+	tests := []struct {
+		name          string
+		namespaces    map[string]bool
+		wantNames     []string
+		wantAllNsFlag bool
+	}{
+		{
+			name:          "allNamespaces enabled when namespaces map is empty",
+			namespaces:    map[string]bool{},
+			wantNames:     []string{"ns-1/item-1", "ns-2/item-2"},
+			wantAllNsFlag: true,
+		},
+		{
+			name:          "allNamespaces disabled when specific namespaces are provided",
+			namespaces:    map[string]bool{"ns-1": true},
+			wantNames:     []string{"ns-1/item-1"},
+			wantAllNsFlag: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+
+			dynamicClient := fake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), map[schema.GroupVersionResource]string{
+				gvr: "ItemsList",
+			})
+
+			_, err := dynamicClient.Resource(gvr).Namespace("ns-1").Create(ctx, obj1, metav1.CreateOptions{})
+			require.NoError(t, err)
+			_, err = dynamicClient.Resource(gvr).Namespace("ns-2").Create(ctx, obj2, metav1.CreateOptions{})
+			require.NoError(t, err)
+
+			store, err := NewDynamicObjectStore(ctx, dynamicClient, gvr, tt.namespaces)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantAllNsFlag, store.allNamespaces)
+
+			results, err := store.ListObjectSimplifications()
+			require.NoError(t, err)
+
+			gotNames := make([]string, 0, len(results))
+			for _, r := range results {
+				gotNames = append(gotNames, r.String())
+			}
+			assert.ElementsMatch(t, tt.wantNames, gotNames)
+		})
+	}
+}

--- a/clusterloader2/pkg/measurement/util/wait_for_conditions.go
+++ b/clusterloader2/pkg/measurement/util/wait_for_conditions.go
@@ -53,9 +53,10 @@ type WaitForGenericK8sObjectsOptions struct {
 
 // NamespacesRange represents namespace range which will be queried.
 type NamespacesRange struct {
-	Prefix string
-	Min    int
-	Max    int
+	AllNamespaces bool
+	Prefix        string
+	Min           int
+	Max           int
 }
 
 // Summary returns summary which should be included in all logs.
@@ -65,6 +66,9 @@ func (o *WaitForGenericK8sObjectsOptions) Summary() string {
 
 // String returns printable representation of the namespaces range.
 func (nr *NamespacesRange) String() string {
+	if nr.AllNamespaces {
+		return "*"
+	}
 	if nr.Prefix == "" {
 		return ""
 	}
@@ -74,6 +78,9 @@ func (nr *NamespacesRange) String() string {
 // getMap returns a map with namespaces which should be queried.
 func (nr *NamespacesRange) getMap() map[string]bool {
 	result := map[string]bool{}
+	if nr.AllNamespaces {
+		return result // all namespaces => empty map
+	}
 	if nr.Prefix == "" {
 		result[""] = true // Cluster-scoped objects.
 		return result
@@ -88,6 +95,7 @@ func (nr *NamespacesRange) getMap() map[string]bool {
 // fulfills given conditions requirements, ctx.Done() channel is used to
 // wait for timeout.
 func WaitForGenericK8sObjects(ctx context.Context, dynamicClient dynamic.Interface, options *WaitForGenericK8sObjectsOptions) error {
+	klog.V(2).Infof("%s", options.Summary())
 	store, err := NewDynamicObjectStore(ctx, dynamicClient, options.GroupVersionResource, options.Namespaces.getMap())
 	if err != nil {
 		return err

--- a/clusterloader2/pkg/measurement/util/wait_for_conditions.go
+++ b/clusterloader2/pkg/measurement/util/wait_for_conditions.go
@@ -95,7 +95,6 @@ func (nr *NamespacesRange) getMap() map[string]bool {
 // fulfills given conditions requirements, ctx.Done() channel is used to
 // wait for timeout.
 func WaitForGenericK8sObjects(ctx context.Context, dynamicClient dynamic.Interface, options *WaitForGenericK8sObjectsOptions) error {
-	klog.V(2).Infof("%s", options.Summary())
 	store, err := NewDynamicObjectStore(ctx, dynamicClient, options.GroupVersionResource, options.Namespaces.getMap())
 	if err != nil {
 		return err

--- a/clusterloader2/pkg/measurement/util/wait_for_conditions_test.go
+++ b/clusterloader2/pkg/measurement/util/wait_for_conditions_test.go
@@ -189,6 +189,40 @@ func TestWaitForGenericK8sObjects(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name:    "successful objects across all namespaces with AllNamespaces true",
+			timeout: 1 * time.Second,
+			options: &WaitForGenericK8sObjectsOptions{
+				GroupVersionResource: schema.GroupVersionResource{
+					Group:    "kuberentes.io",
+					Version:  "v1alpha1",
+					Resource: "Conditions",
+				},
+				Namespaces: NamespacesRange{
+					AllNamespaces: true,
+				},
+				SuccessfulConditions:  []string{"Successful=True"},
+				FailedConditions:      []string{},
+				MinDesiredObjectCount: 2,
+				MaxFailedObjectCount:  0,
+				CallerName:            "test",
+				WaitInterval:          100 * time.Millisecond,
+			},
+			existingObjects: []exampleObject{
+				newExampleObject("test-1", "namespace-1", []interface{}{
+					map[string]interface{}{
+						"type":   "Successful",
+						"status": "True",
+					},
+				}),
+				newExampleObject("test-2", "namespace-2", []interface{}{
+					map[string]interface{}{
+						"type":   "Successful",
+						"status": "True",
+					},
+				}),
+			},
+		},
 	}
 	for _, tt := range tests {
 		tt := tt
@@ -232,5 +266,17 @@ func newExampleObject(name, namespace string, conditions []interface{}) exampleO
 				},
 			},
 		},
+	}
+}
+
+func TestNamespacesRange_AllNamespaces(t *testing.T) {
+	nr := NamespacesRange{
+		AllNamespaces: true,
+	}
+	if got := nr.String(); got != "*" {
+		t.Errorf("String() = %v, want *", got)
+	}
+	if got := nr.getMap(); len(got) != 0 {
+		t.Errorf("getMap() = %v, want empty map", got)
 	}
 }


### PR DESCRIPTION
feat: add support for cross-namespace querying in dynamic object stores and wait-for-conditions measurement

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature
/kind api-change

#### What this PR does / why we need it:

This PR enables using allNamespaces in WaitForGenericK8sObject measurement.
This is helpful in scenarios when the namespace is unknown or predefined (up to this PR it was only possible to reference the automanaged namespaces).

#### Special notes for your reviewer:

The supplemented test cases were generated using Antigravity agent.
