### PR TITLE
Remove dead NODE_MODE override param from 2000/5000 node configs

### DIFF
--- a/clusterloader2/testing/overrides/2000_nodes.yaml
+++ b/clusterloader2/testing/overrides/2000_nodes.yaml
@@ -1,1 +1,1 @@
-NODE_MODE: masterandnondaemons
+# Placeholder so this stays a valid non-empty --testoverrides target.

--- a/clusterloader2/testing/overrides/5000_nodes.yaml
+++ b/clusterloader2/testing/overrides/5000_nodes.yaml
@@ -1,1 +1,1 @@
-NODE_MODE: masterandnondaemons
+# Placeholder so this stays a valid non-empty --testoverrides target.


### PR DESCRIPTION
Drop the inert `NODE_MODE: masterandnondaemons` override from `2000_nodes.yaml` and `5000_nodes.yaml` since nothing reads it ([resource_usage.go](https://github.com/kubernetes/perf-tests/blob/666f845c24f9310e9b9da5d5667d7f445a2a87db/clusterloader2/pkg/measurement/common/resource_usage.go#L104-L108) derives the node set from cluster size, not the param). Orphaned since #1549, which moved that decision to cluster size and dropped the `nodeMode` template wiring. The files stay in place as they are still referenced via `--testoverrides`.

Discovered while checking usage for all the flags.
