### PR TITLE
Provide NodeHealthTracker measurement for CL2

### DIFF
--- a/clusterloader2/pkg/measurement/common/node_health_tracker.go
+++ b/clusterloader2/pkg/measurement/common/node_health_tracker.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -29,14 +29,17 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
+	"k8s.io/perf-tests/clusterloader2/pkg/errors"
 	"k8s.io/perf-tests/clusterloader2/pkg/measurement"
 	"k8s.io/perf-tests/clusterloader2/pkg/measurement/util/informer"
 	"k8s.io/perf-tests/clusterloader2/pkg/util"
 )
 
 const (
-	nodeHealthTrackerMeasurementName = "NodeHealthTracker"
-	nodeHealthTrackerInformerTimeout = time.Minute
+	nodeHealthTrackerMeasurementName  = "NodeHealthTracker"
+	nodeHealthTrackerInformerTimeout  = time.Minute
+	defaultNodeHealthTrackerThreshold = 4
+	defaultNodeHealthTrackerRatio     = 0.01
 )
 
 func init() {
@@ -46,18 +49,25 @@ func init() {
 }
 
 func createNodeHealthTrackerMeasurement() measurement.Measurement {
-	return &nodeHealthTrackerMeasurement{}
+	return &nodeHealthTrackerMeasurement{
+		threshold: defaultNodeHealthTrackerThreshold,
+		ratio:     defaultNodeHealthTrackerRatio,
+	}
 }
 
 type nodeHealthTrackerMeasurement struct {
-	isRunning    bool
-	stopCh       chan struct{}
-	lock         sync.Mutex
-	nodes        map[string]bool
-	runningNodes int
-	nodeCount    int
-	hasSynced    bool
-	lastLogTime  time.Time
+	isRunning        bool
+	stopCh           chan struct{}
+	lock             sync.Mutex
+	nodes            map[string]bool
+	runningNodes     int
+	nodeCount        int
+	hasSynced        bool
+	lastLogTime      time.Time
+	thresholdReached bool
+	violationMsg     string
+	threshold        int
+	ratio            float64
 }
 
 func (m *nodeHealthTrackerMeasurement) Execute(config *measurement.Config) ([]measurement.Summary, error) {
@@ -91,7 +101,17 @@ func (m *nodeHealthTrackerMeasurement) String() string {
 }
 
 func (m *nodeHealthTrackerMeasurement) start(config *measurement.Config) error {
+	threshold, err := util.GetIntOrDefault(config.Params, "threshold", defaultNodeHealthTrackerThreshold)
+	if err != nil {
+		return fmt.Errorf("problem with getting threshold param: %w", err)
+	}
+	ratio, err := util.GetFloat64OrDefault(config.Params, "ratio", defaultNodeHealthTrackerRatio)
+	if err != nil {
+		return fmt.Errorf("problem with getting ratio param: %w", err)
+	}
+
 	m.lock.Lock()
+	klog.V(2).Infof("%s: starting node health tracker measurement...", config.Identifier)
 	if m.isRunning {
 		m.lock.Unlock()
 		klog.V(2).Infof("%s: measurement already running", m)
@@ -104,6 +124,10 @@ func (m *nodeHealthTrackerMeasurement) start(config *measurement.Config) error {
 	m.nodeCount = 0
 	m.hasSynced = false
 	m.lastLogTime = time.Time{}
+	m.thresholdReached = false
+	m.violationMsg = ""
+	m.threshold = threshold
+	m.ratio = ratio
 	m.lock.Unlock()
 
 	selector := util.NewObjectSelector()
@@ -175,8 +199,9 @@ func (m *nodeHealthTrackerMeasurement) checkThresholdAndLog() {
 		return
 	}
 	unhealthyNodes := m.nodeCount - m.runningNodes
-	threshold := math.Max(4, float64(m.nodeCount)*0.01)
+	threshold := math.Max(float64(m.threshold), float64(m.nodeCount)*m.ratio)
 	if float64(unhealthyNodes) > threshold {
+		m.thresholdReached = true
 		now := time.Now()
 		if m.lastLogTime.IsZero() || now.Sub(m.lastLogTime) >= time.Minute {
 			exampleUnhealthyNode := ""
@@ -186,8 +211,12 @@ func (m *nodeHealthTrackerMeasurement) checkThresholdAndLog() {
 					break
 				}
 			}
-			klog.Warningf("%s: number of unhealthy nodes (%d) is above threshold (%v), total nodes: %d, example unhealthy node: %s", m.String(), unhealthyNodes, threshold, m.nodeCount, exampleUnhealthyNode)
+			msg := fmt.Sprintf("number of unhealthy nodes (%d) is above threshold (%v), total nodes: %d, example unhealthy node: %s", unhealthyNodes, threshold, m.nodeCount, exampleUnhealthyNode)
+			m.violationMsg = msg
+			klog.Warningf("%s: %s", m.String(), msg)
 			m.lastLogTime = now
+		} else if m.violationMsg == "" {
+			m.violationMsg = fmt.Sprintf("number of unhealthy nodes (%d) is above threshold (%v), total nodes: %d", unhealthyNodes, threshold, m.nodeCount)
 		}
 	}
 }
@@ -201,9 +230,10 @@ func (m *nodeHealthTrackerMeasurement) gather(config *measurement.Config) ([]mea
 
 	m.stopLocked()
 
-	summaryData := map[string]int{
-		"runningNodes": m.runningNodes,
-		"nodeCount":    m.nodeCount,
+	summaryData := map[string]interface{}{
+		"runningNodes":     m.runningNodes,
+		"nodeCount":        m.nodeCount,
+		"thresholdReached": m.thresholdReached,
 	}
 	content, err := util.PrettyPrintJSON(summaryData)
 	if err != nil {
@@ -211,7 +241,10 @@ func (m *nodeHealthTrackerMeasurement) gather(config *measurement.Config) ([]mea
 	}
 
 	summary := measurement.CreateSummary(nodeHealthTrackerMeasurementName, "json", content)
-	return []measurement.Summary{summary}, nil
+	if m.thresholdReached {
+		err = errors.NewMetricViolationError("node health", m.violationMsg)
+	}
+	return []measurement.Summary{summary}, err
 }
 
 func (m *nodeHealthTrackerMeasurement) stop() {

--- a/clusterloader2/pkg/measurement/common/node_health_tracker.go
+++ b/clusterloader2/pkg/measurement/common/node_health_tracker.go
@@ -1,0 +1,228 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"sync"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+	"k8s.io/perf-tests/clusterloader2/pkg/measurement"
+	"k8s.io/perf-tests/clusterloader2/pkg/measurement/util/informer"
+	"k8s.io/perf-tests/clusterloader2/pkg/util"
+)
+
+const (
+	nodeHealthTrackerMeasurementName = "NodeHealthTracker"
+	nodeHealthTrackerInformerTimeout = time.Minute
+)
+
+func init() {
+	if err := measurement.Register(nodeHealthTrackerMeasurementName, createNodeHealthTrackerMeasurement); err != nil {
+		klog.Fatalf("Cannot register %s: %v", nodeHealthTrackerMeasurementName, err)
+	}
+}
+
+func createNodeHealthTrackerMeasurement() measurement.Measurement {
+	return &nodeHealthTrackerMeasurement{}
+}
+
+type nodeHealthTrackerMeasurement struct {
+	isRunning    bool
+	stopCh       chan struct{}
+	lock         sync.Mutex
+	nodes        map[string]bool
+	runningNodes int
+	nodeCount    int
+	hasSynced    bool
+	lastLogTime  time.Time
+}
+
+func (m *nodeHealthTrackerMeasurement) Execute(config *measurement.Config) ([]measurement.Summary, error) {
+	action, err := util.GetString(config.Params, "action")
+	if err != nil {
+		return nil, fmt.Errorf("problem with getting action param: %w", err)
+	}
+
+	switch action {
+	case "start":
+		if err := m.start(config); err != nil {
+			return nil, fmt.Errorf("starting NodeHealthTracker measurement problem: %w", err)
+		}
+		return nil, nil
+	case "gather":
+		return m.gather(config)
+	case "stop":
+		m.stop()
+		return nil, nil
+	default:
+		return nil, fmt.Errorf("unknown action %v", action)
+	}
+}
+
+func (m *nodeHealthTrackerMeasurement) Dispose() {
+	m.stop()
+}
+
+func (m *nodeHealthTrackerMeasurement) String() string {
+	return nodeHealthTrackerMeasurementName
+}
+
+func (m *nodeHealthTrackerMeasurement) start(config *measurement.Config) error {
+	m.lock.Lock()
+	if m.isRunning {
+		m.lock.Unlock()
+		klog.V(2).Infof("%s: measurement already running", m)
+		return nil
+	}
+	m.isRunning = true
+	m.stopCh = make(chan struct{})
+	m.nodes = make(map[string]bool)
+	m.runningNodes = 0
+	m.nodeCount = 0
+	m.hasSynced = false
+	m.lastLogTime = time.Time{}
+	m.lock.Unlock()
+
+	selector := util.NewObjectSelector()
+	if err := selector.Parse(config.Params); err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+	client := config.ClusterFramework.GetClientSets().GetClient()
+
+	lw := &cache.ListWatch{
+		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+			options.LabelSelector = selector.LabelSelector
+			options.FieldSelector = selector.FieldSelector
+			return client.CoreV1().Nodes().List(ctx, options)
+		},
+		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			options.LabelSelector = selector.LabelSelector
+			options.FieldSelector = selector.FieldSelector
+			return client.CoreV1().Nodes().Watch(ctx, options)
+		},
+	}
+
+	i := informer.NewInformer(lw, m.handleNodeEvent)
+	if err := informer.StartAndSync(i, m.stopCh, nodeHealthTrackerInformerTimeout); err != nil {
+		return fmt.Errorf("problem starting node health tracker informer: %w", err)
+	}
+
+	m.lock.Lock()
+	m.hasSynced = true
+	m.checkThresholdAndLog()
+	m.lock.Unlock()
+
+	return nil
+}
+
+func (m *nodeHealthTrackerMeasurement) handleNodeEvent(oldObj, newObj interface{}) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	if newObj != nil {
+		node, ok := newObj.(*corev1.Node)
+		if ok {
+			m.nodes[node.Name] = util.IsNodeSchedulableAndUntainted(node)
+		}
+	} else if oldObj != nil {
+		node, ok := oldObj.(*corev1.Node)
+		if ok {
+			delete(m.nodes, node.Name)
+		}
+	}
+
+	runningNodes := 0
+	for _, healthy := range m.nodes {
+		if healthy {
+			runningNodes++
+		}
+	}
+	m.runningNodes = runningNodes
+	m.nodeCount = len(m.nodes)
+
+	if m.hasSynced {
+		m.checkThresholdAndLog()
+	}
+}
+
+func (m *nodeHealthTrackerMeasurement) checkThresholdAndLog() {
+	if m.nodeCount == 0 {
+		return
+	}
+	unhealthyNodes := m.nodeCount - m.runningNodes
+	threshold := math.Max(4, float64(m.nodeCount)*0.01)
+	if float64(unhealthyNodes) > threshold {
+		now := time.Now()
+		if m.lastLogTime.IsZero() || now.Sub(m.lastLogTime) >= time.Minute {
+			exampleUnhealthyNode := ""
+			for nodeName, healthy := range m.nodes {
+				if !healthy {
+					exampleUnhealthyNode = nodeName
+					break
+				}
+			}
+			klog.Warningf("%s: number of unhealthy nodes (%d) is above threshold (%v), total nodes: %d, example unhealthy node: %s", m.String(), unhealthyNodes, threshold, m.nodeCount, exampleUnhealthyNode)
+			m.lastLogTime = now
+		}
+	}
+}
+
+func (m *nodeHealthTrackerMeasurement) gather(config *measurement.Config) ([]measurement.Summary, error) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	if !m.isRunning {
+		return nil, fmt.Errorf("measurement %s has not been started", nodeHealthTrackerMeasurementName)
+	}
+
+	m.stopLocked()
+
+	summaryData := map[string]int{
+		"runningNodes": m.runningNodes,
+		"nodeCount":    m.nodeCount,
+	}
+	content, err := util.PrettyPrintJSON(summaryData)
+	if err != nil {
+		return nil, fmt.Errorf("pretty print JSON problem: %w", err)
+	}
+
+	summary := measurement.CreateSummary(nodeHealthTrackerMeasurementName, "json", content)
+	return []measurement.Summary{summary}, nil
+}
+
+func (m *nodeHealthTrackerMeasurement) stop() {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	m.stopLocked()
+}
+
+func (m *nodeHealthTrackerMeasurement) stopLocked() {
+	if m.isRunning {
+		m.isRunning = false
+		close(m.stopCh)
+	}
+}

--- a/clusterloader2/pkg/measurement/common/node_health_tracker_test.go
+++ b/clusterloader2/pkg/measurement/common/node_health_tracker_test.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/perf-tests/clusterloader2/pkg/measurement"
+)
+
+func TestNodeHealthTrackerMeasurement_HandleNodeEvent(t *testing.T) {
+	m := &nodeHealthTrackerMeasurement{
+		isRunning: true,
+		stopCh:    make(chan struct{}),
+		nodes:     make(map[string]bool),
+		hasSynced: true,
+	}
+
+	healthyNode := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "node-1"},
+		Status: corev1.NodeStatus{
+			Conditions: []corev1.NodeCondition{
+				{Type: corev1.NodeReady, Status: corev1.ConditionTrue},
+			},
+		},
+	}
+
+	unhealthyNode := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "node-2"},
+		Status: corev1.NodeStatus{
+			Conditions: []corev1.NodeCondition{
+				{Type: corev1.NodeReady, Status: corev1.ConditionFalse},
+			},
+		},
+	}
+
+	// Add healthy node
+	m.handleNodeEvent(nil, healthyNode)
+	assert.Equal(t, 1, m.nodeCount)
+	assert.Equal(t, 1, m.runningNodes)
+
+	// Add unhealthy node
+	m.handleNodeEvent(nil, unhealthyNode)
+	assert.Equal(t, 2, m.nodeCount)
+	assert.Equal(t, 1, m.runningNodes)
+
+	// Update unhealthy node to healthy
+	unhealthyNode.Status.Conditions[0].Status = corev1.ConditionTrue
+	m.handleNodeEvent(unhealthyNode, unhealthyNode)
+	assert.Equal(t, 2, m.nodeCount)
+	assert.Equal(t, 2, m.runningNodes)
+
+	// Delete a node
+	m.handleNodeEvent(healthyNode, nil)
+	assert.Equal(t, 1, m.nodeCount)
+	assert.Equal(t, 1, m.runningNodes)
+}
+
+func TestNodeHealthTrackerMeasurement_Debounce(t *testing.T) {
+	m := &nodeHealthTrackerMeasurement{
+		isRunning: true,
+		stopCh:    make(chan struct{}),
+		nodes:     make(map[string]bool),
+		hasSynced: true,
+	}
+
+	// Add 5 unhealthy nodes so unhealthyNodes (5) > max(4, 1% of 5 = 0.05)
+	for i := 1; i <= 5; i++ {
+		unhealthyNode := &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("node-%d", i)},
+			Status: corev1.NodeStatus{
+				Conditions: []corev1.NodeCondition{
+					{Type: corev1.NodeReady, Status: corev1.ConditionFalse},
+				},
+			},
+		}
+		m.handleNodeEvent(nil, unhealthyNode)
+	}
+
+	firstLogTime := m.lastLogTime
+	assert.False(t, firstLogTime.IsZero())
+
+	// Another unhealthy event immediately after should not update lastLogTime due to debounce
+	unhealthyNode6 := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "node-6"},
+		Status: corev1.NodeStatus{
+			Conditions: []corev1.NodeCondition{
+				{Type: corev1.NodeReady, Status: corev1.ConditionFalse},
+			},
+		},
+	}
+	m.handleNodeEvent(nil, unhealthyNode6)
+	assert.Equal(t, firstLogTime, m.lastLogTime)
+}
+
+func TestNodeHealthTrackerMeasurement_Gather(t *testing.T) {
+	m := &nodeHealthTrackerMeasurement{
+		isRunning:    true,
+		stopCh:       make(chan struct{}),
+		nodes:        make(map[string]bool),
+		runningNodes: 5,
+		nodeCount:    10,
+	}
+
+	config := &measurement.Config{
+		Params: map[string]interface{}{},
+	}
+	summaries, err := m.gather(config)
+	assert.NoError(t, err)
+	assert.Len(t, summaries, 1)
+	assert.Equal(t, nodeHealthTrackerMeasurementName, summaries[0].SummaryName())
+	assert.False(t, m.isRunning)
+}

--- a/clusterloader2/pkg/measurement/common/node_health_tracker_test.go
+++ b/clusterloader2/pkg/measurement/common/node_health_tracker_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/perf-tests/clusterloader2/pkg/errors"
 	"k8s.io/perf-tests/clusterloader2/pkg/measurement"
 )
 
@@ -32,6 +33,8 @@ func TestNodeHealthTrackerMeasurement_HandleNodeEvent(t *testing.T) {
 		stopCh:    make(chan struct{}),
 		nodes:     make(map[string]bool),
 		hasSynced: true,
+		threshold: defaultNodeHealthTrackerThreshold,
+		ratio:     defaultNodeHealthTrackerRatio,
 	}
 
 	healthyNode := &corev1.Node{
@@ -80,6 +83,8 @@ func TestNodeHealthTrackerMeasurement_Debounce(t *testing.T) {
 		stopCh:    make(chan struct{}),
 		nodes:     make(map[string]bool),
 		hasSynced: true,
+		threshold: defaultNodeHealthTrackerThreshold,
+		ratio:     defaultNodeHealthTrackerRatio,
 	}
 
 	// Add 5 unhealthy nodes so unhealthyNodes (5) > max(4, 1% of 5 = 0.05)
@@ -118,6 +123,8 @@ func TestNodeHealthTrackerMeasurement_Gather(t *testing.T) {
 		nodes:        make(map[string]bool),
 		runningNodes: 5,
 		nodeCount:    10,
+		threshold:    defaultNodeHealthTrackerThreshold,
+		ratio:        defaultNodeHealthTrackerRatio,
 	}
 
 	config := &measurement.Config{
@@ -128,4 +135,67 @@ func TestNodeHealthTrackerMeasurement_Gather(t *testing.T) {
 	assert.Len(t, summaries, 1)
 	assert.Equal(t, nodeHealthTrackerMeasurementName, summaries[0].SummaryName())
 	assert.False(t, m.isRunning)
+}
+
+func TestNodeHealthTrackerMeasurement_Gather_Failure(t *testing.T) {
+	m := &nodeHealthTrackerMeasurement{
+		isRunning:        true,
+		stopCh:           make(chan struct{}),
+		nodes:            make(map[string]bool),
+		runningNodes:     5,
+		nodeCount:        10,
+		thresholdReached: true,
+		violationMsg:     "number of unhealthy nodes (5) is above threshold (4), total nodes: 10",
+		threshold:        defaultNodeHealthTrackerThreshold,
+		ratio:            defaultNodeHealthTrackerRatio,
+	}
+
+	config := &measurement.Config{
+		Params: map[string]interface{}{},
+	}
+	summaries, err := m.gather(config)
+	assert.Error(t, err)
+	assert.True(t, errors.IsMetricViolationError(err))
+	assert.Len(t, summaries, 1)
+}
+
+func TestNodeHealthTrackerMeasurement_ConfigurableParameters(t *testing.T) {
+	m := &nodeHealthTrackerMeasurement{
+		isRunning: true,
+		stopCh:    make(chan struct{}),
+		nodes:     make(map[string]bool),
+		hasSynced: true,
+		threshold: 10,
+		ratio:     0.05,
+	}
+
+	// Add 5 unhealthy nodes. With threshold=10, max(10, 5*0.05)=10. 5 <= 10, so should not trigger threshold.
+	for i := 1; i <= 5; i++ {
+		unhealthyNode := &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("node-%d", i)},
+			Status: corev1.NodeStatus{
+				Conditions: []corev1.NodeCondition{
+					{Type: corev1.NodeReady, Status: corev1.ConditionFalse},
+				},
+			},
+		}
+		m.handleNodeEvent(nil, unhealthyNode)
+	}
+
+	assert.False(t, m.thresholdReached)
+
+	// Add 6 more unhealthy nodes (total 11 unhealthy nodes). 11 > 10, so should trigger threshold.
+	for i := 6; i <= 11; i++ {
+		unhealthyNode := &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("node-%d", i)},
+			Status: corev1.NodeStatus{
+				Conditions: []corev1.NodeCondition{
+					{Type: corev1.NodeReady, Status: corev1.ConditionFalse},
+				},
+			},
+		}
+		m.handleNodeEvent(nil, unhealthyNode)
+	}
+
+	assert.True(t, m.thresholdReached)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR introduces a Node Health tracker measurement. This measurement subscribes (opens WATCH) to the Node resources in Kubernetes. When the number of unhealthy nodes goes above `max(4, 1% of all nodes)`, then a message printed to the log (at most once a minute) and the test is marked as failed during `gather` phase.

