### PR TITLE
Add custom resource LIST benchmark scenario

### DIFF
--- a/clusterloader2/testing/list/README.md
+++ b/clusterloader2/testing/list/README.md
@@ -1,14 +1,17 @@
 # List load test
 
-List load test perform the following steps:
-- Create configmaps.
+List load test performs the following steps:
+- Create configured resources.
   - The namespaces used here are managed by CL2.
-  - The size and number of configmaps can be specified using `CL2_LIST_CONFIG_MAP_BYTES` and `CL2_LIST_CONFIG_MAP_NUMBER`.
-- Optionally create pods.
+  - Configmaps are always created. The size and number of configmaps can be specified using `CL2_LIST_CONFIG_MAP_BYTES` and `CL2_LIST_CONFIG_MAP_NUMBER`.
+  - The number of custom resources can be specified using `CL2_LIST_CUSTOM_RESOURCE_NUMBER`.
+  - The size of each custom resource payload can be specified using `CL2_LIST_CUSTOM_RESOURCE_BYTES`.
+  - The custom resource list benchmark is skipped by default unless `CL2_LIST_CUSTOM_RESOURCE_NUMBER` is greater than 0.
+  - The custom resource shape uses a larger, Kueue-like nested schema to exercise list cost for bigger CRD-backed objects.
   - The number of pods can be specified using `CL2_LIST_POD_NUMBER`.
   - The pod list benchmark is skipped by default unless `CL2_LIST_POD_NUMBER` is greater than 0.
   - Pods use the exemplar pod shape from reconcile-objects to measure realistic per-pod list cost.
-- Create RBAC rules to allow lister pods to access these configmaps
+- Create RBAC rules to allow lister pods to access the configured resources.
 - Create lister pods using deployment in a separate namespace to list configured resources.
   - The namespace is created using `namespace.yaml` as a template, but its lifecycle is managed by CL2.
   - The number of replicas for the lister pods can be specified using `CL2_LIST_BENCHMARK_PODS`.

--- a/clusterloader2/testing/list/clusterrole.yaml
+++ b/clusterloader2/testing/list/clusterrole.yaml
@@ -9,3 +9,9 @@ rules:
   - "*"
   verbs:
   - list
+- apiGroups:
+  - clusterloader.io-0
+  resources:
+  - listbenchmarkresources
+  verbs:
+  - list

--- a/clusterloader2/testing/list/config.yaml
+++ b/clusterloader2/testing/list/config.yaml
@@ -2,6 +2,9 @@
 {{$configMapBytes := DefaultParam .CL2_LIST_CONFIG_MAP_BYTES 100000}}
 {{$configMapNumber := DefaultParam .CL2_LIST_CONFIG_MAP_NUMBER 10000}}
 {{$configMapGroup := DefaultParam .CL2_LIST_CONFIG_MAP_GROUP "list-configmap"}}
+{{$customResourceBytes := DefaultParam .CL2_LIST_CUSTOM_RESOURCE_BYTES 100000}}
+{{$customResourceNumber := DefaultParam .CL2_LIST_CUSTOM_RESOURCE_NUMBER 0}}
+{{$customResourceGroup := DefaultParam .CL2_LIST_CUSTOM_RESOURCE_GROUP "list-custom-resource"}}
 {{$podNumber := DefaultParam .CL2_LIST_POD_NUMBER 0}}
 {{$podGroup := DefaultParam .CL2_LIST_POD_GROUP "list-pod"}}
 
@@ -85,6 +88,98 @@ steps:
     params:
       namePrefix: "list-configmaps-"
       replicas: 0
+
+{{if $customResourceNumber}}
+- name: Delete configmaps before custom resource list benchmark
+  phases:
+  - namespaceRange:
+      min: 1
+      max: 1
+    tuningSet: Sequence
+    replicasPerNamespace: 0
+    objectBundle:
+    - basename: {{$configMapGroup}}
+      objectTemplatePath: configmap.yaml
+      templateFillMap:
+        bytes: {{$configMapBytes}}
+        group: {{$configMapGroup}}
+
+- name: Create custom resource definition
+  phases:
+  - replicasPerNamespace: 1
+    tuningSet: Sequence
+    objectBundle:
+    - basename: listbenchmarkresources.clusterloader.io
+      objectTemplatePath: customresourcedefinition.yaml
+
+- name: Wait for custom resource definition to be served
+  measurements:
+    - Identifier: Wait
+      Method: Sleep
+      Params:
+        duration: 30s
+
+- name: Create custom resources
+  phases:
+  - namespaceRange:
+      min: 1
+      max: 1
+    tuningSet: Sequence
+    replicasPerNamespace: {{$customResourceNumber}}
+    objectBundle:
+    - basename: {{$customResourceGroup}}
+      objectTemplatePath: customresource.yaml
+      templateFillMap:
+        bytes: {{$customResourceBytes}}
+        group: {{$customResourceGroup}}
+
+- module:
+    path: modules/list-benchmark.yaml
+    params:
+      namePrefix: "list-customresources-"
+      replicas: {{$listReplicas}}
+      uri: /apis/clusterloader.io-0/v1alpha1/listbenchmarkresources?resourceVersion=0
+      namespaced: false
+      contentType: {{$contentType}}
+- module:
+    path: /modules/measurements.yaml
+    params:
+      action: start
+- name: Wait 5 minutes for custom resource list benchmark
+  measurements:
+    - Identifier: Wait
+      Method: Sleep
+      Params:
+        duration: 5m
+- module:
+    path: /modules/measurements.yaml
+    params:
+      action: gather
+- module:
+    path: modules/list-benchmark.yaml
+    params:
+      namePrefix: "list-customresources-"
+      replicas: 0
+
+- name: Delete custom resources
+  phases:
+  - namespaceRange:
+      min: 1
+      max: 1
+    tuningSet: Sequence
+    replicasPerNamespace: 0
+    objectBundle:
+    - basename: {{$customResourceGroup}}
+      objectTemplatePath: customresource.yaml
+
+- name: Delete custom resource definition
+  phases:
+  - replicasPerNamespace: 0
+    tuningSet: Sequence
+    objectBundle:
+    - basename: listbenchmarkresources.clusterloader.io
+      objectTemplatePath: customresourcedefinition.yaml
+{{end}}
 
 {{if $podNumber}}
 - name: Delete configmaps before pod list benchmark

--- a/clusterloader2/testing/list/customresource.yaml
+++ b/clusterloader2/testing/list/customresource.yaml
@@ -1,0 +1,184 @@
+{{$bytes := .bytes}}
+{{$group := DefaultParam .group .Name}}
+
+apiVersion: clusterloader.io-0/v1alpha1
+kind: ListBenchmarkResource
+metadata:
+  name: {{.Name}}
+  labels:
+    group: {{$group}}
+    kueue.x-k8s.io/queue-name: benchmark-queue
+    app.kubernetes.io/name: list-benchmark-resource
+    app.kubernetes.io/component: workload
+  annotations:
+    list-benchmark.k8s.io/description: "large custom resource for LIST benchmark"
+    list-benchmark.k8s.io/source: "clusterloader2"
+spec:
+  queueName: benchmark-queue
+  priorityClassName: batch
+  priority: 1000
+  active: true
+  podSets:
+  - name: main
+    count: 100
+    minCount: 80
+    template:
+      metadata:
+        labels:
+          app.kubernetes.io/name: list-benchmark-resource
+          app.kubernetes.io/component: worker
+          workload-type: batch
+        annotations:
+          prometheus.io/scrape: "false"
+          sidecar.istio.io/inject: "false"
+      spec:
+        restartPolicy: Never
+        schedulerName: default-scheduler
+        serviceAccountName: default
+        nodeSelector:
+          kubernetes.io/os: linux
+          workload-profile: benchmark
+        tolerations:
+        - key: dedicated
+          operator: Equal
+          value: batch
+          effect: NoSchedule
+        containers:
+        - name: main
+          image: registry.k8s.io/pause:3.9
+          command:
+          - /bin/sh
+          - -c
+          args:
+          - sleep 3600
+          env:
+          - name: WORKLOAD_NAME
+            value: {{.Name}}
+          - name: QUEUE_NAME
+            value: benchmark-queue
+          - name: PAYLOAD_CLASS
+            value: large
+          resources:
+            requests:
+              cpu: 250m
+              memory: 256Mi
+            limits:
+              cpu: "1"
+              memory: 1Gi
+          volumeMounts:
+          - name: config
+            mountPath: /etc/config
+            readOnly: true
+          - name: scratch
+            mountPath: /var/tmp
+        - name: sidecar
+          image: registry.k8s.io/pause:3.9
+          env:
+          - name: WORKLOAD_NAME
+            value: {{.Name}}
+          - name: QUEUE_NAME
+            value: benchmark-queue
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+        volumes:
+        - name: config
+          configMap:
+            name: benchmark-config
+        - name: credentials
+          secret:
+            secretName: benchmark-secret
+        - name: scratch
+          configMap:
+            name: benchmark-scratch
+    topologyRequest:
+      required: "cloud.google.com/gke-nodepool in (benchmark-pool)"
+      preferred: "topology.kubernetes.io/zone in (us-central1-a,us-central1-b)"
+    payload: "{{RandData $bytes}}"
+  - name: reducer
+    count: 25
+    minCount: 10
+    template:
+      metadata:
+        labels:
+          app.kubernetes.io/name: list-benchmark-resource
+          app.kubernetes.io/component: reducer
+          workload-type: batch
+        annotations:
+          prometheus.io/scrape: "false"
+      spec:
+        restartPolicy: Never
+        schedulerName: default-scheduler
+        containers:
+        - name: reducer
+          image: registry.k8s.io/pause:3.9
+          env:
+          - name: WORKLOAD_NAME
+            value: {{.Name}}
+          resources:
+            requests:
+              cpu: 500m
+              memory: 512Mi
+            limits:
+              cpu: "2"
+              memory: 2Gi
+    topologyRequest:
+      preferred: "topology.kubernetes.io/zone in (us-central1-a,us-central1-b)"
+    payload: "{{RandData $bytes}}"
+  admission:
+    clusterQueue: benchmark-cluster-queue
+    podSetAssignments:
+    - name: main
+      flavors:
+        cpu: default
+        memory: default
+      resourceUsage:
+        cpu: "25"
+        memory: 25Gi
+      count: 100
+    - name: reducer
+      flavors:
+        cpu: default
+        memory: default
+      resourceUsage:
+        cpu: "12"
+        memory: 12Gi
+      count: 25
+  admissionChecks:
+  - name: quota-reservation
+    state: Ready
+    message: "quota reserved for benchmark workload"
+    podSetUpdates:
+    - name: main
+      labels:
+        quota.kueue.x-k8s.io/reserved: "true"
+      annotations:
+        quota.kueue.x-k8s.io/flavor: default
+  - name: topology-assignment
+    state: Ready
+    message: "topology assignment is available"
+    podSetUpdates:
+    - name: reducer
+      labels:
+        topology.kueue.x-k8s.io/zone: us-central1-a
+      annotations:
+        topology.kueue.x-k8s.io/request: preferred
+  conditions:
+  - type: QuotaReserved
+    status: "True"
+    reason: QuotaReserved
+    message: "quota has been reserved"
+    lastTransitionTime: "2026-01-01T00:00:00Z"
+  - type: Admitted
+    status: "True"
+    reason: Admitted
+    message: "workload admitted for benchmark"
+    lastTransitionTime: "2026-01-01T00:00:00Z"
+  requeueState:
+    count: 0
+    requeueAt: "2026-01-01T00:00:00Z"
+  payload: "{{RandData $bytes}}"

--- a/clusterloader2/testing/list/customresourcedefinition.yaml
+++ b/clusterloader2/testing/list/customresourcedefinition.yaml
@@ -1,0 +1,240 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: {{.Name}}
+spec:
+  group: clusterloader.io-0
+  scope: Namespaced
+  names:
+    plural: listbenchmarkresources
+    singular: listbenchmarkresource
+    kind: ListBenchmarkResource
+    listKind: ListBenchmarkResourceList
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              queueName:
+                type: string
+              priorityClassName:
+                type: string
+              priority:
+                type: integer
+                format: int32
+              active:
+                type: boolean
+              podSets:
+                type: array
+                items:
+                  type: object
+                  required:
+                  - name
+                  - count
+                  properties:
+                    name:
+                      type: string
+                    count:
+                      type: integer
+                      format: int32
+                    minCount:
+                      type: integer
+                      format: int32
+                    template:
+                      type: object
+                      properties:
+                        metadata:
+                          type: object
+                          properties:
+                            labels:
+                              type: object
+                              additionalProperties:
+                                type: string
+                            annotations:
+                              type: object
+                              additionalProperties:
+                                type: string
+                        spec:
+                          type: object
+                          properties:
+                            restartPolicy:
+                              type: string
+                            schedulerName:
+                              type: string
+                            serviceAccountName:
+                              type: string
+                            nodeSelector:
+                              type: object
+                              additionalProperties:
+                                type: string
+                            tolerations:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  key:
+                                    type: string
+                                  operator:
+                                    type: string
+                                  value:
+                                    type: string
+                                  effect:
+                                    type: string
+                            containers:
+                              type: array
+                              items:
+                                type: object
+                                required:
+                                - name
+                                properties:
+                                  name:
+                                    type: string
+                                  image:
+                                    type: string
+                                  command:
+                                    type: array
+                                    items:
+                                      type: string
+                                  args:
+                                    type: array
+                                    items:
+                                      type: string
+                                  env:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                  resources:
+                                    type: object
+                                    properties:
+                                      requests:
+                                        type: object
+                                        additionalProperties:
+                                          type: string
+                                      limits:
+                                        type: object
+                                        additionalProperties:
+                                          type: string
+                                  volumeMounts:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        name:
+                                          type: string
+                                        mountPath:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                            volumes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  name:
+                                    type: string
+                                  configMap:
+                                    type: object
+                                    properties:
+                                      name:
+                                        type: string
+                                  secret:
+                                    type: object
+                                    properties:
+                                      secretName:
+                                        type: string
+                    topologyRequest:
+                      type: object
+                      properties:
+                        required:
+                          type: string
+                        preferred:
+                          type: string
+                    payload:
+                      type: string
+              admission:
+                type: object
+                properties:
+                  clusterQueue:
+                    type: string
+                  podSetAssignments:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        flavors:
+                          type: object
+                          additionalProperties:
+                            type: string
+                        resourceUsage:
+                          type: object
+                          additionalProperties:
+                            type: string
+                        count:
+                          type: integer
+                          format: int32
+              admissionChecks:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    state:
+                      type: string
+                    message:
+                      type: string
+                    podSetUpdates:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                          labels:
+                            type: object
+                            additionalProperties:
+                              type: string
+                          annotations:
+                            type: object
+                            additionalProperties:
+                              type: string
+              conditions:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                    status:
+                      type: string
+                    reason:
+                      type: string
+                    message:
+                      type: string
+                    lastTransitionTime:
+                      type: string
+                      format: date-time
+              requeueState:
+                type: object
+                properties:
+                  count:
+                    type: integer
+                    format: int32
+                  requeueAt:
+                    type: string
+                    format: date-time
+              payload:
+                type: string


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/sig api-machinery

#### What this PR does / why we need it:

Adds an optional Custom Resource LIST scenario to the existing ClusterLoader2 `testing/list` benchmark.

The scenario is disabled by default and can be enabled with `CL2_LIST_CUSTOM_RESOURCE_NUMBER`. When enabled, it:

- creates a namespaced `ListBenchmarkResource` CRD for the benchmark,
- uses a larger, Kueue-like nested CRD schema and custom resource shape,
- creates benchmark custom resources with configurable payload size,
- starts a request-benchmark deployment that LISTs the custom resource endpoint,
- runs the custom-resource LIST benchmark as a separate sequential benchmark segment,
- cleans up the custom resources and CRD after the benchmark.

#### Which issue(s) this PR fixes:

Part of kubernetes/kubernetes#130169.

#### Special notes for your reviewer:

This focuses on the custom-resource slice of kubernetes/kubernetes#130169 and is rebased on top of the Pods LIST benchmark that is now in `master`.

AI disclosure: This PR was prepared in part with the assistance of an AI coding assistant. I reviewed the generated changes, understand the code being submitted, and verified it with the tests listed below.

Validation:

- `go test ./api ./pkg/config ./pkg/test` from `clusterloader2` passes.
- `git diff --check` passes.
- Dry-run config rendering was checked for the default path, the CR-enabled path, and the CR+Pods-enabled path.
  - The default rendered config contains no custom-resource or pod LIST steps.
  - `CL2_LIST_CUSTOM_RESOURCE_NUMBER=1` renders the CRD, custom-resource, custom-resource lister, and cleanup steps.
  - `CL2_LIST_CUSTOM_RESOURCE_NUMBER=1 CL2_LIST_POD_NUMBER=1` renders the custom-resource segment followed by the pod segment.
- The rendered CRD and a sample rendered custom resource pass `kubectl apply --dry-run=server` against a local kind apiserver.
