### PR TITLE
clusterloader2: collect etcd-events pprof profiles in TestMetrics

### DIFF
--- a/clusterloader2/cmd/clusterloader.go
+++ b/clusterloader2/cmd/clusterloader.go
@@ -78,6 +78,7 @@ func initClusterFlags() {
 	flags.StringEnvVar(&clusterLoaderConfig.ClusterConfig.EtcdKeyPath, "etcd-key", "ETCD_KEY", "/etc/srv/kubernetes/pki/etcd-apiserver-server.key", "Path to the etcd key on the master machine")
 	flags.IntEnvVar(&clusterLoaderConfig.ClusterConfig.EtcdInsecurePort, "etcd-insecure-port", "ETCD_INSECURE_PORT", 2382, "Inscure http port")
 	flags.IntEnvVar(&clusterLoaderConfig.ClusterConfig.EtcdPprofPort, "etcd-pprof-port", "ETCD_PPROF_PORT", 2385, "Insecure http port serving etcd /debug/pprof (etcd --listen-client-http-urls)")
+	flags.IntEnvVar(&clusterLoaderConfig.ClusterConfig.EtcdEventsPprofPort, "etcd-events-pprof-port", "ETCD_EVENTS_PPROF_PORT", 2386, "Insecure http port serving etcd-events /debug/pprof (etcd --listen-client-http-urls)")
 	flags.BoolEnvVar(&clusterLoaderConfig.ClusterConfig.DeleteStaleNamespaces, "delete-stale-namespaces", "DELETE_STALE_NAMESPACES", false, "DEPRECATED: Whether to delete all stale namespaces before the test execution.")
 	err := flags.MarkDeprecated("delete-stale-namespaces", "specify deleteStaleNamespaces in testconfig file instead.")
 	if err != nil {

--- a/clusterloader2/pkg/config/cluster.go
+++ b/clusterloader2/pkg/config/cluster.go
@@ -44,6 +44,7 @@ type ClusterConfig struct {
 	EtcdKeyPath         string
 	EtcdInsecurePort    int
 	EtcdPprofPort       int
+	EtcdEventsPprofPort int
 	MasterIPs           []string
 	MasterInternalIPs   []string
 	MasterName          string

--- a/clusterloader2/pkg/measurement/common/bundle/test_metrics.go
+++ b/clusterloader2/pkg/measurement/common/bundle/test_metrics.go
@@ -60,6 +60,15 @@ func createTestMetricsMeasurement() measurement.Measurement {
 	if metrics.etcdBlockProfile, err = measurement.CreateMeasurement("BlockProfile"); err != nil {
 		klog.Errorf("%v: etcdBlockProfile creation error: %v", metrics, err)
 	}
+	if metrics.etcdEventsCPUProfile, err = measurement.CreateMeasurement("CPUProfile"); err != nil {
+		klog.Errorf("%v: etcdEventsCPUProfile creation error: %v", metrics, err)
+	}
+	if metrics.etcdEventsMemoryProfile, err = measurement.CreateMeasurement("MemoryProfile"); err != nil {
+		klog.Errorf("%v: etcdEventsMemoryProfile creation error: %v", metrics, err)
+	}
+	if metrics.etcdEventsBlockProfile, err = measurement.CreateMeasurement("BlockProfile"); err != nil {
+		klog.Errorf("%v: etcdEventsBlockProfile creation error: %v", metrics, err)
+	}
 	if metrics.apiserverCPUProfile, err = measurement.CreateMeasurement("CPUProfile"); err != nil {
 		klog.Errorf("%v: apiserverCPUProfile creation error: %v", metrics, err)
 	}
@@ -104,6 +113,9 @@ type testMetrics struct {
 	etcdCPUProfile                 measurement.Measurement
 	etcdMemoryProfile              measurement.Measurement
 	etcdBlockProfile               measurement.Measurement
+	etcdEventsCPUProfile           measurement.Measurement
+	etcdEventsMemoryProfile        measurement.Measurement
+	etcdEventsBlockProfile         measurement.Measurement
 	apiserverCPUProfile            measurement.Measurement
 	apiserverMemoryProfile         measurement.Measurement
 	apiserverBlockProfile          measurement.Measurement
@@ -144,6 +156,14 @@ func (t *testMetrics) Execute(config *measurement.Config) ([]measurement.Summary
 		"action":        "gather",
 		"componentName": "etcd",
 	})
+	etcdEventsStartConfig := createConfig(config, map[string]interface{}{
+		"action":        "start",
+		"componentName": "etcd-events",
+	})
+	etcdEventsGatherConfig := createConfig(config, map[string]interface{}{
+		"action":        "gather",
+		"componentName": "etcd-events",
+	})
 	kubeApiserverStartConfig := createConfig(config, map[string]interface{}{
 		"action":        "start",
 		"componentName": "kube-apiserver",
@@ -183,6 +203,12 @@ func (t *testMetrics) Execute(config *measurement.Config) ([]measurement.Summary
 		appendResults(&summaries, errList, summary, executeError(t.etcdMemoryProfile.String(), action, err))
 		summary, err = execute(t.etcdBlockProfile, etcdStartConfig)
 		appendResults(&summaries, errList, summary, executeError(t.etcdBlockProfile.String(), action, err))
+		summary, err = execute(t.etcdEventsCPUProfile, etcdEventsStartConfig)
+		appendResults(&summaries, errList, summary, executeError(t.etcdEventsCPUProfile.String(), action, err))
+		summary, err = execute(t.etcdEventsMemoryProfile, etcdEventsStartConfig)
+		appendResults(&summaries, errList, summary, executeError(t.etcdEventsMemoryProfile.String(), action, err))
+		summary, err = execute(t.etcdEventsBlockProfile, etcdEventsStartConfig)
+		appendResults(&summaries, errList, summary, executeError(t.etcdEventsBlockProfile.String(), action, err))
 		summary, err = execute(t.apiserverCPUProfile, kubeApiserverStartConfig)
 		appendResults(&summaries, errList, summary, executeError(t.apiserverCPUProfile.String(), action, err))
 		summary, err = execute(t.apiserverMemoryProfile, kubeApiserverStartConfig)
@@ -228,6 +254,12 @@ func (t *testMetrics) Execute(config *measurement.Config) ([]measurement.Summary
 		appendResults(&summaries, errList, summary, executeError(t.etcdMemoryProfile.String(), action, err))
 		summary, err = execute(t.etcdBlockProfile, etcdGatherConfig)
 		appendResults(&summaries, errList, summary, executeError(t.etcdBlockProfile.String(), action, err))
+		summary, err = execute(t.etcdEventsCPUProfile, etcdEventsGatherConfig)
+		appendResults(&summaries, errList, summary, executeError(t.etcdEventsCPUProfile.String(), action, err))
+		summary, err = execute(t.etcdEventsMemoryProfile, etcdEventsGatherConfig)
+		appendResults(&summaries, errList, summary, executeError(t.etcdEventsMemoryProfile.String(), action, err))
+		summary, err = execute(t.etcdEventsBlockProfile, etcdEventsGatherConfig)
+		appendResults(&summaries, errList, summary, executeError(t.etcdEventsBlockProfile.String(), action, err))
 		summary, err = execute(t.apiserverCPUProfile, kubeApiserverGatherConfig)
 		appendResults(&summaries, errList, summary, executeError(t.apiserverCPUProfile.String(), action, err))
 		summary, err = execute(t.apiserverMemoryProfile, kubeApiserverGatherConfig)
@@ -270,6 +302,9 @@ func (t *testMetrics) Dispose() {
 	t.etcdCPUProfile.Dispose()
 	t.etcdMemoryProfile.Dispose()
 	t.etcdBlockProfile.Dispose()
+	t.etcdEventsCPUProfile.Dispose()
+	t.etcdEventsMemoryProfile.Dispose()
+	t.etcdEventsBlockProfile.Dispose()
 	t.apiserverCPUProfile.Dispose()
 	t.apiserverMemoryProfile.Dispose()
 	t.apiserverBlockProfile.Dispose()

--- a/clusterloader2/pkg/measurement/common/profile.go
+++ b/clusterloader2/pkg/measurement/common/profile.go
@@ -225,19 +225,19 @@ func (p *profileMeasurement) shouldExposeAPIServerDebugEndpoint() bool {
 }
 
 func (p *profileMeasurement) getProfileCommand(config *measurement.Config) (string, error) {
-	profileProtocol, profilePort, err := config.ClusterFramework.GetClusterConfig().Provider.GetComponentProtocolAndPort(p.config.componentName)
+	clusterConfig := config.ClusterFramework.GetClusterConfig()
+	switch p.config.componentName {
+	case "etcd":
+		return fmt.Sprintf("curl -s http://localhost:%d/debug/pprof/%s", clusterConfig.EtcdPprofPort, p.config.kind), nil
+	case "etcd-events":
+		return fmt.Sprintf("curl -s http://localhost:%d/debug/pprof/%s", clusterConfig.EtcdEventsPprofPort, p.config.kind), nil
+	}
+
+	profileProtocol, profilePort, err := clusterConfig.Provider.GetComponentProtocolAndPort(p.config.componentName)
 	if err != nil {
 		return "", goerrors.Errorf("get profile command failed finding component protocol/port: %v", err)
 	}
-
-	var command string
-	if p.config.componentName == "etcd" {
-		command = fmt.Sprintf("curl -s http://localhost:%d/debug/pprof/%s", config.ClusterFramework.GetClusterConfig().EtcdPprofPort, p.config.kind)
-	} else {
-		command = fmt.Sprintf("curl -s -k %slocalhost:%v/debug/pprof/%s", profileProtocol, profilePort, p.config.kind)
-	}
-
-	return command, nil
+	return fmt.Sprintf("curl -s -k %slocalhost:%v/debug/pprof/%s", profileProtocol, profilePort, p.config.kind), nil
 }
 
 func exposeAPIServerDebugEndpoint(c clientset.Interface) error {


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
TestMetrics only profiles the main etcd. This also collects CPU/heap/block pprof from etcd-events, via a new --etcd-events-pprof-port flag (default 2386). The etcd-events pprof endpoint is already exposed by the kops scalability scenario: https://github.com/kubernetes/kops/blob/7a0fb7e7c2672507c73a89113e7eeba532cdd35b/tests/e2e/scenarios/scalability/run-test.sh#L90-L92

/assign @serathius