### PR TITLE
clusterloader2/testing/watch-list: scale up watch-list test to match 5K workload

### DIFF
--- a/clusterloader2/testing/overrides/watch_list_off.yaml
+++ b/clusterloader2/testing/overrides/watch_list_off.yaml
@@ -2,7 +2,7 @@
 # due to the size of the total payload
 CUSTOM_API_CALL_THRESHOLDS: |
   - verb: LIST
-    resource: secrets
+    resource: pods
     subresource: ''
-    scope: namespace
+    scope: cluster
     threshold: 60s

--- a/clusterloader2/testing/watch-list/clusterrole.yaml
+++ b/clusterloader2/testing/watch-list/clusterrole.yaml
@@ -1,8 +1,8 @@
-kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
 metadata:
   name: {{.Name}}
 rules:
   - apiGroups: [""]
-    resources: ["secrets"]
+    resources: ["pods"]
     verbs: ["get", "list", "watch"]

--- a/clusterloader2/testing/watch-list/clusterrolebinding.yaml
+++ b/clusterloader2/testing/watch-list/clusterrolebinding.yaml
@@ -1,11 +1,12 @@
-kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
 metadata:
   name: {{.Name}}
 subjects:
   - kind: ServiceAccount
     name: default
+    namespace: {{.JobNamespace}}
 roleRef:
-  kind: Role
+  kind: ClusterRole
   name: {{.Name}}
   apiGroup: rbac.authorization.k8s.io

--- a/clusterloader2/testing/watch-list/config.yaml
+++ b/clusterloader2/testing/watch-list/config.yaml
@@ -1,27 +1,29 @@
 {{$enableWatchListFeature := DefaultParam .CL2_ENABLE_WATCH_LIST_FEATURE false}}
-{{$testDuration := "5m"}}
 {{$customApiCallThresholds := DefaultParam .CUSTOM_API_CALL_THRESHOLDS ""}}
 {{$SINGLE_RESOURCE_API_LATENCY_THRESHOLD := DefaultParam .CL2_SINGLE_RESOURCE_API_LATENCY_THRESHOLD "1s"}}
+{{$namespaces := 165}}
+{{$podsPerNamespace := 1000}}
+{{$testDuration := "5m"}}
 name: watch-list
 namespace:
-  number: 1
+  number: {{$namespaces}}
   prefix: "watch-list"
 tuningSets:
-- name: Uniform10qps
+- name: Uniform500qps
   qpsLoad:
-    qps: 10
+    qps: 500
 steps:
-- name: Create secrets
+- name: Create pods
   phases:
   - namespaceRange:
       min: 1
-      max: 1
+      max: {{$namespaces}}
       basename: watch-list
-    replicasPerNamespace: 400
-    tuningSet: Uniform10qps
+    replicasPerNamespace: {{$podsPerNamespace}}
+    tuningSet: Uniform500qps
     objectBundle:
-    - basename: huge-secret
-      objectTemplatePath: "secret.yaml"
+    - basename: list-pod
+      objectTemplatePath: "pod.yaml"
 - name: Start measurements
   measurements:
     - Identifier: TestMetrics
@@ -37,19 +39,24 @@ steps:
       Method: APIResponsivenessPrometheus
       Params:
         action: start
-- name: Start the secret informers
+- name: Start the informers
   phases:
+    - replicasPerNamespace: 1
+      tuningSet: Uniform500qps
+      objectBundle:
+        - basename: watch-list-rbac
+          objectTemplatePath: clusterrole.yaml
+        - basename: watch-list-rbac
+          objectTemplatePath: clusterrolebinding.yaml
+          templateFillMap:
+            JobNamespace: watch-list-1
     - namespaceRange:
         min: 1
         max: 1
         basename: watch-list
-      replicasPerNamespace: 2
-      tuningSet: Uniform10qps
+      replicasPerNamespace: 1
+      tuningSet: Uniform500qps
       objectBundle:
-        - basename: watch-list-secret
-          objectTemplatePath: role.yaml
-        - basename: watch-list-secret
-          objectTemplatePath: roleBinding.yaml
         - basename: watch-list
           objectTemplatePath: "job.yaml"
           templateFillMap:
@@ -74,7 +81,7 @@ steps:
     - Identifier: WaitForRunningWatchListJobs
     Params:
       action: gather
-- name: Wait for the secret informer job to finish
+- name: Wait for the informer job to finish
   measurements:
     - Identifier: WaitForFinishedJobs
       Method: WaitForFinishedJobs

--- a/clusterloader2/testing/watch-list/job.yaml
+++ b/clusterloader2/testing/watch-list/job.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       containers:
         - name: {{.Name}}
-          image: gcr.io/k8s-staging-perf-tests/watch-list:v0.0.1
+          image: gcr.io/k8s-staging-perf-tests/watch-list:v0.0.4
           resources:
             requests:
               memory: "16Gi"
@@ -21,5 +21,5 @@ spec:
               memory: "16Gi"
               cpu: "6"
           command: [ "watch-list" ]
-          args: [ "--alsologtostderr=true", "--v=4", "--timeout={{.Duration}}", "--count=16", "--namespace=watch-list-1", "--enableWatchListFeature={{.EnableWatchListFeature}}"]
+          args: [ "--alsologtostderr=true", "--v=4", "--timeout={{.Duration}}", "--count=1", "--resource=pods", "--enableWatchListFeature={{.EnableWatchListFeature}}"]
       restartPolicy: Never

--- a/clusterloader2/testing/watch-list/pod.yaml
+++ b/clusterloader2/testing/watch-list/pod.yaml
@@ -1,0 +1,132 @@
+{{$group := DefaultParam .group .Name}}
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{.Name}}
+  labels:
+    group: {{$group}}
+    app.kubernetes.io/name: "payment-service"
+    app.kubernetes.io/instance: "payment-service-primary"
+    app.kubernetes.io/version: "v2.1.4"
+    app.kubernetes.io/component: "backend"
+    app.kubernetes.io/part-of: "ecommerce-platform"
+    env: "production"
+    track: "canary"
+  annotations:
+    prometheus.io/scrape: "false"
+    prometheus.io/port: "8080"
+    prometheus.io/path: "/metrics"
+    sidecar.istio.io/inject: "false"
+    cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
+    vault.hashicorp.com/agent-inject: "false"
+    vault.hashicorp.com/role: "my-app-db-role"
+    fluentbit.io/parser: "json"
+    argocd.argoproj.io/hook: "PreSync"
+    argocd.argoproj.io/hook-delete-policy: "HookSucceeded"
+spec:
+  schedulerName: "do-not-schedule"
+  initContainers:
+  - name: init-0
+    image: registry.k8s.io/e2e-test-images/agnhost:2.53
+    command: ["/bin/sh", "-c", "sleep 1"]
+  - name: init-1
+    image: registry.k8s.io/e2e-test-images/agnhost:2.53
+    command: ["/bin/sh", "-c", "sleep 1"]
+  containers:
+  - name: main
+    image: registry.k8s.io/pause:3.9
+    env:
+    - name: POD_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.name
+    - name: POD_NAMESPACE
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
+    - name: NODE_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: spec.nodeName
+    - name: POD_IP
+      valueFrom:
+        fieldRef:
+          fieldPath: status.podIP
+    - name: GOMAXPROCS
+      valueFrom:
+        resourceFieldRef:
+          containerName: main
+          resource: limits.cpu
+    - name: GOMEMLIMIT
+      valueFrom:
+        resourceFieldRef:
+          containerName: main
+          resource: limits.memory
+    - name: JAVA_TOOL_OPTIONS
+      value: "-XX:MaxRAMPercentage=75.0"
+    - name: REDIS_URL
+      value: "redis://main:6379/0"
+    - name: PYTHONUNBUFFERED
+      value: "1"
+    - name: NODE_ENV
+      value: "prod"
+    resources:
+      requests:
+        cpu: 5m
+        memory: 20M
+    volumeMounts:
+    - mountPath: /var/configmap
+      name: configmap
+    - mountPath: /var/secret
+      name: secret
+  - name: sidecar
+    image: registry.k8s.io/pause:3.9
+    env:
+    - name: POD_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.name
+    - name: POD_NAMESPACE
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
+    - name: NODE_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: spec.nodeName
+    - name: POD_IP
+      valueFrom:
+        fieldRef:
+          fieldPath: status.podIP
+    - name: GOMAXPROCS
+      valueFrom:
+        resourceFieldRef:
+          containerName: sidecar
+          resource: limits.cpu
+    - name: GOMEMLIMIT
+      valueFrom:
+        resourceFieldRef:
+          containerName: sidecar
+          resource: limits.memory
+    - name: JAVA_TOOL_OPTIONS
+      value: "-XX:MaxRAMPercentage=75.0"
+    - name: REDIS_URL
+      value: "redis://main:6379/0"
+    - name: PYTHONUNBUFFERED
+      value: "1"
+    - name: NODE_ENV
+      value: "prod"
+    resources:
+      requests:
+        cpu: 5m
+        memory: 20M
+  volumes:
+  - name: configmap
+    configMap:
+      name: {{.Name}}
+      optional: true
+  - name: secret
+    secret:
+      secretName: {{.Name}}
+      optional: true

--- a/clusterloader2/testing/watch-list/secret.yaml
+++ b/clusterloader2/testing/watch-list/secret.yaml
@@ -1,9 +1,0 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {{.Name}}
-type: Opaque
-stringData:
-# To get 1MB of payload we need:
-# 1 mln(bytes)/1.33 (base64 after serialisation is ~30% increase) = ~760K bytes
-  password: {{RandData 760000}}


### PR DESCRIPTION
Before: 400 secrets (1MB each) in 1 namespace, 2 jobs with 16 informers each.

After: 165K pods (~10KB each) across 165 namespaces, 1 job with 1 informer. Pods use schedulerName: "do-not-schedule" so they stay Pending without creating scheduler load. This gives ~1.5GB of total data and ~165K watch events, matching the pod count and payload size in the 5K scale test.


