### PR TITLE
clusterloader2/testing/watch-list: scale down to 10K pods

### DIFF
--- a/clusterloader2/testing/watch-list/config.yaml
+++ b/clusterloader2/testing/watch-list/config.yaml
@@ -1,7 +1,7 @@
 {{$enableWatchListFeature := DefaultParam .CL2_ENABLE_WATCH_LIST_FEATURE false}}
 {{$customApiCallThresholds := DefaultParam .CUSTOM_API_CALL_THRESHOLDS ""}}
 {{$SINGLE_RESOURCE_API_LATENCY_THRESHOLD := DefaultParam .CL2_SINGLE_RESOURCE_API_LATENCY_THRESHOLD "1s"}}
-{{$namespaces := 165}}
+{{$namespaces := 10}}
 {{$podsPerNamespace := 1000}}
 {{$testDuration := "5m"}}
 name: watch-list


### PR DESCRIPTION
scale down watch-list benchmark from 165K pods to 10K pods.
successfully run on a remote machine.