### PR TITLE
WaitForGenericK8sObjects: add support for empty conditions

### DIFF
--- a/clusterloader2/pkg/framework/framework.go
+++ b/clusterloader2/pkg/framework/framework.go
@@ -95,6 +95,15 @@ func newFramework(clusterConfig *config.ClusterConfig, clientsNumber int, kubeCo
 	return &f, nil
 }
 
+// NewFrameworkFromClients creates new Framework with given clientSets and dynamicClients for testing.
+func NewFrameworkFromClients(clientSets *MultiClientSet, dynamicClients *MultiDynamicClient) *Framework {
+	return &Framework{
+		automanagedNamespaces: map[string]bool{},
+		clientSets:            clientSets,
+		dynamicClients:        dynamicClients,
+	}
+}
+
 // GetAutomanagedNamespacePrefix returns automanaged namespace prefix.
 func (f *Framework) GetAutomanagedNamespacePrefix() string {
 	return f.automanagedNamespacePrefix

--- a/clusterloader2/pkg/framework/multiclient.go
+++ b/clusterloader2/pkg/framework/multiclient.go
@@ -96,3 +96,10 @@ func (m *MultiDynamicClient) GetClient() dynamic.Interface {
 	m.current = (m.current + 1) % len(m.clients)
 	return m.clients[m.current]
 }
+
+// NewMultiDynamicClientFromClients creates new MultiDynamicClient for given slice of dynamic clients.
+func NewMultiDynamicClientFromClients(clients ...dynamic.Interface) *MultiDynamicClient {
+	return &MultiDynamicClient{
+		clients: clients,
+	}
+}

--- a/clusterloader2/pkg/measurement/common/wait_for_generic_k8s_object.go
+++ b/clusterloader2/pkg/measurement/common/wait_for_generic_k8s_object.go
@@ -68,21 +68,13 @@ func (w *waitForGenericK8sObjectsMeasurement) Execute(config *measurement.Config
 	if err != nil {
 		return nil, err
 	}
-	successfulConditions, err := util.GetStringArray(config.Params, "successfulConditions")
+	successfulConditions, err := util.GetStringArrayOrDefault(config.Params, "successfulConditions", []string{})
 	if err != nil {
-		if util.IsErrKeyNotFound(err) {
-			successfulConditions = []string{}
-		} else {
-			return nil, err
-		}
+		return nil, err
 	}
-	failedConditions, err := util.GetStringArray(config.Params, "failedConditions")
+	failedConditions, err := util.GetStringArrayOrDefault(config.Params, "failedConditions", []string{})
 	if err != nil {
-		if util.IsErrKeyNotFound(err) {
-			failedConditions = []string{}
-		} else {
-			return nil, err
-		}
+		return nil, err
 	}
 	minDesiredObjectCount, err := util.GetInt(config.Params, "minDesiredObjectCount")
 	if err != nil {

--- a/clusterloader2/pkg/measurement/common/wait_for_generic_k8s_object.go
+++ b/clusterloader2/pkg/measurement/common/wait_for_generic_k8s_object.go
@@ -70,17 +70,25 @@ func (w *waitForGenericK8sObjectsMeasurement) Execute(config *measurement.Config
 	}
 	successfulConditions, err := util.GetStringArray(config.Params, "successfulConditions")
 	if err != nil {
-		return nil, err
+		if util.IsErrKeyNotFound(err) {
+			successfulConditions = []string{}
+		} else {
+			return nil, err
+		}
 	}
 	failedConditions, err := util.GetStringArray(config.Params, "failedConditions")
 	if err != nil {
-		return nil, err
+		if util.IsErrKeyNotFound(err) {
+			failedConditions = []string{}
+		} else {
+			return nil, err
+		}
 	}
 	minDesiredObjectCount, err := util.GetInt(config.Params, "minDesiredObjectCount")
 	if err != nil {
 		return nil, err
 	}
-	maxFailedObjectCount, err := util.GetInt(config.Params, "maxFailedObjectCount")
+	maxFailedObjectCount, err := util.GetIntOrDefault(config.Params, "maxFailedObjectCount", 0)
 	if err != nil {
 		return nil, err
 	}

--- a/clusterloader2/pkg/measurement/common/wait_for_generic_k8s_object_test.go
+++ b/clusterloader2/pkg/measurement/common/wait_for_generic_k8s_object_test.go
@@ -17,10 +17,18 @@ limitations under the License.
 package common
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic/fake"
+	"k8s.io/perf-tests/clusterloader2/pkg/framework"
+	"k8s.io/perf-tests/clusterloader2/pkg/measurement"
 	measurementutil "k8s.io/perf-tests/clusterloader2/pkg/measurement/util"
 )
 
@@ -140,4 +148,63 @@ func TestGetLabelSelector(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestWaitForGenericK8sObjectsMeasurement_Execute_OmittedConditions(t *testing.T) {
+	fakeClient := fake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), map[schema.GroupVersionResource]string{
+		{Group: "", Version: "v1", Resource: "pods"}: "PodList",
+	})
+
+	pod1 := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Pod",
+			"metadata": map[string]interface{}{
+				"name":      "pod-1",
+				"namespace": "test-ns-0",
+			},
+		},
+	}
+	pod2 := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Pod",
+			"metadata": map[string]interface{}{
+				"name":      "pod-2",
+				"namespace": "test-ns-0",
+			},
+		},
+	}
+
+	ctx := context.Background()
+	gvr := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}
+	_, err := fakeClient.Resource(gvr).Namespace("test-ns-0").Create(ctx, pod1, metav1.CreateOptions{})
+	assert.NoError(t, err)
+	_, err = fakeClient.Resource(gvr).Namespace("test-ns-0").Create(ctx, pod2, metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	multiDynamic := framework.NewMultiDynamicClientFromClients(fakeClient)
+	clusterFramework := framework.NewFrameworkFromClients(nil, multiDynamic)
+
+	m := createWaitForGenericK8sObjectsMeasurement()
+	config := &measurement.Config{
+		ClusterFramework: clusterFramework,
+		Params: map[string]interface{}{
+			"objectGroup":           "",
+			"objectVersion":         "v1",
+			"objectResource":        "pods",
+			"minDesiredObjectCount": 2,
+			"refreshInterval":       "100ms",
+			"timeout":               "1s",
+			"namespaceRange": map[string]interface{}{
+				"prefix": "test-ns",
+				"min":    0,
+				"max":    0,
+			},
+		},
+	}
+
+	summaries, err := m.Execute(config)
+	assert.NoError(t, err)
+	assert.Nil(t, summaries)
 }

--- a/clusterloader2/pkg/measurement/util/wait_for_conditions.go
+++ b/clusterloader2/pkg/measurement/util/wait_for_conditions.go
@@ -103,31 +103,34 @@ func WaitForGenericK8sObjects(ctx context.Context, dynamicClient dynamic.Interfa
 		return err
 	}
 
-	objects, err := store.ListObjectSimplifications()
-	if err != nil {
-		return err
-	}
-	successful, failed, count := countObjectsMatchingConditions(objects, options.SuccessfulConditions, options.FailedConditions)
+	var successful, failed []string
+	var count int
+
 	for {
+		objects, err := store.ListObjectSimplifications()
+		if err != nil {
+			return err
+		}
+		successful, failed, count = countObjectsMatchingConditions(objects, options.SuccessfulConditions, options.FailedConditions)
+		klog.V(2).Infof("%s: successful=%d failed=%d count=%d", options.Summary(), len(successful), len(failed), count)
+
+		if len(options.SuccessfulConditions) == 0 && len(options.FailedConditions) == 0 {
+			if options.MinDesiredObjectCount <= count {
+				return nil
+			}
+		} else if options.MinDesiredObjectCount <= len(successful)+len(failed) {
+			if options.MaxFailedObjectCount < len(failed) {
+				return fmt.Errorf("%s: too many failed objects, expected at most %d - currently there are: successful=%d failed=%d count=%d failed-objects=[%s]",
+					options.Summary(), options.MaxFailedObjectCount, len(successful), len(failed), count, strings.Join(failed, ","))
+			}
+			return nil
+		}
+
 		select {
 		case <-ctx.Done():
 			return fmt.Errorf("%s: timeout while waiting for %d objects to be successful or failed - currently there are: successful=%d failed=%d count=%d",
 				options.Summary(), options.MinDesiredObjectCount, len(successful), len(failed), count)
 		case <-time.After(options.WaitInterval):
-			objects, err := store.ListObjectSimplifications()
-			if err != nil {
-				return err
-			}
-			successful, failed, count = countObjectsMatchingConditions(objects, options.SuccessfulConditions, options.FailedConditions)
-
-			klog.V(2).Infof("%s: successful=%d failed=%d count=%d", options.Summary(), len(successful), len(failed), count)
-			if options.MinDesiredObjectCount <= len(successful)+len(failed) {
-				if options.MaxFailedObjectCount < len(failed) {
-					return fmt.Errorf("%s: too many failed objects, expected at most %d - currently there are: successful=%d failed=%d count=%d failed-objects=[%s]",
-						options.Summary(), options.MaxFailedObjectCount, len(successful), len(failed), count, strings.Join(failed, ","))
-				}
-				return nil
-			}
 		}
 	}
 }

--- a/clusterloader2/pkg/measurement/util/wait_for_conditions_test.go
+++ b/clusterloader2/pkg/measurement/util/wait_for_conditions_test.go
@@ -261,6 +261,32 @@ func TestWaitForGenericK8sObjects(t *testing.T) {
 				}),
 			},
 		},
+		{
+			name:    "objects created with empty conditions (no conditions specified)",
+			timeout: 1 * time.Second,
+			options: &WaitForGenericK8sObjectsOptions{
+				GroupVersionResource: schema.GroupVersionResource{
+					Group:    "kubernetes.io",
+					Version:  "v1alpha1",
+					Resource: "Conditions",
+				},
+				Namespaces: NamespacesRange{
+					Prefix: "namespace",
+					Min:    1,
+					Max:    1,
+				},
+				SuccessfulConditions:  []string{},
+				FailedConditions:      []string{},
+				MinDesiredObjectCount: 2,
+				MaxFailedObjectCount:  0,
+				CallerName:            "test",
+				WaitInterval:          100 * time.Millisecond,
+			},
+			existingObjects: []exampleObject{
+				newExampleObject("test-1", "namespace-1", []interface{}{}),
+				newExampleObject("test-2", "namespace-1", []interface{}{}),
+			},
+		},
 	}
 	for _, tt := range tests {
 		tt := tt

--- a/clusterloader2/pkg/util/util.go
+++ b/clusterloader2/pkg/util/util.go
@@ -95,6 +95,15 @@ func GetStringArray(dict map[string]interface{}, key string) ([]string, error) {
 	return getStringArray(dict, key)
 }
 
+// GetStringArrayOrDefault tries to return value from map cast to a []string type. If value doesn't exist default value is used.
+func GetStringArrayOrDefault(dict map[string]interface{}, key string, defaultValue []string) ([]string, error) {
+	value, err := getStringArray(dict, key)
+	if IsErrKeyNotFound(err) {
+		return defaultValue, nil
+	}
+	return value, err
+}
+
 // GetLabelSelector tries to return value from map parsed as labels.Selector type. If value doesn't exist, error is returned.
 func GetLabelSelector(dict map[string]interface{}, key string) (*labels.Selector, error) {
 	return getLabelSelector(dict, key)

--- a/clusterloader2/pkg/util/util_test.go
+++ b/clusterloader2/pkg/util/util_test.go
@@ -278,3 +278,48 @@ func TestGetBool(t *testing.T) {
 		})
 	}
 }
+
+func TestGetStringArrayOrDefault(t *testing.T) {
+	tests := []struct {
+		name         string
+		dict         map[string]interface{}
+		key          string
+		defaultValue []string
+		want         []string
+		wantErr      bool
+	}{
+		{
+			name:         "key present",
+			dict:         map[string]interface{}{"conditions": []interface{}{"ConditionA=True", "ConditionB=True"}},
+			key:          "conditions",
+			defaultValue: []string{},
+			want:         []string{"ConditionA=True", "ConditionB=True"},
+		},
+		{
+			name:         "key missing - returns default",
+			dict:         map[string]interface{}{},
+			key:          "conditions",
+			defaultValue: []string{"DefaultCond=True"},
+			want:         []string{"DefaultCond=True"},
+		},
+		{
+			name:         "key missing - returns empty default",
+			dict:         map[string]interface{}{},
+			key:          "conditions",
+			defaultValue: []string{},
+			want:         []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetStringArrayOrDefault(tt.dict, tt.key, tt.defaultValue)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetStringArrayOrDefault() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !tt.wantErr {
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Adds support for simply waiting for the given pods to become created, without anything else.
