### PR TITLE
Do not log HTTP status code in case of error

### DIFF
--- a/clusterloader2/pkg/measurement/common/api_availability_measurement.go
+++ b/clusterloader2/pkg/measurement/common/api_availability_measurement.go
@@ -112,12 +112,14 @@ func (a *apiAvailabilityMeasurement) pollHost(hostIP string) (string, error) {
 func (a *apiAvailabilityMeasurement) updateClusterAvailabilityMetrics(c clientset.Interface) {
 	result := c.CoreV1().RESTClient().Get().AbsPath("/readyz").Do(context.Background())
 	status := 0
-	result.StatusCode(&status)
-	availability := status == http.StatusOK
-	if !availability {
-		klog.Warningf("cluster not available; HTTP status code: %d", status)
-		if err := result.Error(); err != nil {
-			klog.Warningf("request error: %v", err)
+	availability := false
+	if err := result.Error(); err != nil {
+		klog.Warningf("cluster not available; request error: %v", err)
+	} else {
+		result.StatusCode(&status)
+		availability = status == http.StatusOK
+		if !availability {
+			klog.Warningf("cluster not available; HTTP status code: %d", status)
 		}
 	}
 	a.clusterLevelMetrics.update(availability)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Due to a bug in the HTTP client library, the HTTP status code is not returned correctly and should not be logged in case of an error.
