### PR TITLE
Optimize WaitForGenericK8sObjects

### DIFF
--- a/clusterloader2/pkg/framework/multiclient.go
+++ b/clusterloader2/pkg/framework/multiclient.go
@@ -103,3 +103,10 @@ func NewMultiDynamicClientFromClients(clients ...dynamic.Interface) *MultiDynami
 		clients: clients,
 	}
 }
+
+// NewMultiClientSetFromClients creates new MultiClientSet for given slice of typed clients.
+func NewMultiClientSetFromClients(clients ...clientset.Interface) *MultiClientSet {
+	return &MultiClientSet{
+		clients: clients,
+	}
+}

--- a/clusterloader2/pkg/measurement/common/wait_for_generic_k8s_object.go
+++ b/clusterloader2/pkg/measurement/common/wait_for_generic_k8s_object.go
@@ -18,10 +18,14 @@ package common
 
 import (
 	"context"
+	"fmt"
 	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic/dynamicinformer"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 	"k8s.io/perf-tests/clusterloader2/pkg/measurement"
 	measurementutil "k8s.io/perf-tests/clusterloader2/pkg/measurement/util"
@@ -89,7 +93,6 @@ func (w *waitForGenericK8sObjectsMeasurement) Execute(config *measurement.Config
 		return nil, err
 	}
 
-	dynamicClient := config.ClusterFramework.GetDynamicClients().GetClient()
 	ctx, cancel := context.WithTimeout(context.TODO(), timeout)
 	defer cancel()
 
@@ -104,7 +107,31 @@ func (w *waitForGenericK8sObjectsMeasurement) Execute(config *measurement.Config
 		CallerName:            w.String(),
 		WaitInterval:          refreshInterval,
 	}
-	return nil, measurementutil.WaitForGenericK8sObjects(ctx, dynamicClient, options)
+
+	// Special fast path for performance-critical resource type: pods.
+	if groupVersionResource.Resource == "pods" && groupVersionResource.Group == "" && groupVersionResource.Version == "v1" {
+		klog.V(2).Infof("%s: Using optimized typed pod informer", waitForGenericK8sObjectsMeasurementName)
+		typedClient := config.ClusterFramework.GetClientSets().GetClient()
+		podsIndexer, err := podIndexerFactory.PodsIndexer(typedClient)
+		if err != nil {
+			return nil, fmt.Errorf("failed to retrieve shared pods indexer: %w", err)
+		}
+		options.GenericLister = cache.NewGenericLister(podsIndexer.GetIndexer(), groupVersionResource.GroupResource())
+	} else {
+		klog.V(2).Infof("%s: Using dynamic informer", waitForGenericK8sObjectsMeasurementName)
+		dynamicClient := config.ClusterFramework.GetDynamicClients().GetClient()
+		tweakListOptions := func(listOptions *metav1.ListOptions) {
+			if labelSelector != nil {
+				listOptions.LabelSelector = labelSelector.String()
+			}
+		}
+		informerFactory := dynamicinformer.NewFilteredDynamicSharedInformerFactory(dynamicClient, 10*time.Second, metav1.NamespaceAll, tweakListOptions)
+		options.GenericLister = informerFactory.ForResource(groupVersionResource).Lister()
+		informerFactory.Start(ctx.Done())
+		informerFactory.WaitForCacheSync(ctx.Done())
+	}
+
+	return nil, measurementutil.WaitForGenericK8sObjects(ctx, options)
 }
 
 // Dispose cleans up after the measurement.

--- a/clusterloader2/pkg/measurement/common/wait_for_generic_k8s_object_test.go
+++ b/clusterloader2/pkg/measurement/common/wait_for_generic_k8s_object_test.go
@@ -17,16 +17,16 @@ limitations under the License.
 package common
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic/fake"
+	fakeclientset "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/perf-tests/clusterloader2/pkg/framework"
 	"k8s.io/perf-tests/clusterloader2/pkg/measurement"
 	measurementutil "k8s.io/perf-tests/clusterloader2/pkg/measurement/util"
@@ -155,36 +155,23 @@ func TestWaitForGenericK8sObjectsMeasurement_Execute_OmittedConditions(t *testin
 		{Group: "", Version: "v1", Resource: "pods"}: "PodList",
 	})
 
-	pod1 := &unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"apiVersion": "v1",
-			"kind":       "Pod",
-			"metadata": map[string]interface{}{
-				"name":      "pod-1",
-				"namespace": "test-ns-0",
-			},
+	pod1 := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod-1",
+			Namespace: "test-ns-0",
 		},
 	}
-	pod2 := &unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"apiVersion": "v1",
-			"kind":       "Pod",
-			"metadata": map[string]interface{}{
-				"name":      "pod-2",
-				"namespace": "test-ns-0",
-			},
+	pod2 := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod-2",
+			Namespace: "test-ns-0",
 		},
 	}
-
-	ctx := context.Background()
-	gvr := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}
-	_, err := fakeClient.Resource(gvr).Namespace("test-ns-0").Create(ctx, pod1, metav1.CreateOptions{})
-	assert.NoError(t, err)
-	_, err = fakeClient.Resource(gvr).Namespace("test-ns-0").Create(ctx, pod2, metav1.CreateOptions{})
-	assert.NoError(t, err)
 
 	multiDynamic := framework.NewMultiDynamicClientFromClients(fakeClient)
-	clusterFramework := framework.NewFrameworkFromClients(nil, multiDynamic)
+	fakeTypedClient := fakeclientset.NewSimpleClientset(pod1, pod2)
+	multiClientSet := framework.NewMultiClientSetFromClients(fakeTypedClient)
+	clusterFramework := framework.NewFrameworkFromClients(multiClientSet, multiDynamic)
 
 	m := createWaitForGenericK8sObjectsMeasurement()
 	config := &measurement.Config{

--- a/clusterloader2/pkg/measurement/util/controlled_pods_indexer.go
+++ b/clusterloader2/pkg/measurement/util/controlled_pods_indexer.go
@@ -71,6 +71,11 @@ func deletionHandlingUIDKeyFunc(obj interface{}) (string, error) {
 	return string(getObjUID(obj)), nil
 }
 
+// GetIndexer returns the underlying pods indexer.
+func (p *ControlledPodsIndexer) GetIndexer() cache.Indexer {
+	return p.podsIndexer
+}
+
 // NewControlledPodsIndexer creates a new ControlledPodsIndexer instance.
 func NewControlledPodsIndexer(podsInformer coreinformers.PodInformer, rsInformer appsinformers.ReplicaSetInformer) (*ControlledPodsIndexer, error) {
 	if err := podsInformer.Informer().AddIndexers(cache.Indexers{controllerUIDIndex: controllerUIDIndexFunc}); err != nil {

--- a/clusterloader2/pkg/measurement/util/object_store_dynamic.go
+++ b/clusterloader2/pkg/measurement/util/object_store_dynamic.go
@@ -22,64 +22,35 @@ with slight changes regarding labelSelector and flagSelector applied.
 package util
 
 import (
-	"context"
-	"encoding/json"
 	"fmt"
-	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/dynamic"
-	"k8s.io/client-go/dynamic/dynamicinformer"
 	"k8s.io/client-go/tools/cache"
 )
 
-const (
-	defaultResyncInterval = 10 * time.Second
-)
-
-// DynamicObjectStore is a convenient wrapper around cache.GenericLister.
-type DynamicObjectStore struct {
-	cache.GenericLister
-	namespaces    map[string]bool
-	allNamespaces bool
-}
-
-// NewDynamicObjectStore creates DynamicObjectStore based on given object version resource and selector.
-func NewDynamicObjectStore(ctx context.Context, dynamicClient dynamic.Interface, gvr schema.GroupVersionResource, namespaces map[string]bool, labelSelector labels.Selector) (*DynamicObjectStore, error) {
-	tweakListOptions := func(options *metav1.ListOptions) {
-		if labelSelector != nil {
-			options.LabelSelector = labelSelector.String()
-		}
+// ListObjectSimplifications returns a list of simplified objects using the provided lister.
+func ListObjectSimplifications(lister cache.GenericLister, namespaces map[string]bool, labelSelector labels.Selector) ([]ObjectSimplification, error) {
+	selector := labels.Everything()
+	if labelSelector != nil {
+		selector = labelSelector
 	}
-	informerFactory := dynamicinformer.NewFilteredDynamicSharedInformerFactory(dynamicClient, defaultResyncInterval, metav1.NamespaceAll, tweakListOptions)
-	lister := informerFactory.ForResource(gvr).Lister()
-	informerFactory.Start(ctx.Done())
-	informerFactory.WaitForCacheSync(ctx.Done())
-
-	return &DynamicObjectStore{
-		GenericLister: lister,
-		namespaces:    namespaces,
-		allNamespaces: len(namespaces) == 0,
-	}, nil
-}
-
-// ListObjectSimplifications returns list of objects with conditions for each object that was returned by lister.
-func (s *DynamicObjectStore) ListObjectSimplifications() ([]ObjectSimplification, error) {
-	objects, err := s.GenericLister.List(labels.Everything())
+	objects, err := lister.List(selector)
 	if err != nil {
 		return nil, err
 	}
 
+	allNamespaces := len(namespaces) == 0
 	result := make([]ObjectSimplification, 0, len(objects))
 	for _, o := range objects {
 		os, err := getObjectSimplification(o)
 		if err != nil {
 			return nil, err
 		}
-		if !s.allNamespaces && !s.namespaces[os.Metadata.Namespace] {
+		if !allNamespaces && !namespaces[os.Metadata.Namespace] {
 			continue
 		}
 		result = append(result, os)
@@ -105,17 +76,56 @@ func (o ObjectSimplification) String() string {
 }
 
 func getObjectSimplification(o runtime.Object) (ObjectSimplification, error) {
-	dataMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(o)
-	if err != nil {
-		return ObjectSimplification{}, err
+	// Fast path for typed Pods
+	if pod, ok := o.(*corev1.Pod); ok {
+		var conditions []metav1.Condition
+		for _, c := range pod.Status.Conditions {
+			conditions = append(conditions, metav1.Condition{
+				Type:   string(c.Type),
+				Status: metav1.ConditionStatus(c.Status),
+			})
+		}
+		return ObjectSimplification{
+			Metadata: metav1.ObjectMeta{
+				Name:      pod.Name,
+				Namespace: pod.Namespace,
+			},
+			Status: StatusWithConditions{
+				Conditions: conditions,
+			},
+		}, nil
 	}
 
-	jsonBytes, err := json.Marshal(dataMap)
-	if err != nil {
-		return ObjectSimplification{}, err
+	u, ok := o.(*unstructured.Unstructured)
+	if !ok {
+		dataMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(o)
+		if err != nil {
+			return ObjectSimplification{}, err
+		}
+		u = &unstructured.Unstructured{Object: dataMap}
 	}
 
-	object := ObjectSimplification{}
-	err = json.Unmarshal(jsonBytes, &object)
-	return object, err
+	conditionsSlice, _, _ := unstructured.NestedSlice(u.Object, "status", "conditions")
+	var conditions []metav1.Condition
+	for _, c := range conditionsSlice {
+		cMap, ok := c.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		cType, _ := cMap["type"].(string)
+		cStatus, _ := cMap["status"].(string)
+		conditions = append(conditions, metav1.Condition{
+			Type:   cType,
+			Status: metav1.ConditionStatus(cStatus),
+		})
+	}
+	return ObjectSimplification{
+		Metadata: metav1.ObjectMeta{
+			Name:      u.GetName(),
+			Namespace: u.GetNamespace(),
+		},
+		Status: StatusWithConditions{
+			Conditions: conditions,
+		},
+	}, nil
 }

--- a/clusterloader2/pkg/measurement/util/object_store_dynamic_test.go
+++ b/clusterloader2/pkg/measurement/util/object_store_dynamic_test.go
@@ -23,11 +23,13 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic/dynamicinformer"
 	"k8s.io/client-go/dynamic/fake"
 )
 
@@ -62,22 +64,19 @@ func TestDynamicObjectStore_AllNamespaces(t *testing.T) {
 	}
 
 	tests := []struct {
-		name          string
-		namespaces    map[string]bool
-		wantNames     []string
-		wantAllNsFlag bool
+		name       string
+		namespaces map[string]bool
+		wantNames  []string
 	}{
 		{
-			name:          "allNamespaces enabled when namespaces map is empty",
-			namespaces:    map[string]bool{},
-			wantNames:     []string{"ns-1/item-1", "ns-2/item-2"},
-			wantAllNsFlag: true,
+			name:       "allNamespaces enabled when namespaces map is empty",
+			namespaces: map[string]bool{},
+			wantNames:  []string{"ns-1/item-1", "ns-2/item-2"},
 		},
 		{
-			name:          "allNamespaces disabled when specific namespaces are provided",
-			namespaces:    map[string]bool{"ns-1": true},
-			wantNames:     []string{"ns-1/item-1"},
-			wantAllNsFlag: false,
+			name:       "allNamespaces disabled when specific namespaces are provided",
+			namespaces: map[string]bool{"ns-1": true},
+			wantNames:  []string{"ns-1/item-1"},
 		},
 	}
 
@@ -95,11 +94,12 @@ func TestDynamicObjectStore_AllNamespaces(t *testing.T) {
 			_, err = dynamicClient.Resource(gvr).Namespace("ns-2").Create(ctx, obj2, metav1.CreateOptions{})
 			require.NoError(t, err)
 
-			store, err := NewDynamicObjectStore(ctx, dynamicClient, gvr, tt.namespaces, nil)
-			require.NoError(t, err)
-			assert.Equal(t, tt.wantAllNsFlag, store.allNamespaces)
+			informerFactory := dynamicinformer.NewFilteredDynamicSharedInformerFactory(dynamicClient, 10*time.Second, metav1.NamespaceAll, nil)
+			lister := informerFactory.ForResource(gvr).Lister()
+			informerFactory.Start(ctx.Done())
+			informerFactory.WaitForCacheSync(ctx.Done())
 
-			results, err := store.ListObjectSimplifications()
+			results, err := ListObjectSimplifications(lister, tt.namespaces, nil)
 			require.NoError(t, err)
 
 			gotNames := make([]string, 0, len(results))
@@ -160,11 +160,60 @@ func TestDynamicObjectStore_LabelSelector(t *testing.T) {
 	require.NoError(t, err)
 
 	labelSelector := labels.SelectorFromSet(labels.Set{"app": "worker"})
-	store, err := NewDynamicObjectStore(ctx, dynamicClient, gvr, map[string]bool{"ns-1": true}, labelSelector)
-	require.NoError(t, err)
 
-	results, err := store.ListObjectSimplifications()
+	tweakListOptions := func(options *metav1.ListOptions) {
+		options.LabelSelector = labelSelector.String()
+	}
+	informerFactory := dynamicinformer.NewFilteredDynamicSharedInformerFactory(dynamicClient, 10*time.Second, metav1.NamespaceAll, tweakListOptions)
+	lister := informerFactory.ForResource(gvr).Lister()
+	informerFactory.Start(ctx.Done())
+	informerFactory.WaitForCacheSync(ctx.Done())
+
+	results, err := ListObjectSimplifications(lister, map[string]bool{"ns-1": true}, labelSelector)
 	require.NoError(t, err)
 	require.Len(t, results, 1)
 	assert.Equal(t, "ns-1/matching-item", results[0].String())
+}
+
+func getMockPod() *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "default",
+		},
+		Status: corev1.PodStatus{
+			Conditions: []corev1.PodCondition{
+				{
+					Type:   corev1.PodReady,
+					Status: corev1.ConditionTrue,
+				},
+				{
+					Type:   corev1.PodInitialized,
+					Status: corev1.ConditionTrue,
+				},
+			},
+		},
+	}
+}
+
+func getMockUnstructured() *unstructured.Unstructured {
+	pod := getMockPod()
+	u, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(pod)
+	return &unstructured.Unstructured{Object: u}
+}
+
+func BenchmarkGetObjectSimplification_Pod(b *testing.B) {
+	pod := getMockPod()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = getObjectSimplification(pod)
+	}
+}
+
+func BenchmarkGetObjectSimplification_Unstructured(b *testing.B) {
+	u := getMockUnstructured()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = getObjectSimplification(u)
+	}
 }

--- a/clusterloader2/pkg/measurement/util/wait_for_conditions.go
+++ b/clusterloader2/pkg/measurement/util/wait_for_conditions.go
@@ -25,7 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 )
 
@@ -52,6 +52,10 @@ type WaitForGenericK8sObjectsOptions struct {
 	CallerName string
 	// WaitInterval contains interval for which the function waits between refreshes.
 	WaitInterval time.Duration
+	// GenericLister allows the caller to provide a pre-warmed cache to avoid
+	// instantiating a new dynamic informer. If provided, GroupVersionResource is
+	// ignored for informer creation.
+	GenericLister cache.GenericLister
 }
 
 // NamespacesRange represents namespace range which will be queried.
@@ -97,17 +101,18 @@ func (nr *NamespacesRange) getMap() map[string]bool {
 // WaitForGenericK8sObjects waits till the desired number of k8s objects
 // fulfills given conditions requirements, ctx.Done() channel is used to
 // wait for timeout.
-func WaitForGenericK8sObjects(ctx context.Context, dynamicClient dynamic.Interface, options *WaitForGenericK8sObjectsOptions) error {
-	store, err := NewDynamicObjectStore(ctx, dynamicClient, options.GroupVersionResource, options.Namespaces.getMap(), options.LabelSelector)
-	if err != nil {
-		return err
+func WaitForGenericK8sObjects(ctx context.Context, options *WaitForGenericK8sObjectsOptions) error {
+	lister := options.GenericLister
+	if lister == nil {
+		return fmt.Errorf("GenericLister is required")
 	}
 
+	namespacesMap := options.Namespaces.getMap()
 	var successful, failed []string
 	var count int
 
 	for {
-		objects, err := store.ListObjectSimplifications()
+		objects, err := ListObjectSimplifications(lister, namespacesMap, options.LabelSelector)
 		if err != nil {
 			return err
 		}

--- a/clusterloader2/pkg/measurement/util/wait_for_conditions_test.go
+++ b/clusterloader2/pkg/measurement/util/wait_for_conditions_test.go
@@ -21,13 +21,39 @@ import (
 	"testing"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic/dynamicinformer"
 	"k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/tools/cache"
 )
+
+type fakeGenericLister struct {
+	objects []runtime.Object
+}
+
+func (f *fakeGenericLister) List(selector labels.Selector) (ret []runtime.Object, err error) {
+	for _, obj := range f.objects {
+		if pod, ok := obj.(*corev1.Pod); ok {
+			if selector.Matches(labels.Set(pod.Labels)) {
+				ret = append(ret, obj)
+			}
+		}
+	}
+	return ret, nil
+}
+
+func (f *fakeGenericLister) Get(name string) (runtime.Object, error) {
+	return nil, nil
+}
+
+func (f *fakeGenericLister) ByNamespace(namespace string) cache.GenericNamespaceLister {
+	return nil
+}
 
 func TestWaitForGenericK8sObjects(t *testing.T) {
 
@@ -287,6 +313,58 @@ func TestWaitForGenericK8sObjects(t *testing.T) {
 				newExampleObject("test-2", "namespace-1", []interface{}{}),
 			},
 		},
+		{
+			name:    "successful pods (special case) filtered by label selector",
+			timeout: 1 * time.Second,
+			options: &WaitForGenericK8sObjectsOptions{
+				GroupVersionResource: schema.GroupVersionResource{
+					Group:    "",
+					Version:  "v1",
+					Resource: "pods",
+				},
+				Namespaces: NamespacesRange{
+					Prefix: "namespace",
+					Min:    1,
+					Max:    1,
+				},
+				LabelSelector:         labels.SelectorFromSet(labels.Set{"app": "worker"}),
+				SuccessfulConditions:  []string{"Ready=True"},
+				FailedConditions:      []string{},
+				MinDesiredObjectCount: 1,
+				MaxFailedObjectCount:  0,
+				CallerName:            "test",
+				WaitInterval:          100 * time.Millisecond,
+				GenericLister: &fakeGenericLister{
+					objects: []runtime.Object{
+						&corev1.Pod{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "test-1",
+								Namespace: "namespace-1",
+								Labels:    map[string]string{"app": "worker"},
+							},
+							Status: corev1.PodStatus{
+								Conditions: []corev1.PodCondition{
+									{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+								},
+							},
+						},
+						&corev1.Pod{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "test-2",
+								Namespace: "namespace-1",
+								Labels:    map[string]string{"app": "api"},
+							},
+							Status: corev1.PodStatus{
+								Conditions: []corev1.PodCondition{
+									{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+								},
+							},
+						},
+					},
+				},
+			},
+			existingObjects: nil,
+		},
 	}
 	for _, tt := range tests {
 		tt := tt
@@ -304,7 +382,19 @@ func TestWaitForGenericK8sObjects(t *testing.T) {
 				}
 			}
 
-			if err := WaitForGenericK8sObjects(ctx, dynamicClient, tt.options); (err != nil) != tt.wantErr {
+			if tt.options.GenericLister == nil {
+				tweakListOptions := func(listOptions *metav1.ListOptions) {
+					if tt.options.LabelSelector != nil {
+						listOptions.LabelSelector = tt.options.LabelSelector.String()
+					}
+				}
+				informerFactory := dynamicinformer.NewFilteredDynamicSharedInformerFactory(dynamicClient, 10*time.Second, metav1.NamespaceAll, tweakListOptions)
+				tt.options.GenericLister = informerFactory.ForResource(tt.options.GroupVersionResource).Lister()
+				informerFactory.Start(ctx.Done())
+				informerFactory.WaitForCacheSync(ctx.Done())
+			}
+
+			if err := WaitForGenericK8sObjects(ctx, tt.options); (err != nil) != tt.wantErr {
 				t.Errorf("WaitForGenericK8sObjects() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})


### PR DESCRIPTION
Optimizes WaitForGenericK8sObjectsMeasurement for pods use case:
* uses protobuf-based typed client instead of dynamic and json (shared with other measurements to reduce cpu and memory footprint)
* Drops json.Marshal/json.Unmarshal approach for dynamic objects which was very expensive


## Benchmark Results (ns/op)

| Object Type | Old JSON Implementation | New Optimized Implementation | Speedup |
| :--- | :--- | :--- | :--- |
| **Typed Pod** | ~21,390 ns/op | ~228.7 ns/op | **~93x faster** |
| **Unstructured** | ~9,974 ns/op | ~1,299 ns/op | **~7.6x faster** |
