### PR TITLE
clusterloader2: compute SchedulingThroughput from PodScheduled bind time

### DIFF
--- a/clusterloader2/pkg/measurement/common/scheduling_throughput.go
+++ b/clusterloader2/pkg/measurement/common/scheduling_throughput.go
@@ -22,7 +22,7 @@ import (
 	"sort"
 	"time"
 
-	clientset "k8s.io/client-go/kubernetes"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
 	"k8s.io/perf-tests/clusterloader2/pkg/errors"
 	"k8s.io/perf-tests/clusterloader2/pkg/measurement"
@@ -32,7 +32,6 @@ import (
 
 const (
 	schedulingThroughputMeasurementName = "SchedulingThroughput"
-	defaultSchedulingThroughputInterval = 5 * time.Second
 )
 
 func init() {
@@ -46,16 +45,27 @@ func createSchedulingThroughputMeasurement() measurement.Measurement {
 }
 
 type schedulingThroughputMeasurement struct {
-	schedulingThroughputs []float64
-	isRunning             bool
-	stopCh                chan struct{}
+	podStore    *measurementutil.PodStore
+	selector    *util.ObjectSelector
+	startSecond int64
+	isRunning   bool
 }
 
 // Execute supports two actions:
-//   - start - starts the pods scheduling observation.
-//     Pods can be specified by field and/or label selectors.
+//   - start - begins watching pods matching the field and/or label selectors.
 //     If namespace is not passed by parameter, all-namespace scope is assumed.
-//   - gather - creates summary for observed values.
+//   - gather - buckets the matched pods into one-second bins by the time the
+//     scheduler stamped their PodScheduled condition and reports the per-second
+//     throughput distribution.
+//
+// Throughput is derived from each pod's PodScheduled LastTransitionTime rather
+// than by polling pod counts on the client's clock. That places every bind in
+// the second it actually happened, so the per-second curve is accurate
+// regardless of test size or client watch-delivery lag. Because it reads only
+// the pod object it works on any cluster, including managed control planes
+// whose scheduler /metrics endpoint is unreachable. PodScheduled
+// LastTransitionTime is second-resolution, so this is a per-second signal and
+// must not be used to derive sub-second latency.
 func (s *schedulingThroughputMeasurement) Execute(config *measurement.Config) ([]measurement.Summary, error) {
 	action, err := util.GetString(config.Params, "action")
 	if err != nil {
@@ -67,16 +77,19 @@ func (s *schedulingThroughputMeasurement) Execute(config *measurement.Config) ([
 			klog.V(3).Infof("%s: measurement already running", s)
 			return nil, nil
 		}
-		selector := util.NewObjectSelector()
-		if err := selector.Parse(config.Params); err != nil {
+		s.selector = util.NewObjectSelector()
+		if err := s.selector.Parse(config.Params); err != nil {
 			return nil, err
 		}
-		measurmentInterval, err := util.GetDurationOrDefault(config.Params, "measurmentInterval", defaultSchedulingThroughputInterval)
+		ps, err := measurementutil.NewPodStore(config.ClusterFramework.GetClientSets().GetClient(), s.selector)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("pod store creation error: %v", err)
 		}
-		s.stopCh = make(chan struct{})
-		return nil, s.start(config.ClusterFramework.GetClientSets().GetClient(), selector, measurmentInterval)
+		s.podStore = ps
+		s.startSecond = time.Now().Unix()
+		s.isRunning = true
+		klog.V(2).Infof("%s: started watching %s", s, s.selector.String())
+		return nil, nil
 	case "gather":
 		threshold, err := util.GetFloat64OrDefault(config.Params, "threshold", 0)
 		if err != nil {
@@ -102,6 +115,42 @@ func (s *schedulingThroughputMeasurement) Execute(config *measurement.Config) ([
 	}
 }
 
+func (s *schedulingThroughputMeasurement) gather(threshold float64) ([]measurement.Summary, error) {
+	if !s.isRunning {
+		klog.Errorf("%s: measurement is not running", s)
+		return nil, fmt.Errorf("measurement is not running")
+	}
+	pods, err := s.podStore.List()
+	if err != nil {
+		return nil, fmt.Errorf("unexpected error on PodStore.List: %w", err)
+	}
+	s.stop()
+
+	summary := computeSchedulingThroughput(pods, s.startSecond)
+
+	content, err := util.PrettyPrintJSON(summary)
+	if err != nil {
+		return nil, err
+	}
+	klog.V(2).Infof("%s: %d pods scheduled over %ds; peak %.0f/s, p50 %.0f/s", s, summary.TotalScheduled, summary.WindowSeconds, summary.Max, summary.Perc50)
+	summaries := []measurement.Summary{measurement.CreateSummary(schedulingThroughputMeasurementName, "json", content)}
+	if threshold > 0 && summary.Max < threshold {
+		return summaries, errors.NewMetricViolationError(
+			"scheduler throughput",
+			fmt.Sprintf("actual throughput %f lower than threshold %f", summary.Max, threshold))
+	}
+	return summaries, nil
+}
+
+func (s *schedulingThroughputMeasurement) stop() {
+	if s.isRunning {
+		s.isRunning = false
+		if s.podStore != nil {
+			s.podStore.Stop()
+		}
+	}
+}
+
 // Dispose cleans up after the measurement.
 func (s *schedulingThroughputMeasurement) Dispose() {
 	s.stop()
@@ -112,78 +161,88 @@ func (*schedulingThroughputMeasurement) String() string {
 	return schedulingThroughputMeasurementName
 }
 
-func (s *schedulingThroughputMeasurement) start(clientSet clientset.Interface, selector *util.ObjectSelector, measurmentInterval time.Duration) error {
-	ps, err := measurementutil.NewPodStore(clientSet, selector)
-	if err != nil {
-		return fmt.Errorf("pod store creation error: %v", err)
-	}
-	s.isRunning = true
-	klog.V(2).Infof("%s: starting collecting throughput data", s)
-
-	go func() {
-		defer ps.Stop()
-		lastScheduledCount := 0
-		for {
-			select {
-			case <-s.stopCh:
-				return
-			case <-time.After(measurmentInterval):
-				pods, err := ps.List()
-				if err != nil {
-					// List in NewPodStore never returns error.
-					// TODO(mborsz): Even if this is a case now, it doesn't need to be true in future. Refactor this.
-					panic(fmt.Errorf("unexpected error on PodStore.List: %w", err))
-				}
-				podsStatus := measurementutil.ComputePodsStartupStatus(pods, 0, nil /* updatePodPredicate */)
-				throughput := float64(podsStatus.Scheduled-lastScheduledCount) / float64(measurmentInterval/time.Second)
-				s.schedulingThroughputs = append(s.schedulingThroughputs, throughput)
-				lastScheduledCount = podsStatus.Scheduled
-				klog.V(3).Infof("%v: %s: %d pods scheduled", s, selector.String(), lastScheduledCount)
-			}
+// computeSchedulingThroughput buckets each scheduled pod into the second its
+// PodScheduled condition was stamped and returns the per-second throughput
+// distribution. Pods scheduled before startSecond (or not yet scheduled) are
+// ignored, so a reused selector cannot pull in pre-existing pods. The active
+// window is densified, filling idle seconds with zero, so the percentiles
+// describe the whole scheduling window.
+func computeSchedulingThroughput(pods []*corev1.Pod, startSecond int64) *schedulingThroughput {
+	counts := make(map[int64]int)
+	total := 0
+	var minSec, maxSec int64
+	first := true
+	for _, pod := range pods {
+		sec, ok := podScheduledSecond(pod)
+		if !ok || sec < startSecond {
+			continue
 		}
-	}()
-	return nil
+		counts[sec]++
+		total++
+		if first || sec < minSec {
+			minSec = sec
+		}
+		if first || sec > maxSec {
+			maxSec = sec
+		}
+		first = false
+	}
+
+	summary := &schedulingThroughput{TotalScheduled: total}
+	if total == 0 {
+		return summary
+	}
+	var perSecondCounts []float64
+	for sec := minSec; sec <= maxSec; sec++ {
+		c := counts[sec]
+		summary.PerSecond = append(summary.PerSecond, throughputPoint{UnixSecond: sec, Scheduled: c})
+		perSecondCounts = append(perSecondCounts, float64(c))
+	}
+	summary.WindowSeconds = int(maxSec-minSec) + 1
+	sorted := make([]float64, len(perSecondCounts))
+	copy(sorted, perSecondCounts)
+	sort.Float64s(sorted)
+	summary.Perc50 = percentileOf(sorted, 50)
+	summary.Perc90 = percentileOf(sorted, 90)
+	summary.Perc99 = percentileOf(sorted, 99)
+	summary.Max = sorted[len(sorted)-1]
+	return summary
 }
 
-func (s *schedulingThroughputMeasurement) gather(threshold float64) ([]measurement.Summary, error) {
-	if !s.isRunning {
-		klog.Errorf("%s: measurement is not running", s)
-		return nil, fmt.Errorf("measurement is not running")
+// podScheduledSecond returns the unix second of the pod's PodScheduled=True
+// transition, or false if the pod has not been scheduled.
+func podScheduledSecond(pod *corev1.Pod) (int64, bool) {
+	for i := range pod.Status.Conditions {
+		c := &pod.Status.Conditions[i]
+		if c.Type == corev1.PodScheduled && c.Status == corev1.ConditionTrue {
+			return c.LastTransitionTime.Unix(), true
+		}
 	}
-	s.stop()
-	klog.V(2).Infof("%s: gathering data", s)
-
-	throughputSummary := &schedulingThroughput{}
-	if length := len(s.schedulingThroughputs); length > 0 {
-		sort.Float64s(s.schedulingThroughputs)
-		throughputSummary.Perc50 = s.schedulingThroughputs[int(math.Ceil(float64(length*50)/100))-1]
-		throughputSummary.Perc90 = s.schedulingThroughputs[int(math.Ceil(float64(length*90)/100))-1]
-		throughputSummary.Perc99 = s.schedulingThroughputs[int(math.Ceil(float64(length*99)/100))-1]
-		throughputSummary.Max = s.schedulingThroughputs[length-1]
-	}
-	content, err := util.PrettyPrintJSON(throughputSummary)
-	if err != nil {
-		return nil, err
-	}
-	summary := measurement.CreateSummary(schedulingThroughputMeasurementName, "json", content)
-	if threshold > 0 && throughputSummary.Max < threshold {
-		err = errors.NewMetricViolationError(
-			"scheduler throughput",
-			fmt.Sprintf("actual throughput %f lower than threshold %f", throughputSummary.Max, threshold))
-	}
-	return []measurement.Summary{summary}, err
+	return 0, false
 }
 
-func (s *schedulingThroughputMeasurement) stop() {
-	if s.isRunning {
-		close(s.stopCh)
-		s.isRunning = false
+func percentileOf(sorted []float64, p int) float64 {
+	if len(sorted) == 0 {
+		return 0
 	}
+	idx := int(math.Ceil(float64(len(sorted)*p)/100)) - 1
+	if idx < 0 {
+		idx = 0
+	}
+	return sorted[idx]
+}
+
+type throughputPoint struct {
+	UnixSecond int64 `json:"unixSecond"`
+	Scheduled  int   `json:"scheduled"`
 }
 
 type schedulingThroughput struct {
-	Perc50 float64 `json:"perc50"`
-	Perc90 float64 `json:"perc90"`
-	Perc99 float64 `json:"perc99"`
-	Max    float64 `json:"max"`
+	Perc50         float64           `json:"perc50"`
+	Perc90         float64           `json:"perc90"`
+	Perc99         float64           `json:"perc99"`
+	Max            float64           `json:"max"`
+	TotalScheduled int               `json:"totalScheduled"`
+	WindowSeconds  int               `json:"windowSeconds"`
+	PerSecond      []throughputPoint `json:"perSecond"`
 }

--- a/clusterloader2/pkg/measurement/common/scheduling_throughput_test.go
+++ b/clusterloader2/pkg/measurement/common/scheduling_throughput_test.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func scheduledPod(unixSecond int64) *corev1.Pod {
+	return &corev1.Pod{
+		Status: corev1.PodStatus{
+			Conditions: []corev1.PodCondition{{
+				Type:               corev1.PodScheduled,
+				Status:             corev1.ConditionTrue,
+				LastTransitionTime: metav1.NewTime(time.Unix(unixSecond, 0)),
+			}},
+		},
+	}
+}
+
+func unscheduledPod() *corev1.Pod {
+	return &corev1.Pod{
+		Status: corev1.PodStatus{
+			Conditions: []corev1.PodCondition{{
+				Type:   corev1.PodScheduled,
+				Status: corev1.ConditionFalse,
+			}},
+		},
+	}
+}
+
+func TestComputeSchedulingThroughput(t *testing.T) {
+	cases := []struct {
+		name        string
+		pods        []*corev1.Pod
+		startSecond int64
+		wantTotal   int
+		wantWindow  int
+		wantPerSec  []int
+		wantP50     float64
+		wantMax     float64
+	}{
+		{
+			name:        "buckets pods by their scheduled second",
+			pods:        []*corev1.Pod{scheduledPod(100), scheduledPod(100), scheduledPod(100), scheduledPod(101), scheduledPod(102), scheduledPod(102)},
+			startSecond: 0,
+			wantTotal:   6,
+			wantWindow:  3,
+			wantPerSec:  []int{3, 1, 2},
+			wantP50:     2,
+			wantMax:     3,
+		},
+		{
+			name:        "ignores pods scheduled before start",
+			pods:        []*corev1.Pod{scheduledPod(90), scheduledPod(95), scheduledPod(100), scheduledPod(100)},
+			startSecond: 100,
+			wantTotal:   2,
+			wantWindow:  1,
+			wantPerSec:  []int{2},
+			wantP50:     2,
+			wantMax:     2,
+		},
+		{
+			name:        "skips unscheduled pods",
+			pods:        []*corev1.Pod{scheduledPod(100), unscheduledPod(), {}},
+			startSecond: 0,
+			wantTotal:   1,
+			wantWindow:  1,
+			wantPerSec:  []int{1},
+			wantP50:     1,
+			wantMax:     1,
+		},
+		{
+			name:        "zero-fills idle seconds inside the window",
+			pods:        []*corev1.Pod{scheduledPod(100), scheduledPod(100), scheduledPod(102)},
+			startSecond: 0,
+			wantTotal:   3,
+			wantWindow:  3,
+			wantPerSec:  []int{2, 0, 1},
+			wantP50:     1,
+			wantMax:     2,
+		},
+		{
+			name:        "no scheduled pods",
+			pods:        []*corev1.Pod{unscheduledPod(), {}},
+			startSecond: 0,
+			wantTotal:   0,
+			wantWindow:  0,
+			wantPerSec:  nil,
+			wantP50:     0,
+			wantMax:     0,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := computeSchedulingThroughput(tc.pods, tc.startSecond)
+			assert.Equal(t, tc.wantTotal, got.TotalScheduled, "totalScheduled")
+			assert.Equal(t, tc.wantWindow, got.WindowSeconds, "windowSeconds")
+			assert.Equal(t, tc.wantP50, got.Perc50, "perc50")
+			assert.Equal(t, tc.wantMax, got.Max, "max")
+			var gotPerSec []int
+			for _, p := range got.PerSecond {
+				gotPerSec = append(gotPerSec, p.Scheduled)
+			}
+			assert.Equal(t, tc.wantPerSec, gotPerSec, "perSecond counts")
+		})
+	}
+}


### PR DESCRIPTION
Computes `SchedulingThroughput` from each pod's `PodScheduled` `LastTransitionTime` (the scheduler-stamped bind time) instead of polling and diffing pod counts on the client's clock. The bind time is accurate and not subject to client watch-delivery lag, and because it only reads the pod object it also works where the scheduler `/metrics` isn't reachable.

Output keeps `perc50/90/99/max` and adds a `perSecond` series. Unit test included.

Fixes #1027

```release-note
clusterloader2: SchedulingThroughput now computes per-second throughput from the scheduler-stamped PodScheduled transition time.
```
