### PR TITLE
clusterloader2/testing/watch-list: scale up to 80K pods

### DIFF
--- a/clusterloader2/testing/watch-list/config.yaml
+++ b/clusterloader2/testing/watch-list/config.yaml
@@ -1,7 +1,7 @@
 {{$enableWatchListFeature := DefaultParam .CL2_ENABLE_WATCH_LIST_FEATURE false}}
 {{$customApiCallThresholds := DefaultParam .CUSTOM_API_CALL_THRESHOLDS ""}}
 {{$SINGLE_RESOURCE_API_LATENCY_THRESHOLD := DefaultParam .CL2_SINGLE_RESOURCE_API_LATENCY_THRESHOLD "1s"}}
-{{$namespaces := 10}}
+{{$namespaces := 80}}
 {{$podsPerNamespace := 1000}}
 {{$testDuration := "5m"}}
 name: watch-list


### PR DESCRIPTION
Scale the watch-list benchmark from 10K to 80K pods. I think it should  produce a ~781 MB protobuf payload per WatchList call.