### PR TITLE
Allow customizing registry.k8s.io across ClusterLoader2

### DIFF
--- a/clusterloader2/cmd/clusterloader.go
+++ b/clusterloader2/cmd/clusterloader.go
@@ -138,6 +138,7 @@ func initFlags() {
 	flags.IntVar(&port, "port", 8000, "Port to be used by http server with pprof.")
 	flags.DurationEnvVar(&heapProfileInterval, "heap-profile-interval", "CL2_HEAP_PROFILE_INTERVAL", 0, "Interval between clusterloader2 heap profiles. 0 represents disabled.")
 	flags.BoolVar(&dryRun, "dry-run", false, "Whether to skip running test and only compile test config")
+	flags.StringEnvVar(&clusterLoaderConfig.ImageRegistry, "registry-k8s-repo", "REGISTRY_K8S_REPO", "registry.k8s.io", "FQDN of registry.k8s.io image repo")
 
 	initClusterFlags()
 	execservice.InitFlags(&clusterLoaderConfig.ExecServiceConfig)
@@ -287,6 +288,7 @@ func main() {
 	if err := flags.Parse(); err != nil {
 		klog.Exitf("Flag parse failed: %v", err)
 	}
+	clusterLoaderConfig.ExecServiceConfig.ImageRegistry = clusterLoaderConfig.ImageRegistry
 
 	// Start http server with pprof.
 	go func() {

--- a/clusterloader2/docs/GETTING_STARTED.md
+++ b/clusterloader2/docs/GETTING_STARTED.md
@@ -205,7 +205,7 @@ so we don't need to worry with cleaning up cluster.
 
 Now, in order to finish our first test, we need to specify deployment template.
 You can think of it as regular kubernetes object, but with templating.
-CL2 by default adds parameter `Name` that you can use in your template.
+CL2 by default adds parameters like `Name` and `ImageRegistry` that you can use in your template. `ImageRegistry` defaults to `registry.k8s.io`, but can be overridden by passing the `--registry-k8s-repo` flag or setting the `REGISTRY_K8S_REPO` environment variable.
 In our config, we also passed `Replicas` parameter.
 We need to remember to set correct labels so PodStartupLatency
 and WaitForControlledPodsRunning will watch correct pods.
@@ -228,7 +228,7 @@ spec:
         group: test-pod
     spec:
       containers:
-      - image: registry.k8s.io/pause:3.9
+      - image: {{.ImageRegistry}}/pause:3.9
         name: {{.Name}}
 ```
 ## Execute test

--- a/clusterloader2/pkg/config/cluster.go
+++ b/clusterloader2/pkg/config/cluster.go
@@ -32,6 +32,7 @@ type ClusterLoaderConfig struct {
 	// OverridePaths defines what override files should be applied
 	// globally to the config specified by the ConfigPath for each TestScenario.
 	OverridePaths []string `json:"overridePaths"`
+	ImageRegistry string
 }
 
 // ClusterConfig is a structure that represents cluster description.

--- a/clusterloader2/pkg/config/template_provider.go
+++ b/clusterloader2/pkg/config/template_provider.go
@@ -264,6 +264,7 @@ func GetMapping(clusterLoaderConfig *ClusterLoaderConfig, testOverridePaths []st
 		return nil, errors.NewErrorList(fmt.Errorf("mapping creation error: %v", err))
 	}
 	mapping["Nodes"] = clusterLoaderConfig.ClusterConfig.Nodes
+	mapping["ImageRegistry"] = clusterLoaderConfig.ImageRegistry
 	envMapping, err := LoadCL2Envs()
 	if err != nil {
 		return nil, errors.NewErrorList(goerrors.Errorf("mapping creation error: %v", err))

--- a/clusterloader2/pkg/dependency/dra/dra.go
+++ b/clusterloader2/pkg/dependency/dra/dra.go
@@ -82,6 +82,7 @@ func (d *draDependency) Setup(config *dependency.Config) error {
 	mapping := map[string]interface{}{
 		"Namespace":       namespace,
 		"WorkerNodeCount": getWorkerCount(config),
+		"ImageRegistry":   config.ClusterLoaderConfig.ImageRegistry,
 	}
 
 	if extendedResourceName, ok := config.Params["ExtendedResourceName"]; ok {

--- a/clusterloader2/pkg/dependency/dra/manifests/dra-example-driver/kubeletplugin.yaml
+++ b/clusterloader2/pkg/dependency/dra/manifests/dra-example-driver/kubeletplugin.yaml
@@ -35,7 +35,7 @@ spec:
         securityContext:
           privileged: true
         # image: /:v0.2.0
-        image: registry.k8s.io/dra-example-driver/dra-example-driver:v0.2.0
+        image: {{.ImageRegistry}}/dra-example-driver/dra-example-driver:v0.2.0
         imagePullPolicy: Always
         command: ["dra-example-kubeletplugin"]
         resources:

--- a/clusterloader2/pkg/execservice/exec_service.go
+++ b/clusterloader2/pkg/execservice/exec_service.go
@@ -67,12 +67,6 @@ func InitFlags(c *config.ExecServiceConfig) {
 		true,
 		"Whether to enable exec service that allows executing arbitrary commands from a pod running in the cluster.",
 	)
-	flags.StringVar(
-		&c.ImageRegistry,
-		"registry-k8s-repo",
-		"registry.k8s.io",
-		"FQDN of registry.k8s.io image repo",
-	)
 }
 
 // SetUpExecService creates exec pod.

--- a/clusterloader2/pkg/measurement/common/probes/manifests/dnsLookup/dns-prober-deployment.yaml
+++ b/clusterloader2/pkg/measurement/common/probes/manifests/dnsLookup/dns-prober-deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: dns
-          image: registry.k8s.io/perf-tests/probes:v0.0.7
+          image: {{.ImageRegistry}}/perf-tests/probes:v0.0.7
           args:
             - --metric-bind-address=0.0.0.0:8080
             - --mode=dns

--- a/clusterloader2/pkg/measurement/common/probes/manifests/dnsPropagation/dns-propagation-prober-deployment.yaml
+++ b/clusterloader2/pkg/measurement/common/probes/manifests/dnsPropagation/dns-propagation-prober-deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: prober
-          image: registry.k8s.io/perf-tests/probes:v0.0.7
+          image: {{.ImageRegistry}}/perf-tests/probes:v0.0.7
           args:
             - --metric-bind-address=0.0.0.0:8080
             - --mode=dns-propagation

--- a/clusterloader2/pkg/measurement/common/probes/manifests/metricsServer/metrics-server-prober-deployment.yaml
+++ b/clusterloader2/pkg/measurement/common/probes/manifests/metricsServer/metrics-server-prober-deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: prober
-          image: registry.k8s.io/perf-tests/probes:v0.0.7
+          image: {{.ImageRegistry}}/perf-tests/probes:v0.0.7
           args:
             - --metric-bind-address=0.0.0.0:8080
             - --mode=kubeclient

--- a/clusterloader2/pkg/measurement/common/probes/manifests/ping-client-deployment.yaml
+++ b/clusterloader2/pkg/measurement/common/probes/manifests/ping-client-deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: ping-client
-          image: registry.k8s.io/perf-tests/probes:v0.0.7
+          image: {{.ImageRegistry}}/perf-tests/probes:v0.0.7
           args:
             - --metric-bind-address=0.0.0.0:8080
             - --mode=ping-client

--- a/clusterloader2/pkg/measurement/common/probes/manifests/ping-server-deployment.yaml
+++ b/clusterloader2/pkg/measurement/common/probes/manifests/ping-server-deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: ping-server
-          image: registry.k8s.io/perf-tests/probes:v0.0.7
+          image: {{.ImageRegistry}}/perf-tests/probes:v0.0.7
           args:
             - --metric-bind-address=0.0.0.0:8080
             - --mode=ping-server

--- a/clusterloader2/pkg/measurement/common/probes/probes.go
+++ b/clusterloader2/pkg/measurement/common/probes/probes.go
@@ -199,6 +199,7 @@ func (p *probesMeasurement) initialize(config *measurement.Config) error {
 	p.templateMapping = map[string]interface{}{
 		"Replicas":          replicasPerProbe,
 		"PingSleepDuration": pingSleepDuration,
+		"ImageRegistry":     config.ClusterLoaderConfig.ImageRegistry,
 	}
 	if p.config.Name == "DnsPropagation" {
 		dnsPropagationTemplateMapping, err := InitializeTemplateMappingForDNSPropagationProbe(config)

--- a/clusterloader2/pkg/prometheus/manifests/exporters/kube-state-metrics/deployment.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/exporters/kube-state-metrics/deployment.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       automountServiceAccountToken: true
       containers:
-      - image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.13.0
+      - image: {{.ImageRegistry}}/kube-state-metrics/kube-state-metrics:v2.13.0
         livenessProbe:
           httpGet:
             path: /livez

--- a/clusterloader2/pkg/prometheus/manifests/exporters/metrics-server/resourceConsumer.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/exporters/metrics-server/resourceConsumer.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: resource-consumer
-        image: registry.k8s.io/e2e-test-images/resource-consumer:1.9
+        image: {{.ImageRegistry}}/e2e-test-images/resource-consumer:1.9
         command:
           - ./consume-cpu/consume-cpu
         args:

--- a/clusterloader2/testing/density/deployment.yaml
+++ b/clusterloader2/testing/density/deployment.yaml
@@ -16,7 +16,7 @@ spec:
         group: {{.Group}}
     spec:
       containers:
-      - image: registry.k8s.io/pause:3.9
+      - image: {{.ImageRegistry}}/pause:3.9
         imagePullPolicy: IfNotPresent
         name: {{.Name}}
         ports:

--- a/clusterloader2/testing/density/scheduler/custom-scheduler-metrics/deployment-custom-schd-sample.yaml
+++ b/clusterloader2/testing/density/scheduler/custom-scheduler-metrics/deployment-custom-schd-sample.yaml
@@ -16,5 +16,5 @@ spec:
     spec:
       schedulerName: default-scheduler
       containers:
-      - image: registry.k8s.io/pause:3.9
+      - image: {{.ImageRegistry}}/pause:3.9
         name: {{.Name}}

--- a/clusterloader2/testing/density/scheduler/pod-affinity/deployment.yaml
+++ b/clusterloader2/testing/density/scheduler/pod-affinity/deployment.yaml
@@ -25,7 +25,7 @@ spec:
               topologyKey: "kubernetes.io/hostname"
             weight: 1
       containers:
-      - image: registry.k8s.io/pause:3.9
+      - image: {{.ImageRegistry}}/pause:3.9
         imagePullPolicy: IfNotPresent
         name: {{.Name}}
         ports:

--- a/clusterloader2/testing/density/scheduler/pod-anti-affinity/deployment.yaml
+++ b/clusterloader2/testing/density/scheduler/pod-anti-affinity/deployment.yaml
@@ -25,7 +25,7 @@ spec:
               topologyKey: "kubernetes.io/hostname"
             weight: 1
       containers:
-      - image: registry.k8s.io/pause:3.9
+      - image: {{.ImageRegistry}}/pause:3.9
         imagePullPolicy: IfNotPresent
         name: {{.Name}}
         ports:

--- a/clusterloader2/testing/density/scheduler/pod-topology-spread/deployment.yaml
+++ b/clusterloader2/testing/density/scheduler/pod-topology-spread/deployment.yaml
@@ -27,7 +27,7 @@ spec:
           matchLabels:
             group: {{.Group}}
       containers:
-      - image: registry.k8s.io/pause:3.9
+      - image: {{.ImageRegistry}}/pause:3.9
         imagePullPolicy: IfNotPresent
         name: {{.Name}}
         ports:

--- a/clusterloader2/testing/experimental/storage/pod-startup/volume-types/configmap/deployment_with_configmap.yaml
+++ b/clusterloader2/testing/experimental/storage/pod-startup/volume-types/configmap/deployment_with_configmap.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - name: {{.Name}}
-        image: registry.k8s.io/pause:3.9
+        image: {{.ImageRegistry}}/pause:3.9
         imagePullPolicy: IfNotPresent
         volumeMounts:
         {{ range $volumeIndex := Loop .VolumesPerPod }}

--- a/clusterloader2/testing/experimental/storage/pod-startup/volume-types/downwardapi/deployment_with_downwardapi.yaml
+++ b/clusterloader2/testing/experimental/storage/pod-startup/volume-types/downwardapi/deployment_with_downwardapi.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - name: {{.Name}}
-        image: registry.k8s.io/pause:3.9
+        image: {{.ImageRegistry}}/pause:3.9
         imagePullPolicy: IfNotPresent
         volumeMounts:
         {{ range $volumeIndex := Loop .VolumesPerPod }}

--- a/clusterloader2/testing/experimental/storage/pod-startup/volume-types/emptydir/deployment_with_emptydir.yaml
+++ b/clusterloader2/testing/experimental/storage/pod-startup/volume-types/emptydir/deployment_with_emptydir.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - name: {{.Name}}
-        image: registry.k8s.io/pause:3.9
+        image: {{.ImageRegistry}}/pause:3.9
         imagePullPolicy: IfNotPresent
         volumeMounts:
         {{ range $volumeIndex := Loop .VolumesPerPod }}

--- a/clusterloader2/testing/experimental/storage/pod-startup/volume-types/genericephemeralinline/deployment_with_inline.yaml
+++ b/clusterloader2/testing/experimental/storage/pod-startup/volume-types/genericephemeralinline/deployment_with_inline.yaml
@@ -24,7 +24,7 @@ spec:
     spec:
       containers:
       - name: {{.Name}}
-        image: registry.k8s.io/pause:3.9
+        image: {{.ImageRegistry}}/pause:3.9
         imagePullPolicy: IfNotPresent
         volumeMounts:
         {{ range $volumeIndex := Loop .VolumesPerPod }}

--- a/clusterloader2/testing/experimental/storage/pod-startup/volume-types/persistentvolume/deployment_with_pvc.yaml
+++ b/clusterloader2/testing/experimental/storage/pod-startup/volume-types/persistentvolume/deployment_with_pvc.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - name: {{.Name}}
-        image: registry.k8s.io/pause:3.9
+        image: {{.ImageRegistry}}/pause:3.9
         imagePullPolicy: IfNotPresent
         volumeMounts:
         {{ range $volumeIndex := Loop .VolumesPerPod }}

--- a/clusterloader2/testing/experimental/storage/pod-startup/volume-types/secret/deployment_with_secret.yaml
+++ b/clusterloader2/testing/experimental/storage/pod-startup/volume-types/secret/deployment_with_secret.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - name: {{.Name}}
-        image: registry.k8s.io/pause:3.9
+        image: {{.ImageRegistry}}/pause:3.9
         imagePullPolicy: IfNotPresent
         volumeMounts:
         {{ range $volumeIndex := Loop .VolumesPerPod }}

--- a/clusterloader2/testing/list/pod.yaml
+++ b/clusterloader2/testing/list/pod.yaml
@@ -27,14 +27,14 @@ metadata:
 spec:
   initContainers:
   - name: init-0
-    image: registry.k8s.io/e2e-test-images/agnhost:2.53
+    image: {{.ImageRegistry}}/e2e-test-images/agnhost:2.53
     command: ["/bin/sh", "-c", "sleep 1"]
   - name: init-1
-    image: registry.k8s.io/e2e-test-images/agnhost:2.53
+    image: {{.ImageRegistry}}/e2e-test-images/agnhost:2.53
     command: ["/bin/sh", "-c", "sleep 1"]
   containers:
   - name: main
-    image: registry.k8s.io/pause:3.9
+    image: {{.ImageRegistry}}/pause:3.9
     env:
     - name: POD_NAME
       valueFrom:
@@ -80,7 +80,7 @@ spec:
     - mountPath: /var/secret
       name: secret
   - name: sidecar
-    image: registry.k8s.io/pause:3.9
+    image: {{.ImageRegistry}}/pause:3.9
     env:
     - name: POD_NAME
       valueFrom:

--- a/clusterloader2/testing/load/config.yaml
+++ b/clusterloader2/testing/load/config.yaml
@@ -80,7 +80,7 @@
 {{$SLEEP_AFTER_EXEC_DURATION := DefaultParam .CL2_SLEEP_AFTER_EXEC_DURATION "0s"}}
 {{$RESTART_APISERVER := DefaultParam .CL2_RESTART_APISERVER false}}
 
-{{$registry := DefaultParam .CL2_LATENCY_POD_REGISTRY "registry.k8s.io"}}
+{{$registry := DefaultParam .CL2_LATENCY_POD_REGISTRY .ImageRegistry}}
 {{$latencyPodImage := DefaultParam .CL2_LATENCY_POD_IMAGE (Concat $registry "/pause:3.9")}}
 {{$defaultQps := DefaultParam .CL2_DEFAULT_QPS (IfThenElse (le .Nodes 500) 10 100)}}
 

--- a/clusterloader2/testing/load/modules/reconcile-objects/config.yaml
+++ b/clusterloader2/testing/load/modules/reconcile-objects/config.yaml
@@ -13,12 +13,12 @@
 {{$operationTimeout := .operationTimeout}}
 
 # DaemonSets
-{{$daemonSetImage := DefaultParam .daemonSetImage "registry.k8s.io/pause:3.9"}}
+{{$daemonSetImage := DefaultParam .daemonSetImage (Concat .ImageRegistry "/pause:3.9")}}
 {{$daemonSetReplicas := .daemonSetReplicas}}
 {{$daemonSetEnv := .daemonSetEnv}}
 
 # Deployments
-{{$deploymentImage := DefaultParam .deploymentImage "registry.k8s.io/pause:3.9"}}
+{{$deploymentImage := DefaultParam .deploymentImage (Concat .ImageRegistry "/pause:3.9")}}
 {{$bigDeploymentSize := .bigDeploymentSize}}
 {{$bigDeploymentsPerNamespace := .bigDeploymentsPerNamespace}}
 {{$mediumDeploymentSize := .mediumDeploymentSize}}
@@ -27,14 +27,14 @@
 {{$smallDeploymentsPerNamespace := .smallDeploymentsPerNamespace}}
 
 # StatefulSets
-{{$statefulSetImage := DefaultParam .statefulSetImage "registry.k8s.io/pause:3.9"}}
+{{$statefulSetImage := DefaultParam .statefulSetImage (Concat .ImageRegistry "/pause:3.9")}}
 {{$smallStatefulSetSize := .smallStatefulSetSize}}
 {{$smallStatefulSetsPerNamespace := .smallStatefulSetsPerNamespace}}
 {{$mediumStatefulSetSize := .mediumStatefulSetSize}}
 {{$mediumStatefulSetsPerNamespace := .mediumStatefulSetsPerNamespace}}
 
 # Jobs
-{{$jobImage := DefaultParam .jobImage "registry.k8s.io/pause:3.10"}}
+{{$jobImage := DefaultParam .jobImage (Concat .ImageRegistry "/pause:3.10")}}
 {{$bigJobSize := .bigJobSize}}
 {{$bigJobsPerNamespace := .bigJobsPerNamespace}}
 {{$mediumJobSize := .mediumJobSize}}

--- a/clusterloader2/testing/load/modules/reconcile-objects/daemonset.yaml
+++ b/clusterloader2/testing/load/modules/reconcile-objects/daemonset.yaml
@@ -1,4 +1,4 @@
-{{$Image := DefaultParam .Image "registry.k8s.io/pause:3.9"}}
+{{$Image := DefaultParam .Image (Concat .ImageRegistry "/pause:3.9")}}
 {{$Env := DefaultParam .Env ""}}
 {{$DaemonSetSurge := DefaultParam .CL2_DS_SURGE (MaxInt 10 (DivideInt .Nodes 20))}} # 5% of nodes, but not less than 10
 {{$TOLERATION := DefaultParam .CL2_TOLERATION ""}}
@@ -54,14 +54,14 @@ spec:
 {{if $RealisticPod }}
       initContainers:
       - name: init-0
-        image: registry.k8s.io/e2e-test-images/agnhost:2.53
+        image: {{.ImageRegistry}}/e2e-test-images/agnhost:2.53
         command: ["/bin/sh", "-c", "sleep 1"]
       - name: init-1
-        image: registry.k8s.io/e2e-test-images/agnhost:2.53
+        image: {{.ImageRegistry}}/e2e-test-images/agnhost:2.53
         command: ["/bin/sh", "-c", "sleep 1"]
       containers:
       - name: main
-        image: registry.k8s.io/pause:3.9
+        image: {{.ImageRegistry}}/pause:3.9
         env:
         - name: POD_NAME
           valueFrom:
@@ -102,7 +102,7 @@ spec:
             cpu: 5m
             memory: 20M
       - name: sidecar
-        image: registry.k8s.io/pause:3.9
+        image: {{.ImageRegistry}}/pause:3.9
         resources:
           requests:
             cpu: 5m

--- a/clusterloader2/testing/load/modules/reconcile-objects/deployment.yaml
+++ b/clusterloader2/testing/load/modules/reconcile-objects/deployment.yaml
@@ -15,7 +15,7 @@
 {{$NetPolServerOnEveryNthPod := DefaultParam .NetPolServerOnEveryNthPod 3}}
 {{$RunNetPolicyTest := and $EnableNetworkPolicyEnforcementLatencyTest (eq (Mod .Index $NetPolServerOnEveryNthPod) 0)}}
 
-{{$Image := DefaultParam .Image "registry.k8s.io/pause:3.9"}}
+{{$Image := DefaultParam .Image (Concat .ImageRegistry "/pause:3.9")}}
 {{$RuntimeClassName := DefaultParam .CL2_RUNTIME_CLASS_NAME nil}}
 {{$RealisticPod := DefaultParam .CL2_REALISTIC_POD false}}
 
@@ -73,14 +73,14 @@ spec:
 {{if $RealisticPod }}
       initContainers:
       - name: init-0
-        image: registry.k8s.io/e2e-test-images/agnhost:2.53
+        image: {{.ImageRegistry}}/e2e-test-images/agnhost:2.53
         command: ["/bin/sh", "-c", "sleep 1"]
       - name: init-1
-        image: registry.k8s.io/e2e-test-images/agnhost:2.53
+        image: {{.ImageRegistry}}/e2e-test-images/agnhost:2.53
         command: ["/bin/sh", "-c", "sleep 1"]
       containers:
       - name: main
-        image: registry.k8s.io/pause:3.9
+        image: {{.ImageRegistry}}/pause:3.9
         env:
         - name: POD_NAME
           valueFrom:
@@ -126,7 +126,7 @@ spec:
         - mountPath: /var/secret
           name: secret
       - name: sidecar
-        image: registry.k8s.io/pause:3.9
+        image: {{.ImageRegistry}}/pause:3.9
         resources:
           requests:
             cpu: 5m

--- a/clusterloader2/testing/load/modules/reconcile-objects/job.yaml
+++ b/clusterloader2/testing/load/modules/reconcile-objects/job.yaml
@@ -1,5 +1,5 @@
 {{$TOLERATION := DefaultParam .CL2_TOLERATION ""}}
-{{$Image := DefaultParam .Image "registry.k8s.io/pause:3.9"}}
+{{$Image := DefaultParam .Image (Concat .ImageRegistry "/pause:3.9")}}
 {{$podPayloadSize := DefaultParam .CL2_JOB_POD_PAYLOAD_SIZE 0}}
 {{$RuntimeClassName := DefaultParam .CL2_RUNTIME_CLASS_NAME nil}}
 {{$RealisticPod := DefaultParam .CL2_REALISTIC_POD false}}
@@ -50,14 +50,14 @@ spec:
 {{if $RealisticPod }}
       initContainers:
       - name: init-0
-        image: registry.k8s.io/e2e-test-images/agnhost:2.53
+        image: {{.ImageRegistry}}/e2e-test-images/agnhost:2.53
         command: ["/bin/sh", "-c", "sleep 1"]
       - name: init-1
-        image: registry.k8s.io/e2e-test-images/agnhost:2.53
+        image: {{.ImageRegistry}}/e2e-test-images/agnhost:2.53
         command: ["/bin/sh", "-c", "sleep 1"]
       containers:
       - name: main
-        image: registry.k8s.io/pause:3.9
+        image: {{.ImageRegistry}}/pause:3.9
         env:
         - name: POD_NAME
           valueFrom:
@@ -98,7 +98,7 @@ spec:
             cpu: 5m
             memory: 20M
       - name: sidecar
-        image: registry.k8s.io/pause:3.9
+        image: {{.ImageRegistry}}/pause:3.9
         resources:
           requests:
             cpu: 5m

--- a/clusterloader2/testing/load/modules/reconcile-objects/statefulset.yaml
+++ b/clusterloader2/testing/load/modules/reconcile-objects/statefulset.yaml
@@ -1,7 +1,7 @@
 {{$EnablePVs := DefaultParam .CL2_ENABLE_PVS true}}
 {{$TOLERATION := DefaultParam .CL2_TOLERATION ""}}
 {{$podPayloadSize := DefaultParam .CL2_STATEFULSET_POD_PAYLOAD_SIZE 0}}
-{{$Image := DefaultParam .Image "registry.k8s.io/pause:3.9"}}
+{{$Image := DefaultParam .Image (Concat .ImageRegistry "/pause:3.9")}}
 {{$RuntimeClassName := DefaultParam .CL2_RUNTIME_CLASS_NAME nil}}
 {{$RealisticPod := DefaultParam .CL2_REALISTIC_POD false}}
 
@@ -51,14 +51,14 @@ spec:
 {{if $RealisticPod }}
       initContainers:
       - name: init-0
-        image: registry.k8s.io/e2e-test-images/agnhost:2.53
+        image: {{.ImageRegistry}}/e2e-test-images/agnhost:2.53
         command: ["/bin/sh", "-c", "sleep 1"]
       - name: init-1
-        image: registry.k8s.io/e2e-test-images/agnhost:2.53
+        image: {{.ImageRegistry}}/e2e-test-images/agnhost:2.53
         command: ["/bin/sh", "-c", "sleep 1"]
       containers:
       - name: main
-        image: registry.k8s.io/pause:3.9
+        image: {{.ImageRegistry}}/pause:3.9
         ports:
           - containerPort: 80
             name: web
@@ -107,7 +107,7 @@ spec:
             mountPath: /var/pv
         {{end}}
       - name: sidecar
-        image: registry.k8s.io/pause:3.9
+        image: {{.ImageRegistry}}/pause:3.9
         resources:
           requests:
             cpu: 5m

--- a/clusterloader2/testing/load/modules/scheduler-throughput/config.yaml
+++ b/clusterloader2/testing/load/modules/scheduler-throughput/config.yaml
@@ -14,7 +14,7 @@
 {{$CHECK_IF_PODS_ARE_UPDATED := DefaultParam .CL2_CHECK_IF_PODS_ARE_UPDATED true}}
 
 
-{{$deploymentImage := DefaultParam .deploymentImage "registry.k8s.io/pause:3.9"}}
+{{$deploymentImage := DefaultParam .deploymentImage (Concat .ImageRegistry "/pause:3.9")}}
 
 steps:
 {{if $is_creating}}

--- a/clusterloader2/testing/load/modules/scheduler-throughput/simple-deployment.yaml
+++ b/clusterloader2/testing/load/modules/scheduler-throughput/simple-deployment.yaml
@@ -3,7 +3,7 @@
 {{$CpuRequest := DefaultParam .CpuRequest "5m"}}
 {{$podPayloadSize := DefaultParam .CL2_DEPLOYMENT_POD_PAYLOAD_SIZE 0}}
 {{$MemoryRequest := DefaultParam .MemoryRequest "20M"}}
-{{$Image := DefaultParam .Image "registry.k8s.io/pause:3.9"}}
+{{$Image := DefaultParam .Image (Concat .ImageRegistry "/pause:3.9")}}
 {{$TOLERATION := DefaultParam .CL2_TOLERATION ""}}
 
 apiVersion: apps/v1

--- a/clusterloader2/testing/node-throughput/config.yaml
+++ b/clusterloader2/testing/node-throughput/config.yaml
@@ -4,7 +4,7 @@
 #Constants
 {{$POD_COUNT := DefaultParam .POD_COUNT 100}}
 {{$POD_THROUGHPUT := DefaultParam .POD_THROUGHPUT 5}}
-{{$CONTAINER_IMAGE := DefaultParam .CONTAINER_IMAGE "registry.k8s.io/pause:3.9"}}
+{{$CONTAINER_IMAGE := DefaultParam .CONTAINER_IMAGE (Concat .ImageRegistry "/pause:3.9")}}
 {{$POD_STARTUP_LATENCY_THRESHOLD := DefaultParam .POD_STARTUP_LATENCY_THRESHOLD "5s"}}
 {{$OPERATION_TIMEOUT := DefaultParam .OPERATION_TIMEOUT "15m"}}
 

--- a/clusterloader2/testing/pod-startup-latency/config.yaml
+++ b/clusterloader2/testing/pod-startup-latency/config.yaml
@@ -5,7 +5,7 @@
 #Constants
 {{$POD_COUNT := DefaultParam .POD_COUNT 30}}
 {{$POD_THROUGHPUT := DefaultParam .POD_THROUGHPUT 1}} # We expect the pod to launch in less than one second, so launching more than 1 pod per second would create a backlog and test a different behaviour.
-{{$CONTAINER_IMAGE := DefaultParam .CONTAINER_IMAGE "registry.k8s.io/pause:3.9"}}
+{{$CONTAINER_IMAGE := DefaultParam .CONTAINER_IMAGE (Concat .ImageRegistry "/pause:3.9")}}
 {{$POD_STARTUP_LATENCY_THRESHOLD := DefaultParam .POD_STARTUP_LATENCY_THRESHOLD "5s"}}
 {{$OPERATION_TIMEOUT := DefaultParam .OPERATION_TIMEOUT "15m"}}
 

--- a/clusterloader2/testing/scheduler-throughput/pod-default.yaml
+++ b/clusterloader2/testing/scheduler-throughput/pod-default.yaml
@@ -6,5 +6,5 @@ metadata:
     group: {{.Group}}  
 spec:
   containers:
-  - image: registry.k8s.io/pause:3.9
+  - image: {{.ImageRegistry}}/pause:3.9
     name: pause

--- a/clusterloader2/testing/watch-list/pod.yaml
+++ b/clusterloader2/testing/watch-list/pod.yaml
@@ -28,14 +28,14 @@ spec:
   schedulerName: "do-not-schedule"
   initContainers:
   - name: init-0
-    image: registry.k8s.io/e2e-test-images/agnhost:2.53
+    image: {{.ImageRegistry}}/e2e-test-images/agnhost:2.53
     command: ["/bin/sh", "-c", "sleep 1"]
   - name: init-1
-    image: registry.k8s.io/e2e-test-images/agnhost:2.53
+    image: {{.ImageRegistry}}/e2e-test-images/agnhost:2.53
     command: ["/bin/sh", "-c", "sleep 1"]
   containers:
   - name: main
-    image: registry.k8s.io/pause:3.9
+    image: {{.ImageRegistry}}/pause:3.9
     env:
     - name: POD_NAME
       valueFrom:
@@ -81,7 +81,7 @@ spec:
     - mountPath: /var/secret
       name: secret
   - name: sidecar
-    image: registry.k8s.io/pause:3.9
+    image: {{.ImageRegistry}}/pause:3.9
     env:
     - name: POD_NAME
       valueFrom:

--- a/clusterloader2/testing/windows-tests/config.yaml
+++ b/clusterloader2/testing/windows-tests/config.yaml
@@ -4,7 +4,7 @@
 #Constants
 {{$POD_COUNT := DefaultParam .CL2_POD_COUNT 80}}
 {{$POD_THROUGHPUT := DefaultParam .CL2_POD_THROUGHPUT 0.03}}
-{{$CONTAINER_IMAGE := DefaultParam .CL2_CONTAINER_IMAGE "registry.k8s.io/pause:3.9"}}
+{{$CONTAINER_IMAGE := DefaultParam .CL2_CONTAINER_IMAGE (Concat .ImageRegistry "/pause:3.9")}}
 {{$POD_STARTUP_LATENCY_THRESHOLD := DefaultParam .CL2_POD_STARTUP_LATENCY_THRESHOLD "60m"}}
 {{$OPERATION_TIMEOUT := DefaultParam .CL2_OPERATION_TIMEOUT "90m"}}
 


### PR DESCRIPTION
#### Summary

*   Introduced the `registry-k8s-repo` CLI flag and `REGISTRY_K8S_REPO` environment variable (mapped to `ImageRegistry` in template mapping) to allow replacing the default `registry.k8s.io` image repository.
*   Updated all test templates and measurement manifests  to use the new `{{.ImageRegistry}}` template variable.
*   Added `ImageRegistry` into the `probes` measurement local template mapping.
*   Updated `docs/GETTING_STARTED.md` documentation to instruct users on how to use the `ImageRegistry` template variable and flag overrides.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Rate-limiting or network isolation often requires pulling test images from a registry mirror rather than the upstream registry.k8s.io. Exposing this customization option via a ClusterLoader2 flag allows users to seamlessly point all benchmark workloads, metrics exporters, probes to their local registry.

This change fails to address some deployed dependencies (such as the GCE PD CSI driver), due to additional complexities, but I am planning to prepare a followup PR to take care of that.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

