### PR TITLE
fix(benchmark): exclude failed runs from benchmark run selection

### DIFF
--- a/benchmark/pkg/metricsfetcher/runselector/schemes/last_n_hours.go
+++ b/benchmark/pkg/metricsfetcher/runselector/schemes/last_n_hours.go
@@ -41,7 +41,8 @@ func GetJobRunsFromLastNHours(job string, n int, utils util.JobLogUtils) ([]int,
 			if (currentTime - startTimestamp) >= uint64(3600*n) {
 				break
 			}
-			if _, err := utils.GetJobRunFinishedStatus(job, buildNumber); err == nil {
+			finished, err := utils.GetJobRunFinishedStatus(job, buildNumber)
+			if err == nil && finished {
 				runs = append(runs, buildNumber)
 			}
 		}

--- a/benchmark/pkg/metricsfetcher/runselector/schemes/last_n_hours_test.go
+++ b/benchmark/pkg/metricsfetcher/runselector/schemes/last_n_hours_test.go
@@ -48,7 +48,7 @@ func TestGetJobRunsFromLastNHours(t *testing.T) {
 			9: true,
 		},
 	}
-	expected := []int{9, 7, 3}
+	expected := []int{9, 3}
 
 	runs, err := GetJobRunsFromLastNHours(lastNhoursJob, numHours, utils)
 	if err != nil {

--- a/benchmark/pkg/metricsfetcher/runselector/schemes/last_n_runs.go
+++ b/benchmark/pkg/metricsfetcher/runselector/schemes/last_n_runs.go
@@ -34,7 +34,8 @@ func GetLastNJobRuns(job string, n int, utils util.JobLogUtils) ([]int, error) {
 	var runs []int
 	for index := 0; index < len(buildNumbers) && len(runs) < n; index++ {
 		buildNumber := buildNumbers[index]
-		if _, err := utils.GetJobRunFinishedStatus(job, buildNumber); err == nil {
+		finished, err := utils.GetJobRunFinishedStatus(job, buildNumber)
+		if err == nil && finished {
 			runs = append(runs, buildNumber)
 		}
 	}

--- a/benchmark/pkg/metricsfetcher/runselector/schemes/last_n_runs_test.go
+++ b/benchmark/pkg/metricsfetcher/runselector/schemes/last_n_runs_test.go
@@ -40,7 +40,7 @@ func TestGetLastNJobRuns(t *testing.T) {
 			9: true,
 		},
 	}
-	expected := []int{9, 7, 5}
+	expected := []int{9, 5, 3}
 
 	runs, err := GetLastNJobRuns(lastNrunsJob, numRuns, utils)
 	if err != nil {


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
`GetLastNJobRuns` and `GetJobRunsFromLastNHours` were accepting any readable `finished.json`, even when the run result was not `SUCCESS`.
That lets failed jobs slip into benchmark samples, which is kinda off for perf comparisons.
This patch only keeps runs where `GetJobRunFinishedStatus(...)` is `true`.

Repro:
1. In `benchmark/pkg/metricsfetcher/runselector/schemes`, use `MockFinishedStatuses: map[int]bool{1:true, 2:false, 3:true}`.
2. Before this patch `GetLastNJobRuns("job", 3, utils)` returns `[3 2 1]`.
3. After this patch it returns `[3 1]`.

#### Which issue(s) this PR fixes:
None found.

#### Special notes for your reviewer:
I re-ran `go test ./pkg/metricsfetcher/runselector/schemes` and `./verify/test.sh`.
I also checked the public GCS layout for `ci-kubernetes-kubemark-100-gce`, it does use root `finished.json`, so this edge case is real, not just mock stuff.
