### PR TITLE
Source load init-events from Prometheus for HA and restart safety

### DIFF
--- a/clusterloader2/testing/load/modules/measurements.yaml
+++ b/clusterloader2/testing/load/modules/measurements.yaml
@@ -220,6 +220,19 @@ steps:
       - name: Watch cache reinitializations
         query: sum(increase(apiserver_watch_cache_initializations_total[%v:])) by (resource)
 {{end}}
+  - Identifier: InitEvents
+    Method: GenericPrometheusQuery
+    Params:
+      action: {{$action}}
+      metricName: Init Events
+      metricVersion: v1
+      unit: events
+      dimensions:
+      - group
+      - resource
+      queries:
+      - name: Init events
+        query: sum(apiserver_init_events_total) by (group, resource)
 {{if $ENABLE_QUOTAS_USAGE_MEASUREMENT}}
   - Identifier: Quotas total usage
     Method: GenericPrometheusQuery

--- a/perfdash/config.go
+++ b/perfdash/config.go
@@ -264,8 +264,8 @@ var (
 			}},
 			"LoadInitEventsCount": []TestDescription{{
 				Name:             "load",
-				OutputFilePrefix: "MetricsForE2E",
-				Parser:           parseApiserverInitEventsCount,
+				OutputFilePrefix: "GenericPrometheusQuery Init Events",
+				Parser:           parsePerfData,
 			}},
 			"LoadWatchCacheInitializationDurationMax": []TestDescription{{
 				Name:             "load",


### PR DESCRIPTION
MetricsForE2E reads init-events from one apiserver as a point-in-time counter, which under-counts under HA, so source it from Prometheus instead. (for kubernetes/test-infra#37360)


Landing https://github.com/kubernetes/test-infra/pull/37360 will let us test this premerge.