### PR TITLE
Customize ContainerRestart to not fail a test

### DIFF
--- a/clusterloader2/pkg/measurement/common/container_restarts.go
+++ b/clusterloader2/pkg/measurement/common/container_restarts.go
@@ -77,6 +77,11 @@ func (a *containerRestartsGatherer) Gather(executor QueryExecutor, startTime, en
 		return nil, err
 	}
 
+	failureEnabled, err := util.GetBoolOrDefault(config.Params, "failureEnabled", true)
+	if err != nil {
+		return nil, err
+	}
+
 	containerRestarts, err := a.gatherContainerRestarts(executor, startTime, endTime)
 	if err != nil {
 		return nil, err
@@ -89,7 +94,10 @@ func (a *containerRestartsGatherer) Gather(executor QueryExecutor, startTime, en
 
 	summaries := []measurement.Summary{measurement.CreateSummary(containerRestartsMeasurementName, "json", content)}
 	if badContainers := a.validateRestarts(containerRestarts, defaultAllowedRestarts, restartCountOverrides); len(badContainers) > 0 {
-		return summaries, errors.NewMetricViolationError("container restarts", fmt.Sprintf("container restart count validation: %v", badContainers))
+		if failureEnabled {
+			return summaries, errors.NewMetricViolationError("container restarts", fmt.Sprintf("container restart count validation: %v", badContainers))
+		}
+		klog.Warningf("container restarts validation failed but failureEnabled is set to false: %v", badContainers)
 	}
 	return summaries, nil
 }

--- a/clusterloader2/pkg/measurement/common/container_restarts_test.go
+++ b/clusterloader2/pkg/measurement/common/container_restarts_test.go
@@ -110,6 +110,17 @@ func TestContainerRestartsMeasurement(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:               "double_restart_of_apiserver/violation_but_failure_disabled",
+			hasError:           false,
+			testSeriesFile:     "double_restart_of_apiserver.yaml",
+			testSeriesDuration: 10 * time.Minute,
+			config: &measurement.Config{
+				Params: map[string]interface{}{
+					"failureEnabled": false,
+				},
+			},
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Adds a failureEnabled configuration option to ContainerRestarts measurement to allow recording container restart violations in logs without failing the test run, matching the pattern used in ClusterOOMsTracker

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

