### PR TITLE
fix(clusterloader2): clarify pod startup status message during rolling updates

### DIFF
--- a/clusterloader2/pkg/measurement/util/pods.go
+++ b/clusterloader2/pkg/measurement/util/pods.go
@@ -67,7 +67,7 @@ type PodsStartupStatus struct {
 
 // String returns string representation for podsStartupStatus.
 func (s *PodsStartupStatus) String() string {
-	return fmt.Sprintf("Pods: %d out of %d created, %d running (%d updated), %d pending scheduled, %d not scheduled, %d inactive, %d terminating, %d unknown, %d runningButNotReady ",
+	return fmt.Sprintf("Pods: %d created, %d desired, %d running (%d updated), %d pending scheduled, %d not scheduled, %d inactive, %d terminating, %d unknown, %d runningButNotReady ",
 		s.Created, s.Expected, s.Running, s.RunningUpdated, s.Pending, s.Waiting, s.Inactive, s.Terminating, s.Unknown, s.RunningButNotReady)
 }
 

--- a/clusterloader2/pkg/measurement/util/pods_test.go
+++ b/clusterloader2/pkg/measurement/util/pods_test.go
@@ -1,0 +1,70 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestPodsStartupStatusStringWithSurgedRollingUpdate(t *testing.T) {
+	pods := []*corev1.Pod{
+		runningAndReadyPod("updated-1"),
+		runningAndReadyPod("updated-2"),
+		runningAndReadyPod("old"),
+	}
+	isPodUpdated := func(pod *corev1.Pod) error {
+		if pod.Name == "old" {
+			return errors.New("pod has old template")
+		}
+		return nil
+	}
+
+	status := ComputePodsStartupStatus(pods, 2, isPodUpdated)
+
+	assert.Equal(t, 3, status.Created)
+	assert.Equal(t, 2, status.Expected)
+	assert.Equal(t, 3, status.Running)
+	assert.Equal(t, 2, status.RunningUpdated)
+
+	got := status.String()
+	want := "Pods: 3 created, 2 desired, 3 running (2 updated), 0 pending scheduled, 0 not scheduled, 0 inactive, 0 terminating, 0 unknown, 0 runningButNotReady "
+
+	assert.Equal(t, want, got)
+	assert.NotContains(t, got, "out of", "should not describe desired pods as a creation limit")
+}
+
+func runningAndReadyPod(name string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			Conditions: []corev1.PodCondition{
+				{
+					Type:   corev1.PodReady,
+					Status: corev1.ConditionTrue,
+				},
+			},
+		},
+	}
+}

--- a/clusterloader2/pkg/measurement/util/pvcs.go
+++ b/clusterloader2/pkg/measurement/util/pvcs.go
@@ -34,7 +34,7 @@ type PVCsStartupStatus struct {
 
 // String returns string representation for PVCsStartupStatus.
 func (s *PVCsStartupStatus) String() string {
-	return fmt.Sprintf("PVCs: %d out of %d created, %d bound, %d pending, %d lost", s.Created, s.Expected, s.Bound, s.Pending, s.Lost)
+	return fmt.Sprintf("PVCs: %d created, %d desired, %d bound, %d pending, %d lost", s.Created, s.Expected, s.Bound, s.Pending, s.Lost)
 }
 
 // ComputePVCsStartupStatus computes PVCsStartupStatus for a group of PVCs.

--- a/clusterloader2/pkg/measurement/util/pvs.go
+++ b/clusterloader2/pkg/measurement/util/pvs.go
@@ -36,7 +36,7 @@ type PVsStartupStatus struct {
 
 // String returns string representation for PVsStartupStatus.
 func (s *PVsStartupStatus) String() string {
-	return fmt.Sprintf("PVs: %d out of %d created, %d bound, %d pending, %d available, %d failed",
+	return fmt.Sprintf("PVs: %d created, %d desired, %d bound, %d pending, %d available, %d failed",
 		s.Created, s.Expected, s.Bound, s.Pending, s.Available, s.Failed)
 }
 


### PR DESCRIPTION
What type of PR is this?

/kind bug

What this PR does / why we need it

During a Deployment rolling update, the number of non-terminating pods can legitimately exceed the desired replica count because of `maxSurge`.
The previous status message:
```text
Pods: %d out of %d created
```
could produce output such as:
```text
Pods: 5017 out of 4990 created
```

This wording is misleading because it implies that the desired replica count is a limit on the number of created pods, whereas temporarily exceeding the desired replica count is expected during a rolling update.
This PR updates the message to:
```text
Pods: %d created, %d desired
```
which more accurately reflects Kubernetes rollout semantics without changing any pod counting, rollout behavior, or success conditions.

A regression test has also been added to cover the rolling update surge scenario.

Which issue(s) this PR fixes

Fixes #3981

## Special notes for your reviewer

- This change only updates the status message formatting.
- Pod counting logic, rollout behavior, and success conditions are unchanged.
- Added `TestPodsStartupStatusStringWithSurgedRollingUpdate` to prevent regressions.