### PR TITLE
benchmark-list: expose Go runtime metrics to disambiguate memory regressions

### DIFF
--- a/clusterloader2/testing/list/modules/measurements.yaml
+++ b/clusterloader2/testing/list/modules/measurements.yaml
@@ -42,4 +42,50 @@ steps:
         threshold: {{$APISERVER_MEMORY_THRESHOLD_MEGABYTES}}
         requireSamples: false
         lowerBound: false
+  - Identifier: APIServerHeapInuse
+    Method: GenericPrometheusQuery
+    Params:
+      action: {{$action}}
+      metricName: kube-apiserver heap inuse
+      metricVersion: v1
+      unit: MiB
+      queries:
+      - name: MaxHeapInuse
+        query: |
+          max_over_time(
+          sum(
+            go_memstats_heap_inuse_bytes{job="master",endpoint="apiserver"}
+            / 1024 / 1024
+          )[%v:])
+        requireSamples: false
+  - Identifier: APIServerGCRate
+    Method: GenericPrometheusQuery
+    Params:
+      action: {{$action}}
+      metricName: kube-apiserver GC rate
+      metricVersion: v1
+      unit: count/s
+      queries:
+      - name: GCRate
+        query: |
+          sum(
+            rate(
+              go_gc_duration_seconds_count{job="master", endpoint="apiserver"}[%v])
+          )
+        requireSamples: false
+  - Identifier: APIServerAllocationRate
+    Method: GenericPrometheusQuery
+    Params:
+      action: {{$action}}
+      metricName: kube-apiserver allocation rate
+      metricVersion: v1
+      unit: MiB/s
+      queries:
+      - name: AllocationRate
+        query: |
+          sum(
+            rate(go_memstats_alloc_bytes_total{job="master",endpoint="apiserver"}[%v])
+            / 1024 / 1024
+          )
+        requireSamples: false
   {{end}}

--- a/perfdash/config.go
+++ b/perfdash/config.go
@@ -750,6 +750,13 @@ var (
 				Parser:           parsePerfData,
 			}},
 		},
+		"GenericMeasurements": {
+			"GenericMeasurements": []TestDescription{{
+				OutputFilePrefix:            GenericPrometheusQueryMeasurementName,
+				Parser:                      parsePerfData,
+				FetchMetricNameFromArtifact: true,
+			}},
+		},
 	}
 
 	etcdAPIBenchmarkDescription = TestDescriptions{


### PR DESCRIPTION
What type of PR is this?

/kind bug

What this PR does / why we need it:
This change exposes additional Go runtime metrics for the benchmark-list benchmark using the existing `GenericPrometheusQuery` infrastructure.

The benchmark currently primarily surfaces `container_memory_working_set_bytes`, which can increase when allocation rate decreases and Go GC runs less frequently. This can make allocation improvements appear as memory regressions even when the live heap remains unchanged.

This PR adds GenericPrometheusQuery measurements for:
- `go_memstats_heap_inuse_bytes`
- `rate(go_gc_duration_seconds_count[%v])`
- `rate(go_memstats_alloc_bytes_total[%v])`
and registers these metrics in Perfdash so they are displayed alongside the existing benchmark results.

Files changed:
- `clusterloader2/testing/list/modules/measurements.yaml` – add GenericPrometheusQuery measurements.
- `perfdash/config.go` – register GenericMeasurements for the benchmark-list dashboard.
- `perfdash/parser_test.go` – add coverage for GenericPrometheusQuery parsing.

The implementation is additive and does not modify the existing `ResourceUsageSummary` pipeline.

Which issue(s) this PR fixes:
Fixes #4140

Special notes for your reviewer:
This change intentionally uses the existing GenericPrometheusQuery pipeline instead of extending ResourceUsageSummary.
Relevant tests executed:
- `go test ./...` (perfdash)
- `go test ./pkg/measurement/common` (clusterloader2)

The implementation only adds new benchmark metrics and Perfdash registration without changing existing benchmark behavior.