### PR TITLE
clusterloader2: scrape events etcd metrics

### DIFF
--- a/clusterloader2/cmd/clusterloader.go
+++ b/clusterloader2/cmd/clusterloader.go
@@ -77,6 +77,7 @@ func initClusterFlags() {
 	flags.StringEnvVar(&clusterLoaderConfig.ClusterConfig.EtcdCertificatePath, "etcd-certificate", "ETCD_CERTIFICATE", "/etc/srv/kubernetes/pki/etcd-apiserver-server.crt", "Path to the etcd certificate on the master machine")
 	flags.StringEnvVar(&clusterLoaderConfig.ClusterConfig.EtcdKeyPath, "etcd-key", "ETCD_KEY", "/etc/srv/kubernetes/pki/etcd-apiserver-server.key", "Path to the etcd key on the master machine")
 	flags.IntEnvVar(&clusterLoaderConfig.ClusterConfig.EtcdInsecurePort, "etcd-insecure-port", "ETCD_INSECURE_PORT", 2382, "Inscure http port")
+	flags.IntEnvVar(&clusterLoaderConfig.ClusterConfig.EtcdEventsInsecurePort, "etcd-events-insecure-port", "ETCD_EVENTS_INSECURE_PORT", 2384, "Insecure http port serving etcd-events /metrics (etcd --listen-metrics-urls)")
 	flags.IntEnvVar(&clusterLoaderConfig.ClusterConfig.EtcdPprofPort, "etcd-pprof-port", "ETCD_PPROF_PORT", 2385, "Insecure http port serving etcd /debug/pprof (etcd --listen-client-http-urls)")
 	flags.IntEnvVar(&clusterLoaderConfig.ClusterConfig.EtcdEventsPprofPort, "etcd-events-pprof-port", "ETCD_EVENTS_PPROF_PORT", 2386, "Insecure http port serving etcd-events /debug/pprof (etcd --listen-client-http-urls)")
 	flags.BoolEnvVar(&clusterLoaderConfig.ClusterConfig.DeleteStaleNamespaces, "delete-stale-namespaces", "DELETE_STALE_NAMESPACES", false, "DEPRECATED: Whether to delete all stale namespaces before the test execution.")

--- a/clusterloader2/pkg/config/cluster.go
+++ b/clusterloader2/pkg/config/cluster.go
@@ -37,19 +37,20 @@ type ClusterLoaderConfig struct {
 
 // ClusterConfig is a structure that represents cluster description.
 type ClusterConfig struct {
-	KubeConfigPath      string
-	RunFromCluster      bool
-	Nodes               int
-	Provider            provider.Provider
-	EtcdCertificatePath string
-	EtcdKeyPath         string
-	EtcdInsecurePort    int
-	EtcdPprofPort       int
-	EtcdEventsPprofPort int
-	MasterIPs           []string
-	MasterInternalIPs   []string
-	MasterName          string
-	MasterDNSEndpoint   string
+	KubeConfigPath         string
+	RunFromCluster         bool
+	Nodes                  int
+	Provider               provider.Provider
+	EtcdCertificatePath    string
+	EtcdKeyPath            string
+	EtcdInsecurePort       int
+	EtcdEventsInsecurePort int
+	EtcdPprofPort          int
+	EtcdEventsPprofPort    int
+	MasterIPs              []string
+	MasterInternalIPs      []string
+	MasterName             string
+	MasterDNSEndpoint      string
 	// Deprecated: use NamespaceConfig.DeleteStaleNamespaces instead.
 	DeleteStaleNamespaces bool
 	// TODO(#1696): Clean up after removing automanagedNamespaces

--- a/clusterloader2/pkg/measurement/common/etcd_metrics.go
+++ b/clusterloader2/pkg/measurement/common/etcd_metrics.go
@@ -32,7 +32,8 @@ import (
 )
 
 const (
-	etcdMetricsMetricName = "EtcdMetrics"
+	etcdMetricsMetricName       = "EtcdMetrics"
+	etcdEventsMetricsMetricName = "EtcdEventsMetrics"
 )
 
 func init() {
@@ -43,18 +44,20 @@ func init() {
 
 func createEtcdMetricsMeasurement() measurement.Measurement {
 	return &etcdMetricsMeasurement{
-		stopCh:  make(chan struct{}),
-		wg:      &sync.WaitGroup{},
-		metrics: newEtcdMetrics(),
+		stopCh:        make(chan struct{}),
+		wg:            &sync.WaitGroup{},
+		metrics:       newEtcdMetrics(),
+		eventsMetrics: newEtcdMetrics(),
 	}
 }
 
 type etcdMetricsMeasurement struct {
 	sync.Mutex
-	isRunning bool
-	stopCh    chan struct{}
-	wg        *sync.WaitGroup
-	metrics   *etcdMetrics
+	isRunning     bool
+	stopCh        chan struct{}
+	wg            *sync.WaitGroup
+	metrics       *etcdMetrics
+	eventsMetrics *etcdMetrics
 }
 
 // Execute supports two actions:
@@ -80,6 +83,7 @@ func (e *etcdMetricsMeasurement) Execute(config *measurement.Config) ([]measurem
 	}
 
 	etcdInsecurePort := config.ClusterFramework.GetClusterConfig().EtcdInsecurePort
+	etcdEventsInsecurePort := config.ClusterFramework.GetClusterConfig().EtcdEventsInsecurePort
 	switch action {
 	case "start":
 		klog.V(2).Infof("%s: starting etcd metrics collecting...", e)
@@ -88,21 +92,43 @@ func (e *etcdMetricsMeasurement) Execute(config *measurement.Config) ([]measurem
 			return nil, err
 		}
 		for _, h := range hosts {
-			e.startCollecting(h, provider, waitTime, etcdInsecurePort)
+			e.startCollecting(h, provider, waitTime, etcdInsecurePort, e.metrics, true)
+			if etcdEventsInsecurePort > 0 {
+				e.startCollecting(h, provider, waitTime, etcdEventsInsecurePort, e.eventsMetrics, false)
+			}
 		}
 		return nil, nil
 	case "gather":
 		for _, h := range hosts {
-			if err = e.stopAndSummarize(h, provider, etcdInsecurePort); err != nil {
+			if err = e.stopAndSummarize(h, provider, etcdInsecurePort, e.metrics, true); err != nil {
 				return nil, err
+			}
+		}
+		// The events etcd metrics port is best-effort: it is not exposed on every
+		// provider, and its absence must not fail the main measurement.
+		eventsCollected := false
+		if etcdEventsInsecurePort > 0 {
+			for _, h := range hosts {
+				if err := e.stopAndSummarize(h, provider, etcdEventsInsecurePort, e.eventsMetrics, false); err != nil {
+					klog.Warningf("%s: failed to collect etcd-events metrics on %s: %v", e, h, err)
+					continue
+				}
+				eventsCollected = true
 			}
 		}
 		content, err := util.PrettyPrintJSON(e.metrics)
 		if err != nil {
 			return nil, err
 		}
-		summary := measurement.CreateSummary(etcdMetricsMetricName, "json", content)
-		return []measurement.Summary{summary}, nil
+		summaries := []measurement.Summary{measurement.CreateSummary(etcdMetricsMetricName, "json", content)}
+		if eventsCollected {
+			eventsContent, err := util.PrettyPrintJSON(e.eventsMetrics)
+			if err != nil {
+				return nil, err
+			}
+			summaries = append(summaries, measurement.CreateSummary(etcdEventsMetricsMetricName, "json", eventsContent))
+		}
+		return summaries, nil
 	default:
 		return nil, fmt.Errorf("unknown action %v", action)
 	}
@@ -121,19 +147,19 @@ func (e *etcdMetricsMeasurement) String() string {
 	return etcdMetricsMetricName
 }
 
-func (e *etcdMetricsMeasurement) startCollecting(host string, provider provider.Provider, interval time.Duration, port int) {
+func (e *etcdMetricsMeasurement) startCollecting(host string, provider provider.Provider, interval time.Duration, port int, metrics *etcdMetrics, allowFallback bool) {
 	e.isRunning = true
 	e.wg.Add(1)
 
 	collectEtcdDatabaseSize := func() error {
-		dbSize, err := e.getEtcdDatabaseSize(host, provider, port)
+		dbSize, err := e.getEtcdDatabaseSize(host, provider, port, allowFallback)
 		if err != nil {
 			return err
 		}
 
 		e.Lock()
 		defer e.Unlock()
-		e.metrics.MaxDatabaseSize = math.Max(e.metrics.MaxDatabaseSize, dbSize)
+		metrics.MaxDatabaseSize = math.Max(metrics.MaxDatabaseSize, dbSize)
 
 		return nil
 	}
@@ -154,10 +180,10 @@ func (e *etcdMetricsMeasurement) startCollecting(host string, provider provider.
 	}()
 }
 
-func (e *etcdMetricsMeasurement) stopAndSummarize(host string, provider provider.Provider, port int) error {
+func (e *etcdMetricsMeasurement) stopAndSummarize(host string, provider provider.Provider, port int, metrics *etcdMetrics, allowFallback bool) error {
 	defer e.Dispose()
 	// Do some one-off collection of metrics.
-	samples, err := e.getEtcdMetrics(host, provider, port)
+	samples, err := e.getEtcdMetrics(host, provider, port, allowFallback)
 	if err != nil {
 		return err
 	}
@@ -166,13 +192,13 @@ func (e *etcdMetricsMeasurement) stopAndSummarize(host string, provider provider
 		var hist *measurementutil.HistogramVec
 		switch sample.Metric[model.MetricNameLabel] {
 		case "etcd_disk_backend_commit_duration_seconds_bucket":
-			hist = &e.metrics.BackendCommitDuration
+			hist = &metrics.BackendCommitDuration
 		case "etcd_debugging_snap_save_total_duration_seconds_bucket":
-			hist = &e.metrics.SnapshotSaveTotalDuration
+			hist = &metrics.SnapshotSaveTotalDuration
 		case "etcd_disk_wal_fsync_duration_seconds_bucket":
-			hist = &e.metrics.WalFsyncDuration
+			hist = &metrics.WalFsyncDuration
 		case "etcd_network_peer_round_trip_time_seconds_bucket":
-			hist = &e.metrics.PeerRoundTripTime
+			hist = &metrics.PeerRoundTripTime
 		default:
 			return
 		}
@@ -187,7 +213,7 @@ func (e *etcdMetricsMeasurement) stopAndSummarize(host string, provider provider
 	return nil
 }
 
-func (e *etcdMetricsMeasurement) getEtcdMetrics(host string, provider provider.Provider, port int) ([]*model.Sample, error) {
+func (e *etcdMetricsMeasurement) getEtcdMetrics(host string, provider provider.Provider, port int, allowFallback bool) ([]*model.Sample, error) {
 
 	// In https://github.com/kubernetes/kubernetes/pull/74690, mTLS is enabled for etcd server
 	// in order to bypass TLS credential requirement when checking etc /metrics and /health, you
@@ -197,6 +223,11 @@ func (e *etcdMetricsMeasurement) getEtcdMetrics(host string, provider provider.P
 	samples, err := e.sshEtcdMetrics(cmd, host, provider)
 	if err == nil {
 		return samples, nil
+	}
+	if !allowFallback {
+		// Port 2379 serves the main etcd, so falling back to it would silently
+		// attribute main etcd metrics to another etcd instance.
+		return nil, err
 	}
 	klog.Warningf("%s: call on %d port (%s) failed due to %v. Falling back to default 2379 port.", e, port, cmd, err)
 
@@ -228,8 +259,8 @@ func (e *etcdMetricsMeasurement) sshEtcdMetrics(cmd, host string, provider provi
 	return measurementutil.ExtractMetricSamples(data)
 }
 
-func (e *etcdMetricsMeasurement) getEtcdDatabaseSize(host string, provider provider.Provider, port int) (float64, error) {
-	samples, err := e.getEtcdMetrics(host, provider, port)
+func (e *etcdMetricsMeasurement) getEtcdDatabaseSize(host string, provider provider.Provider, port int, allowFallback bool) (float64, error) {
+	samples, err := e.getEtcdMetrics(host, provider, port, allowFallback)
 	if err != nil {
 		return 0, err
 	}

--- a/clusterloader2/pkg/measurement/common/etcd_metrics.go
+++ b/clusterloader2/pkg/measurement/common/etcd_metrics.go
@@ -60,6 +60,18 @@ type etcdMetricsMeasurement struct {
 	eventsMetrics *etcdMetrics
 }
 
+// etcdInstance is a single etcd instance scraped over master SSH.
+type etcdInstance struct {
+	summaryName string
+	// port is the insecure http port serving /metrics (etcd --listen-metrics-urls).
+	port    int
+	metrics *etcdMetrics
+	// isMain marks the etcd instance backing everything but events. It is the only
+	// one allowed to fall back to the hardcoded 2379 port, and the only one whose
+	// scrape failure fails the measurement.
+	isMain bool
+}
+
 // Execute supports two actions:
 // - start - Starts collecting etcd metrics.
 // - gather - Gathers and prints etcd metrics summary.
@@ -82,8 +94,20 @@ func (e *etcdMetricsMeasurement) Execute(config *measurement.Config) ([]measurem
 		return nil, nil
 	}
 
-	etcdInsecurePort := config.ClusterFramework.GetClusterConfig().EtcdInsecurePort
-	etcdEventsInsecurePort := config.ClusterFramework.GetClusterConfig().EtcdEventsInsecurePort
+	instances := []*etcdInstance{{
+		summaryName: etcdMetricsMetricName,
+		port:        config.ClusterFramework.GetClusterConfig().EtcdInsecurePort,
+		metrics:     e.metrics,
+		isMain:      true,
+	}}
+	if port := config.ClusterFramework.GetClusterConfig().EtcdEventsInsecurePort; port > 0 {
+		instances = append(instances, &etcdInstance{
+			summaryName: etcdEventsMetricsMetricName,
+			port:        port,
+			metrics:     e.eventsMetrics,
+		})
+	}
+
 	switch action {
 	case "start":
 		klog.V(2).Infof("%s: starting etcd metrics collecting...", e)
@@ -92,41 +116,35 @@ func (e *etcdMetricsMeasurement) Execute(config *measurement.Config) ([]measurem
 			return nil, err
 		}
 		for _, h := range hosts {
-			e.startCollecting(h, provider, waitTime, etcdInsecurePort, e.metrics, true)
-			if etcdEventsInsecurePort > 0 {
-				e.startCollecting(h, provider, waitTime, etcdEventsInsecurePort, e.eventsMetrics, false)
+			for _, instance := range instances {
+				e.startCollecting(h, provider, waitTime, instance)
 			}
 		}
 		return nil, nil
 	case "gather":
-		for _, h := range hosts {
-			if err = e.stopAndSummarize(h, provider, etcdInsecurePort, e.metrics, true); err != nil {
-				return nil, err
-			}
-		}
-		// The events etcd metrics port is best-effort: it is not exposed on every
-		// provider, and its absence must not fail the main measurement.
-		eventsCollected := false
-		if etcdEventsInsecurePort > 0 {
+		var summaries []measurement.Summary
+		for _, instance := range instances {
+			collected := false
 			for _, h := range hosts {
-				if err := e.stopAndSummarize(h, provider, etcdEventsInsecurePort, e.eventsMetrics, false); err != nil {
-					klog.Warningf("%s: failed to collect etcd-events metrics on %s: %v", e, h, err)
+				if err := e.stopAndSummarize(h, provider, instance); err != nil {
+					// Only the main etcd is guaranteed to expose its metrics port,
+					// so a failure elsewhere must not fail the measurement.
+					if instance.isMain {
+						return nil, err
+					}
+					klog.Warningf("%s: failed to collect %s on %s: %v", e, instance.summaryName, h, err)
 					continue
 				}
-				eventsCollected = true
+				collected = true
 			}
-		}
-		content, err := util.PrettyPrintJSON(e.metrics)
-		if err != nil {
-			return nil, err
-		}
-		summaries := []measurement.Summary{measurement.CreateSummary(etcdMetricsMetricName, "json", content)}
-		if eventsCollected {
-			eventsContent, err := util.PrettyPrintJSON(e.eventsMetrics)
+			if !collected {
+				continue
+			}
+			content, err := util.PrettyPrintJSON(instance.metrics)
 			if err != nil {
 				return nil, err
 			}
-			summaries = append(summaries, measurement.CreateSummary(etcdEventsMetricsMetricName, "json", eventsContent))
+			summaries = append(summaries, measurement.CreateSummary(instance.summaryName, "json", content))
 		}
 		return summaries, nil
 	default:
@@ -147,19 +165,19 @@ func (e *etcdMetricsMeasurement) String() string {
 	return etcdMetricsMetricName
 }
 
-func (e *etcdMetricsMeasurement) startCollecting(host string, provider provider.Provider, interval time.Duration, port int, metrics *etcdMetrics, allowFallback bool) {
+func (e *etcdMetricsMeasurement) startCollecting(host string, provider provider.Provider, interval time.Duration, instance *etcdInstance) {
 	e.isRunning = true
 	e.wg.Add(1)
 
 	collectEtcdDatabaseSize := func() error {
-		dbSize, err := e.getEtcdDatabaseSize(host, provider, port, allowFallback)
+		dbSize, err := e.getEtcdDatabaseSize(host, provider, instance)
 		if err != nil {
 			return err
 		}
 
 		e.Lock()
 		defer e.Unlock()
-		metrics.MaxDatabaseSize = math.Max(metrics.MaxDatabaseSize, dbSize)
+		instance.metrics.MaxDatabaseSize = math.Max(instance.metrics.MaxDatabaseSize, dbSize)
 
 		return nil
 	}
@@ -180,10 +198,10 @@ func (e *etcdMetricsMeasurement) startCollecting(host string, provider provider.
 	}()
 }
 
-func (e *etcdMetricsMeasurement) stopAndSummarize(host string, provider provider.Provider, port int, metrics *etcdMetrics, allowFallback bool) error {
+func (e *etcdMetricsMeasurement) stopAndSummarize(host string, provider provider.Provider, instance *etcdInstance) error {
 	defer e.Dispose()
 	// Do some one-off collection of metrics.
-	samples, err := e.getEtcdMetrics(host, provider, port, allowFallback)
+	samples, err := e.getEtcdMetrics(host, provider, instance)
 	if err != nil {
 		return err
 	}
@@ -192,13 +210,13 @@ func (e *etcdMetricsMeasurement) stopAndSummarize(host string, provider provider
 		var hist *measurementutil.HistogramVec
 		switch sample.Metric[model.MetricNameLabel] {
 		case "etcd_disk_backend_commit_duration_seconds_bucket":
-			hist = &metrics.BackendCommitDuration
+			hist = &instance.metrics.BackendCommitDuration
 		case "etcd_debugging_snap_save_total_duration_seconds_bucket":
-			hist = &metrics.SnapshotSaveTotalDuration
+			hist = &instance.metrics.SnapshotSaveTotalDuration
 		case "etcd_disk_wal_fsync_duration_seconds_bucket":
-			hist = &metrics.WalFsyncDuration
+			hist = &instance.metrics.WalFsyncDuration
 		case "etcd_network_peer_round_trip_time_seconds_bucket":
-			hist = &metrics.PeerRoundTripTime
+			hist = &instance.metrics.PeerRoundTripTime
 		default:
 			return
 		}
@@ -213,23 +231,23 @@ func (e *etcdMetricsMeasurement) stopAndSummarize(host string, provider provider
 	return nil
 }
 
-func (e *etcdMetricsMeasurement) getEtcdMetrics(host string, provider provider.Provider, port int, allowFallback bool) ([]*model.Sample, error) {
+func (e *etcdMetricsMeasurement) getEtcdMetrics(host string, provider provider.Provider, instance *etcdInstance) ([]*model.Sample, error) {
 
 	// In https://github.com/kubernetes/kubernetes/pull/74690, mTLS is enabled for etcd server
 	// in order to bypass TLS credential requirement when checking etc /metrics and /health, you
 	// need to provide the insecure http port number to access etcd, http://localhost:2382 for
 	// example.
-	cmd := fmt.Sprintf("curl http://localhost:%d/metrics", port)
+	cmd := fmt.Sprintf("curl http://localhost:%d/metrics", instance.port)
 	samples, err := e.sshEtcdMetrics(cmd, host, provider)
 	if err == nil {
 		return samples, nil
 	}
-	if !allowFallback {
-		// Port 2379 serves the main etcd, so falling back to it would silently
-		// attribute main etcd metrics to another etcd instance.
+	if !instance.isMain {
+		// 2379 is served by the main etcd, so falling back to it would report
+		// main etcd's metrics under another instance's name.
 		return nil, err
 	}
-	klog.Warningf("%s: call on %d port (%s) failed due to %v. Falling back to default 2379 port.", e, port, cmd, err)
+	klog.Warningf("%s: call on %d port (%s) failed due to %v. Falling back to default 2379 port.", e, instance.port, cmd, err)
 
 	// Use old endpoint if new one fails, "2379" is hard-coded here as well, it is kept as is since
 	// we don't want to bloat the cluster config only for a fall-back attempt.
@@ -259,8 +277,8 @@ func (e *etcdMetricsMeasurement) sshEtcdMetrics(cmd, host string, provider provi
 	return measurementutil.ExtractMetricSamples(data)
 }
 
-func (e *etcdMetricsMeasurement) getEtcdDatabaseSize(host string, provider provider.Provider, port int, allowFallback bool) (float64, error) {
-	samples, err := e.getEtcdMetrics(host, provider, port, allowFallback)
+func (e *etcdMetricsMeasurement) getEtcdDatabaseSize(host string, provider provider.Provider, instance *etcdInstance) (float64, error) {
+	samples, err := e.getEtcdMetrics(host, provider, instance)
 	if err != nil {
 		return 0, err
 	}

--- a/clusterloader2/pkg/prometheus/manifests/master-ip/master-endpoints.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/master-ip/master-endpoints.yaml
@@ -23,6 +23,8 @@ subsets:
         port: 2379
       - name: etcd-2382
         port: 2382
+      - name: etcd-2384
+        port: 2384
       - name: kubelet
         port: 10250
       - name: kube-scheduler

--- a/clusterloader2/pkg/prometheus/manifests/master-ip/master-service.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/master-ip/master-service.yaml
@@ -26,6 +26,8 @@ spec:
       port: 2379
     - name: etcd-2382
       port: 2382
+    - name: etcd-2384
+      port: 2384
     - name: kubelet
       port: 10250
     - name: kube-scheduler

--- a/clusterloader2/pkg/prometheus/manifests/master-ip/master-serviceMonitor.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/master-ip/master-serviceMonitor.yaml
@@ -19,6 +19,8 @@ spec:
     port: etcd-2379
   - interval: 5s
     port: etcd-2382
+  - interval: 5s
+    port: etcd-2384
   {{end}}
   {{if $PROMETHEUS_SCRAPE_NODE_EXPORTER}}
   # TODO(mborsz): Debug why node-exporter is that slow and change interval back to 5s.

--- a/clusterloader2/pkg/prometheus/prometheus.go
+++ b/clusterloader2/pkg/prometheus/prometheus.go
@@ -610,6 +610,8 @@ func (pc *Controller) isPrometheusReady(ctx context.Context) (bool, error) {
 		// changed in https://github.com/kubernetes/kubernetes/pull/77561, depending on the k8s version
 		// etcd metrics may be available at port 2379 xor 2382. We solve that by setting two etcd
 		// serviceMonitors one for 2379 and other for 2382 and expect that at least 1 of them should be healthy.
+		// Port 2384 serves the events etcd and is only exposed on some providers, so it must stay in
+		// the permissive etcd bucket rather than the all-must-be-ready bucket below.
 		ok, err := CheckAllTargetsReady(ctx, // All non-etcd targets should be ready.
 			pc.framework.GetClientSets().GetClient(),
 			func(t Target) bool { return !isEtcdEndpoint(t.Labels["endpoint"]) },
@@ -617,10 +619,10 @@ func (pc *Controller) isPrometheusReady(ctx context.Context) (bool, error) {
 		if err != nil || !ok {
 			return ok, err
 		}
-		return CheckTargetsReady(ctx, // 1 out of 2 etcd targets should be ready.
+		return CheckTargetsReady(ctx, // 1 out of the etcd targets should be ready.
 			pc.framework.GetClientSets().GetClient(),
 			func(t Target) bool { return isEtcdEndpoint(t.Labels["endpoint"]) },
-			2, // expected targets: etcd-2379 and etcd-2382
+			2, // expected targets: etcd-2379 and etcd-2382, etcd-2384 is optional
 			1, // one of them should be healthy
 			logPrometheusError)
 	}
@@ -726,5 +728,5 @@ func getMasterIpsFromKubernetesService(clusterConfig config.ClusterConfig) ([]st
 }
 
 func isEtcdEndpoint(endpoint string) bool {
-	return endpoint == "etcd-2379" || endpoint == "etcd-2382"
+	return endpoint == "etcd-2379" || endpoint == "etcd-2382" || endpoint == "etcd-2384"
 }


### PR DESCRIPTION
Adds the events etcd instance to both the Prometheus scrape targets and the EtcdMetrics measurement.

Need https://github.com/kubernetes/kops/pull/18685 for this to work.