### PR TITLE
fix: validate stepped load delays

### DIFF
--- a/clusterloader2/api/validation.go
+++ b/clusterloader2/api/validation.go
@@ -273,6 +273,9 @@ func (v *ConfigValidator) validateSteppedLoad(sl *SteppedLoad, fldPath *field.Pa
 	if sl.BurstSize <= 0 {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("burstSize"), sl.BurstSize, "must have positive value"))
 	}
+	if sl.StepDelay <= 0 {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("stepDelay"), sl.StepDelay, "must have positive value"))
+	}
 	return allErrs
 }
 

--- a/clusterloader2/api/validation_test.go
+++ b/clusterloader2/api/validation_test.go
@@ -112,6 +112,21 @@ func TestVerifySteppedLoad(t *testing.T) {
 			},
 			expected: false,
 		},
+		{
+			name: "zero step delay",
+			input: SteppedLoad{
+				BurstSize: 10,
+			},
+			expected: false,
+		},
+		{
+			name: "negative step delay",
+			input: SteppedLoad{
+				BurstSize: 10,
+				StepDelay: -1000,
+			},
+			expected: false,
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			v := NewConfigValidator("", &Config{})


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Rejects zero or negative steppedLoad stepDelay values. Zero made bursts run back to back, kinda defeating stepped load.

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

Repro: omit stepDelay from a steppedLoad config. It passed validation and ran bursts immediately.

Tests: go test ./...