### PR TITLE
docs(watch-list): clarify build and release process

### DIFF
--- a/util-images/watch-list/README.md
+++ b/util-images/watch-list/README.md
@@ -13,7 +13,5 @@ Example usage:
 
 ## Building and Releasing
 
-1. Increment the `TAG` in the Makefile.
-2. `make build`
-3. Test changes with `docker run gcr.io/k8s-staging-perf-tests/watch-list:latest -- ...`
-4. Release with `make push`
+1. Make your change and bump `TAG` in the Makefile in the same pull request.
+2. On merge, a postsubmit job builds and pushes the image automatically to `gcr.io/k8s-staging-perf-tests/watch-list:<TAG>`.


### PR DESCRIPTION
it turns out that on merge a postsubmit job builds and pushes the image automatically to`gcr.io/k8s-staging-perf-tests/watch-list:<TAG>`

xref: https://github.com/kubernetes/perf-tests/pull/4106