### PR TITLE
fix(perfdash): paginate S3 metric listings

### DIFF
--- a/perfdash/s3_metrics_bucket.go
+++ b/perfdash/s3_metrics_bucket.go
@@ -57,25 +57,28 @@ func (s *S3MetricsBucket) GetBuildNumbers(job string) ([]int, error) {
 	jobPrefix := joinStringsAndInts(s.logPath, job) + "/"
 	klog.Infof("%s", jobPrefix)
 
-	objects, err := s.client.ListObjectsV2(context.Background(), &s3.ListObjectsV2Input{
+	paginator := s3.NewListObjectsV2Paginator(s.client, &s3.ListObjectsV2Input{
 		Bucket:    s.bucket,
 		Prefix:    ptr.To(jobPrefix),
 		Delimiter: ptr.To("/"),
 	})
-	if err != nil {
-		return nil, err
-	}
-
-	for _, key := range objects.CommonPrefixes {
-		build := *key.Prefix
-		build = strings.TrimPrefix(build, jobPrefix)
-		build = strings.TrimSuffix(build, "/")
-
-		buildNo, err := strconv.Atoi(build)
+	for paginator.HasMorePages() {
+		objects, err := paginator.NextPage(context.Background())
 		if err != nil {
-			return nil, fmt.Errorf("unknown build name convention: %s", build)
+			return nil, err
 		}
-		builds = append(builds, buildNo)
+
+		for _, key := range objects.CommonPrefixes {
+			build := *key.Prefix
+			build = strings.TrimPrefix(build, jobPrefix)
+			build = strings.TrimSuffix(build, "/")
+
+			buildNo, err := strconv.Atoi(build)
+			if err != nil {
+				return nil, fmt.Errorf("unknown build name convention: %s", build)
+			}
+			builds = append(builds, buildNo)
+		}
 	}
 
 	return builds, nil
@@ -86,15 +89,18 @@ func (s *S3MetricsBucket) ListFilesInBuild(job string, buildNumber int, prefix s
 	var files []string
 	jobPrefix := joinStringsAndInts(s.logPath, job, buildNumber, prefix)
 
-	result, err := s.client.ListObjectsV2(context.Background(), &s3.ListObjectsV2Input{
+	paginator := s3.NewListObjectsV2Paginator(s.client, &s3.ListObjectsV2Input{
 		Bucket: s.bucket,
 		Prefix: ptr.To(jobPrefix),
 	})
-	if err != nil {
-		return nil, fmt.Errorf("while listing objects %v", err.Error())
-	}
-	for _, item := range result.Contents {
-		files = append(files, *item.Key)
+	for paginator.HasMorePages() {
+		result, err := paginator.NextPage(context.Background())
+		if err != nil {
+			return nil, fmt.Errorf("while listing objects %v", err)
+		}
+		for _, item := range result.Contents {
+			files = append(files, *item.Key)
+		}
 	}
 
 	return files, nil

--- a/perfdash/s3_metrics_bucket_test.go
+++ b/perfdash/s3_metrics_bucket_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+)
+
+func TestS3MetricsBucketGetBuildNumbersFollowsPagination(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("continuation-token") == "" {
+			_, _ = w.Write([]byte(`<ListBucketResult><IsTruncated>true</IsTruncated><NextContinuationToken>page-2</NextContinuationToken><CommonPrefixes><Prefix>logs/job/1/</Prefix></CommonPrefixes></ListBucketResult>`))
+			return
+		}
+		_, _ = w.Write([]byte(`<ListBucketResult><IsTruncated>false</IsTruncated><CommonPrefixes><Prefix>logs/job/2/</Prefix></CommonPrefixes></ListBucketResult>`))
+	}))
+	defer server.Close()
+
+	client := s3.NewFromConfig(aws.Config{
+		Region:       "us-west-2",
+		Credentials:  credentials.NewStaticCredentialsProvider("test", "test", ""),
+		BaseEndpoint: aws.String(server.URL),
+	}, func(o *s3.Options) {
+		o.UsePathStyle = true
+	})
+	bucket := &S3MetricsBucket{client: client, bucket: aws.String("test"), logPath: "logs"}
+
+	builds, err := bucket.GetBuildNumbers("job")
+	if err != nil {
+		t.Fatalf("GetBuildNumbers() error = %v", err)
+	}
+	if want := []int{1, 2}; !reflect.DeepEqual(builds, want) {
+		t.Errorf("GetBuildNumbers() = %v, want %v", builds, want)
+	}
+}
+
+func TestS3MetricsBucketListFilesInBuildFollowsPagination(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("continuation-token") == "" {
+			_, _ = w.Write([]byte(`<ListBucketResult><IsTruncated>true</IsTruncated><NextContinuationToken>page-2</NextContinuationToken><Contents><Key>logs/job/1/artifacts/first</Key></Contents></ListBucketResult>`))
+			return
+		}
+		_, _ = w.Write([]byte(`<ListBucketResult><IsTruncated>false</IsTruncated><Contents><Key>logs/job/1/artifacts/second</Key></Contents></ListBucketResult>`))
+	}))
+	defer server.Close()
+
+	client := s3.NewFromConfig(aws.Config{
+		Region:       "us-west-2",
+		Credentials:  credentials.NewStaticCredentialsProvider("test", "test", ""),
+		BaseEndpoint: aws.String(server.URL),
+	}, func(o *s3.Options) {
+		o.UsePathStyle = true
+	})
+	bucket := &S3MetricsBucket{client: client, bucket: aws.String("test"), logPath: "logs"}
+
+	files, err := bucket.ListFilesInBuild("job", 1, "artifacts")
+	if err != nil {
+		t.Fatalf("ListFilesInBuild() error = %v", err)
+	}
+	if want := []string{"logs/job/1/artifacts/first", "logs/job/1/artifacts/second"}; !reflect.DeepEqual(files, want) {
+		t.Errorf("ListFilesInBuild() = %v, want %v", files, want)
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

S3 returns at most 1000 keys per listing, current code drops later pages. This can hide recent builds or metric files. Paginate both listings

#### Which issue(s) this PR fixes:

None.

#### Special notes for your reviewer:

Repro: return `IsTruncated=true` with a continuation token from a mock S3 endpoint. Before this change only page one is returned, now both pages are read

Tests: `make test`, `go test -race ./...`, `go build ./...`