### PR TITLE
request-benchmark: introduce http subcommand with backward compatibility

### DIFF
--- a/util-images/request-benchmark/Makefile
+++ b/util-images/request-benchmark/Makefile
@@ -1,6 +1,6 @@
 PROJECT ?= k8s-staging-perf-tests
 IMG = gcr.io/$(PROJECT)/perf-tests-util/request-benchmark
-TAG = v0.0.10
+TAG = v0.0.11
 
 all: build push
 

--- a/util-images/request-benchmark/main.go
+++ b/util-images/request-benchmark/main.go
@@ -53,15 +53,6 @@ const (
 	tableAccept = "application/json;as=Table;v=v1;g=meta.k8s.io"
 )
 
-var (
-	inflight    = flag.Int("inflight", 1, "Benchmark inflight (number of parallel requests being made to the apiserver")
-	namespace   = flag.String("namespace", "", "Replace %namespace% in URI with provided namespace")
-	URI         = flag.String("uri", "", "Request URI")
-	verb        = flag.String("verb", "GET", "A verb to be used in requests.")
-	qps         = flag.Float64("qps", -1, "The qps limit for all requests")
-	contentType = ContentType("json")
-)
-
 func (c ContentType) String() string {
 	return string(c)
 }
@@ -74,11 +65,6 @@ func (c *ContentType) Set(value string) error {
 	default:
 		return fmt.Errorf("invalid content type: %s. Must be one of: [json, proto, cbor, yaml, table, json-pretty]", value)
 	}
-}
-
-func init() {
-	flag.Var(&contentType, "content-type", "Content type for requests (required). Valid values: [json, proto, cbor, yaml, table, json-pretty]")
-	flag.Parse()
 }
 
 func getContentType(ct ContentType) (string, error) {
@@ -99,24 +85,54 @@ func getContentType(ct ContentType) (string, error) {
 }
 
 func main() {
+	args := os.Args[1:]
+	mode := "http"
+	// if the first arg doesn't start with "-" it's a subcommand name
+	if len(args) > 0 && !strings.HasPrefix(args[0], "-") {
+		mode = args[0]
+		args = args[1:]
+	}
+	switch mode {
+	case "http":
+		if err := runHTTP(args); err != nil {
+			log.Fatal(err)
+		}
+	default:
+		log.Fatalf("unknown subcommand %q, valid: http", mode)
+	}
+}
+
+func runHTTP(args []string) error {
+	fs := flag.NewFlagSet("http", flag.ExitOnError)
+	inflight := fs.Int("inflight", 1, "Benchmark inflight (number of parallel requests being made to the apiserver")
+	namespace := fs.String("namespace", "", "Replace %namespace% in URI with provided namespace")
+	URI := fs.String("uri", "", "Request URI")
+	verb := fs.String("verb", "GET", "A verb to be used in requests.")
+	qps := fs.Float64("qps", -1, "The qps limit for all requests")
+	contentType := ContentType("json")
+	fs.Var(&contentType, "content-type", "Content type for requests (required). Valid values: [json, proto, cbor, yaml, table, json-pretty]")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
 	config, err := getConfig()
 	if err != nil {
-		panic(err)
+		return err
 	}
 	config.QPS = float32(*qps)
 	client, err := rest.HTTPClientFor(config)
 	if err != nil {
-		panic(err)
+		return err
 	}
 	ctx := context.Background()
 
 	serverURL, _, err := rest.DefaultServerUrlFor(config)
 	if err != nil {
-		panic(err)
+		return err
 	}
 	url, err := url.Parse(strings.ReplaceAll(*URI, NamespaceTmpl, *namespace))
 	if err != nil {
-		panic(err)
+		return err
 	}
 	url.Host = serverURL.Host
 	url.Scheme = serverURL.Scheme
@@ -132,15 +148,15 @@ func main() {
 		rateLimiter = flowcontrol.NewTokenBucketRateLimiter(float32(*qps), 10)
 	}
 
-	if err := healthCheck(ctx, client, *url, rateLimiter); err != nil {
-		panic(err)
+	if err := healthCheck(ctx, client, *url, rateLimiter, *verb, contentType); err != nil {
+		return err
 	}
 
 	log.Printf("Sending requests to '%s' with inflight %d. Press Ctrl+C to stop...", url, *inflight)
 	for i := 0; i < *inflight; i++ {
 		go func() {
 			for {
-				sendRequest(ctx, client, *url, rateLimiter)
+				sendRequest(ctx, client, *url, rateLimiter, *verb, contentType)
 			}
 		}()
 	}
@@ -148,23 +164,23 @@ func main() {
 	select {} // block main thread from ending
 }
 
-func healthCheck(ctx context.Context, client *http.Client, url url.URL, rateLimiter flowcontrol.RateLimiter) error {
+func healthCheck(ctx context.Context, client *http.Client, url url.URL, rateLimiter flowcontrol.RateLimiter, verb string, ct ContentType) error {
 	for i := 0; i < HealthCheckRequests; i++ {
-		if sendRequest(ctx, client, url, rateLimiter) {
+		if sendRequest(ctx, client, url, rateLimiter, verb, ct) {
 			return nil
 		}
 	}
 	return fmt.Errorf("could not successfully send a request to %s", url.String())
 }
 
-func sendRequest(ctx context.Context, client *http.Client, url url.URL, rateLimiter flowcontrol.RateLimiter) bool {
-	req, err := http.NewRequestWithContext(ctx, *verb, url.String(), nil)
+func sendRequest(ctx context.Context, client *http.Client, url url.URL, rateLimiter flowcontrol.RateLimiter, verb string, ct ContentType) bool {
+	req, err := http.NewRequestWithContext(ctx, verb, url.String(), nil)
 	if err != nil {
 		log.Printf("Got error creating a request: %v\n", err)
 		return false
 	}
 
-	contentType, err := getContentType(contentType)
+	contentType, err := getContentType(ct)
 	if err != nil {
 		log.Printf("Invalid content type: %v", err)
 		return false


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This is the first step in unifying [`watch-list`](https://github.com/kubernetes/perf-tests/tree/master/util-images/watch-list) and `request-benchmark` into a single binary. Today `watch-list` runs informers.  The upcoming `informer` subcommand will bring that capability into `request-benchmark`.


This PR introduces `http` subcommand and also preserves backward compatibility: callers passing flags directly (no subcommand) are silently routed to http mode.

This PR allows to run:
```
#backward compatible case
request-benchmark --uri=/api/v1/pods --inflight=4

# new subcommand case
request-benchmark http --uri=/api/v1/pods --inflight=4
 ``` 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

