### PR TITLE
fix(dns): preserve pod names in histogram rows

### DIFF
--- a/dns/README.md
+++ b/dns/README.md
@@ -254,6 +254,7 @@ CREATE TABLE results (
 CREATE TABLE histograms (
   run_id,
   run_subid,
+  pod_name,
   rtt_ms,
   rtt_ms_count
 );

--- a/dns/py/data.py
+++ b/dns/py/data.py
@@ -188,6 +188,7 @@ CREATE TABLE IF NOT EXISTS histograms (
       data = {
           'run_id': results['params']['run_id'],
           'run_subid': results['params']['run_subid'],
+          'pod_name': results['params']['pod_name'],
           'rtt_ms': rtt_ms,
           'rtt_ms_count': count,
       }
@@ -198,7 +199,7 @@ CREATE TABLE IF NOT EXISTS histograms (
       _log.debug('histogram sql -- %s', stmt)
       self.c.execute(stmt, list(data.values()))
 
-  def get_results(self, run_id, run_subid):
+  def get_results(self, run_id, run_subid, pod_name):
     sql = ('SELECT ' + ','.join([r.name for r in RESULTS])
            + ' FROM results WHERE run_id = ? and run_subid = ? and pod_name = ?')
     _log.debug('%s', sql)

--- a/dns/py/data_test.py
+++ b/dns/py/data_test.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
 import unittest
 import yaml
 
@@ -33,12 +34,35 @@ class DataTest(unittest.TestCase):
 
   def test_result_db(self):
     results = yaml.safe_load(open('fixtures/results.yaml'))
+    results['params']['pod_name'] = 'dns-perf-client-1'
 
     self.db.put(results)
-    res = self.db.get_results(1234, 0)
+    res = self.db.get_results(1234, 0, 'dns-perf-client-1')
     self.assertEqual(727354, res['queries_sent'])
     self.db.put(results) # dup
 
     self.assertRaises(
         Exception,
         lambda: self.db.put(results, ignore_if_dup=False))
+
+  def test_histograms_keep_pod_name(self):
+    results = yaml.safe_load(open('fixtures/results.yaml'))
+    histogram_count = len(results['data']['histogram'])
+
+    for pod_name in ['dns-perf-client-1', 'dns-perf-client-2']:
+      pod_results = copy.deepcopy(results)
+      pod_results['params']['pod_name'] = pod_name
+      self.db.put(pod_results)
+
+    rows = self.db.c.execute(
+        'SELECT pod_name, COUNT(*) FROM histograms GROUP BY pod_name').fetchall()
+    self.assertEqual(
+        [('dns-perf-client-1', histogram_count),
+         ('dns-perf-client-2', histogram_count)],
+        rows)
+
+    join_count = self.db.c.execute(
+        'SELECT COUNT(*) FROM histograms h JOIN results r '
+        'ON h.run_id = r.run_id AND h.run_subid = r.run_subid '
+        'AND h.pod_name = r.pod_name').fetchone()[0]
+    self.assertEqual(2 * histogram_count, join_count)


### PR DESCRIPTION
Keeps `pod_name` on DNS histogram rows.

The default client deployment has 4 pods. With `--db`, histogram rows got a NULL pod name, so joins with result rows duplicated data

Repro: run `cd dns && python py/run_perf.py --dns-server coredns --params params/coredns/test.yaml --db out/db`, then join `histograms` and `results` on run and subrun. 
Before this fix, every histogram row joins to every client result row

Test: `make verify-all-dev` and DNS Python unit tests