### PR TITLE
Deploy node exporter in providers without SSH

### DIFF
--- a/clusterloader2/pkg/prometheus/manifests/exporters/node_exporter/node-exporter-daemonset.yaml
+++ b/clusterloader2/pkg/prometheus/manifests/exporters/node_exporter/node-exporter-daemonset.yaml
@@ -1,0 +1,63 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: node-exporter
+  namespace: monitoring
+  labels:
+    k8s-app: node-exporter
+spec:
+  selector:
+    matchLabels:
+      k8s-app: node-exporter
+  template:
+    metadata:
+      labels:
+        k8s-app: node-exporter
+    spec:
+      containers:
+        - name: prometheus-node-exporter
+          image: gcr.io/k8s-testimages/quay.io/prometheus/node-exporter:v1.0.1
+          imagePullPolicy: "IfNotPresent"
+          args:
+            - --path.sysfs=/host/sys
+            - --path.rootfs=/host/root
+            - --no-collector.wifi
+            - --no-collector.hwmon
+            - --collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/pods/.+)($|/)
+            - --collector.netstat.fields=^.*$
+            - --collector.qdisc
+          ports:
+            - name: metrics
+              containerPort: 9100
+              hostPort: 9100
+          volumeMounts:
+            - mountPath: /host/sys
+              mountPropagation: HostToContainer
+              name: sys
+              readOnly: true
+            - mountPath: /host/root
+              mountPropagation: HostToContainer
+              name: root
+              readOnly: true
+          resources:
+            limits:
+              cpu: 10m
+              memory: 50Mi
+            requests:
+              cpu: 10m
+              memory: 50Mi
+      hostNetwork: true
+      hostPID: true
+      tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
+      nodeSelector:
+        node-role.kubernetes.io/control-plane: ""
+      volumes:
+        - hostPath:
+            path: /sys
+          name: sys
+        - hostPath:
+            path: /
+          name: root

--- a/clusterloader2/pkg/prometheus/prometheus.go
+++ b/clusterloader2/pkg/prometheus/prometheus.go
@@ -61,6 +61,7 @@ const (
 	masterIPServiceMonitors      = "master-ip/*.yaml"
 	metricsServerManifests       = "exporters/metrics-server/*.yaml"
 	nodeExporterPod              = "exporters/node_exporter/node-exporter.yaml"
+	nodeExporterDaemonSet        = "exporters/node_exporter/node-exporter-daemonset.yaml"
 	windowsNodeExporterManifests = "exporters/windows_node_exporter/*.yaml"
 	pushgatewayManifests         = "pushgateway/*.yaml"
 )
@@ -542,7 +543,7 @@ func (pc *Controller) configureRBACForMetrics(testClusterClientSet kubernetes.In
 // TODO(mborsz): Consider migrating to something less ugly, e.g. daemonset-based approach,
 // when master nodes have configured networking.
 func (pc *Controller) runNodeExporter() error {
-	klog.V(2).Infof("Starting node-exporter on master nodes.")
+	klog.V(2).Infof("Starting node-exporter.")
 	kubemarkFramework, err := framework.NewFramework(&pc.clusterLoaderConfig.ClusterConfig, numK8sClients)
 	if err != nil {
 		return err
@@ -554,28 +555,48 @@ func (pc *Controller) runNodeExporter() error {
 		return err
 	}
 
-	var g errgroup.Group
-	numMasters := 0
+	hasControlPlaneNodesWithLabel := false
 	for _, node := range nodes {
-		node := node
 		if util.IsControlPlaneNode(&node) {
-			numMasters++
-			g.Go(func() error {
-				f, err := manifestsFS.Open(nodeExporterPod)
-				if err != nil {
-					return fmt.Errorf("unable to open manifest file: %v", err)
-				}
-				defer f.Close()
-				return pc.ssh.Exec("sudo tee /etc/kubernetes/manifests/node-exporter.yaml > /dev/null", &node, f)
-			})
+			if _, ok := node.Labels["node-role.kubernetes.io/control-plane"]; ok {
+				hasControlPlaneNodesWithLabel = true
+				break
+			}
 		}
 	}
 
-	if numMasters == 0 {
-		return fmt.Errorf("node-exporter requires master to be registered nodes")
+	if hasControlPlaneNodesWithLabel {
+		klog.V(2).Infof("Control-plane nodes with control-plane label are visible in the cluster. Starting node-exporter as DaemonSet.")
+		return pc.applyDefaultManifests(nodeExporterDaemonSet)
 	}
 
-	return g.Wait()
+	if pc.clusterLoaderConfig.ClusterConfig.Provider.Features().SupportSSHToMaster {
+		klog.V(2).Infof("Control plane nodes are not visible in the cluster, but SSH is available. Starting node-exporter on master nodes via SSH.")
+		var g errgroup.Group
+		numMasters := 0
+		for _, node := range nodes {
+			node := node
+			if util.IsControlPlaneNode(&node) {
+				numMasters++
+				g.Go(func() error {
+					f, err := manifestsFS.Open(nodeExporterPod)
+					if err != nil {
+						return fmt.Errorf("unable to open manifest file: %v", err)
+					}
+					defer f.Close()
+					return pc.ssh.Exec("sudo tee /etc/kubernetes/manifests/node-exporter.yaml > /dev/null", &node, f)
+				})
+			}
+		}
+
+		if numMasters == 0 {
+			return fmt.Errorf("node-exporter requires master to be registered nodes for SSH deployment")
+		}
+
+		return g.Wait()
+	}
+
+	return fmt.Errorf("deploying node_exporter failed: control plane nodes are not visible and SSH to master is not supported")
 }
 
 func (pc *Controller) waitForPrometheusToBeHealthy() error {


### PR DESCRIPTION
/kind feature


Need node exporter to debug node problem on control plane, currently node exporter installation is based on SSHing to KCP VM. For providers that keep control plane nodes registered in cluster it would be much easier to just deploy via daemonset

/cc @Jefftree 