### PR TITLE
Fix DRATestDriver readiness passing before drivers and ResourceSlices exist

### DIFF
--- a/clusterloader2/pkg/dependency/dra/dra.go
+++ b/clusterloader2/pkg/dependency/dra/dra.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"embed"
 	"fmt"
-	"strconv"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -35,7 +34,7 @@ const (
 	draDependencyName      = "DRATestDriver"
 	draNamespace           = "dra-example-driver"
 	draManifests           = "dra-example-driver"
-	defaultWorkerNodeCount = "100"
+	defaultWorkerNodeCount = 100
 	draDaemonsetName       = "dra-example-driver-kubeletplugin"
 	checkDRAReadyInterval  = 30 * time.Second
 	defaultDRATimeout      = 10 * time.Minute
@@ -78,9 +77,14 @@ func (d *draDependency) Setup(config *dependency.Config) error {
 		return err
 	}
 
+	workerCount, err := getWorkerCount(config)
+	if err != nil {
+		return err
+	}
+
 	mapping := map[string]interface{}{
 		"Namespace":       namespace,
-		"WorkerNodeCount": getWorkerCount(config),
+		"WorkerNodeCount": workerCount,
 		"ImageRegistry":   config.ClusterLoaderConfig.ImageRegistry,
 	}
 
@@ -150,7 +154,7 @@ func (d *draDependency) waitForDRADriverToBeHealthy(config *dependency.Config, t
 }
 
 func (d *draDependency) isDRADriverReady(config *dependency.Config, daemonsetName string, namespace string) (done bool, err error) {
-	expectedWorkers, err := getExpectedWorkerCount(config)
+	expectedWorkers, err := getWorkerCount(config)
 	if err != nil {
 		return false, err
 	}
@@ -184,7 +188,7 @@ func (d *draDependency) isDRADriverReady(config *dependency.Config, daemonsetNam
 }
 
 func isResourceSlicesPublished(config *dependency.Config) (bool, error) {
-	expectedWorkers, err := getExpectedWorkerCount(config)
+	expectedWorkers, err := getWorkerCount(config)
 	if err != nil {
 		return false, err
 	}
@@ -201,20 +205,8 @@ func isResourceSlicesPublished(config *dependency.Config) (bool, error) {
 	return true, nil
 }
 
-func getExpectedWorkerCount(config *dependency.Config) (int, error) {
-	defaultWorkers, err := strconv.Atoi(defaultWorkerNodeCount)
-	if err != nil {
-		return 0, fmt.Errorf("invalid default worker node count %q: %w", defaultWorkerNodeCount, err)
-	}
-	return util.GetIntOrDefault(config.Params, "WorkerNodeCount", defaultWorkers)
-}
-
-func getWorkerCount(config *dependency.Config) interface{} {
-	workerCount, ok := config.Params["WorkerNodeCount"]
-	if !ok {
-		workerCount = defaultWorkerNodeCount
-	}
-	return workerCount
+func getWorkerCount(config *dependency.Config) (int, error) {
+	return util.GetIntOrDefault(config.Params, "WorkerNodeCount", defaultWorkerNodeCount)
 }
 
 func getNamespace(config *dependency.Config) (string, error) {

--- a/clusterloader2/pkg/dependency/dra/dra.go
+++ b/clusterloader2/pkg/dependency/dra/dra.go
@@ -20,10 +20,9 @@ import (
 	"context"
 	"embed"
 	"fmt"
-	"strings"
+	"strconv"
 	"time"
 
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
@@ -143,7 +142,7 @@ func (d *draDependency) waitForDRADriverToBeHealthy(config *dependency.Config, t
 		checkDRAReadyInterval,
 		timeout,
 		func() (done bool, err error) {
-			return isResourceSlicesPublished(config, namespace)
+			return isResourceSlicesPublished(config)
 		}); err != nil {
 		return err
 	}
@@ -151,6 +150,12 @@ func (d *draDependency) waitForDRADriverToBeHealthy(config *dependency.Config, t
 }
 
 func (d *draDependency) isDRADriverReady(config *dependency.Config, daemonsetName string, namespace string) (done bool, err error) {
+	expectedWorkers, err := getExpectedWorkerCount(config)
+	if err != nil {
+		return false, err
+	}
+	expected := int32(expectedWorkers)
+
 	ds, err := config.ClusterFramework.GetClientSets().
 		GetClient().
 		AppsV1().
@@ -159,58 +164,49 @@ func (d *draDependency) isDRADriverReady(config *dependency.Config, daemonsetNam
 	if err != nil {
 		return false, fmt.Errorf("failed to get %s: %v", daemonsetName, err)
 	}
-	ready := ds.Status.NumberReady == ds.Status.DesiredNumberScheduled
-	if !ready {
-		klog.V(2).Infof("%s is not ready, "+
-			"DesiredNumberScheduled: %d, NumberReady: %d", daemonsetName, ds.Status.DesiredNumberScheduled, ds.Status.NumberReady)
+
+	if ds.Status.DesiredNumberScheduled < expected {
+		klog.V(2).Infof("%s is not ready, expected workers: %d, DesiredNumberScheduled: %d, NumberReady: %d",
+			daemonsetName, expectedWorkers, ds.Status.DesiredNumberScheduled, ds.Status.NumberReady)
+		return false, nil
 	}
-	return ready, nil
-}
-
-func isResourceSlicesPublished(config *dependency.Config, namespace string) (bool, error) {
-	// Get a list of all nodes
-	// nodes, err := getReadyNodesCount(config)
-	// if err != nil {
-	// 	return false, fmt.Errorf("failed to list nodes: %v", err)
-	// }
-
-	driverPluginPods, err := getDriverPluginPods(config, namespace, draDaemonsetName)
-	if err != nil {
-		return false, fmt.Errorf("failed to list driverPluginPods: %v", err)
+	if ds.Status.NumberReady < expected {
+		klog.V(2).Infof("%s is not ready, expected workers: %d, DesiredNumberScheduled: %d, NumberReady: %d",
+			daemonsetName, expectedWorkers, ds.Status.DesiredNumberScheduled, ds.Status.NumberReady)
+		return false, nil
 	}
-
-	workerCount := driverPluginPods
-
-	resourceSlices, err := config.ClusterFramework.GetClientSets().GetClient().ResourceV1().ResourceSlices().List(context.Background(), metav1.ListOptions{})
-	if err != nil {
-		return false, fmt.Errorf("failed to list resourceslices: %v", err)
-	}
-	if len(resourceSlices.Items) != workerCount {
-		klog.V(2).Infof("waiting for resourceslices to be available, "+
-			"DesiredResourceSliceCount: %d, NumberResourceSlicesAvailable: %d", workerCount, len(resourceSlices.Items))
+	if ds.Status.NumberReady != ds.Status.DesiredNumberScheduled {
+		klog.V(2).Infof("%s is not ready, DesiredNumberScheduled: %d, NumberReady: %d",
+			daemonsetName, ds.Status.DesiredNumberScheduled, ds.Status.NumberReady)
 		return false, nil
 	}
 	return true, nil
 }
 
-func getDriverPluginPods(config *dependency.Config, namespace string, namePrefix string) (int, error) {
-	pods, err := config.ClusterFramework.GetClientSets().GetClient().CoreV1().Pods(namespace).List(context.Background(), metav1.ListOptions{})
+func isResourceSlicesPublished(config *dependency.Config) (bool, error) {
+	expectedWorkers, err := getExpectedWorkerCount(config)
 	if err != nil {
-		return 0, fmt.Errorf("failed to list pods in namespace %s: %w", namespace, err)
+		return false, err
 	}
 
-	runningPods := 0
-	for _, pod := range pods.Items {
-		if !strings.HasPrefix(pod.Name, namePrefix) {
-			continue
-		}
-
-		if pod.Status.Phase == corev1.PodRunning {
-			runningPods++
-		}
+	resourceSlices, err := config.ClusterFramework.GetClientSets().GetClient().ResourceV1().ResourceSlices().List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		return false, fmt.Errorf("failed to list resourceslices: %v", err)
 	}
+	if len(resourceSlices.Items) < expectedWorkers {
+		klog.V(2).Infof("waiting for resourceslices to be available, expected: %d, available: %d",
+			expectedWorkers, len(resourceSlices.Items))
+		return false, nil
+	}
+	return true, nil
+}
 
-	return runningPods, nil
+func getExpectedWorkerCount(config *dependency.Config) (int, error) {
+	defaultWorkers, err := strconv.Atoi(defaultWorkerNodeCount)
+	if err != nil {
+		return 0, fmt.Errorf("invalid default worker node count %q: %w", defaultWorkerNodeCount, err)
+	}
+	return util.GetIntOrDefault(config.Params, "WorkerNodeCount", defaultWorkers)
 }
 
 func getWorkerCount(config *dependency.Config) interface{} {

--- a/clusterloader2/pkg/dependency/dra/dra.go
+++ b/clusterloader2/pkg/dependency/dra/dra.go
@@ -20,10 +20,8 @@ import (
 	"context"
 	"embed"
 	"fmt"
-	"strings"
 	"time"
 
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
@@ -131,11 +129,17 @@ func (d *draDependency) Teardown(config *dependency.Config) error {
 }
 
 func (d *draDependency) waitForDRADriverToBeHealthy(config *dependency.Config, timeout time.Duration, daemonsetName string, namespace string) error {
+	var desiredCount int32
 	if err := wait.PollImmediate(
 		checkDRAReadyInterval,
 		timeout,
 		func() (done bool, err error) {
-			return d.isDRADriverReady(config, daemonsetName, namespace)
+			ready, desired, pollErr := d.isDRADriverReady(config, daemonsetName, namespace)
+			if pollErr != nil {
+				return false, pollErr
+			}
+			desiredCount = desired
+			return ready, nil
 		}); err != nil {
 		return err
 	}
@@ -143,74 +147,47 @@ func (d *draDependency) waitForDRADriverToBeHealthy(config *dependency.Config, t
 		checkDRAReadyInterval,
 		timeout,
 		func() (done bool, err error) {
-			return isResourceSlicesPublished(config, namespace)
+			return isResourceSlicesPublished(config, int(desiredCount))
 		}); err != nil {
 		return err
 	}
 	return nil
 }
 
-func (d *draDependency) isDRADriverReady(config *dependency.Config, daemonsetName string, namespace string) (done bool, err error) {
+func (d *draDependency) isDRADriverReady(config *dependency.Config, daemonsetName string, namespace string) (ready bool, desired int32, err error) {
 	ds, err := config.ClusterFramework.GetClientSets().
 		GetClient().
 		AppsV1().
 		DaemonSets(namespace).
 		Get(context.Background(), daemonsetName, metav1.GetOptions{})
 	if err != nil {
-		return false, fmt.Errorf("failed to get %s: %v", daemonsetName, err)
+		return false, 0, fmt.Errorf("failed to get %s: %v", daemonsetName, err)
 	}
-	ready := ds.Status.NumberReady == ds.Status.DesiredNumberScheduled
-	if !ready {
-		klog.V(2).Infof("%s is not ready, "+
-			"DesiredNumberScheduled: %d, NumberReady: %d", daemonsetName, ds.Status.DesiredNumberScheduled, ds.Status.NumberReady)
+
+	if ds.Status.DesiredNumberScheduled == 0 {
+		klog.V(2).Infof("%s is not ready, DesiredNumberScheduled is 0", daemonsetName)
+		return false, 0, nil
 	}
-	return ready, nil
+	if ds.Status.NumberReady != ds.Status.DesiredNumberScheduled {
+		klog.V(2).Infof("%s is not ready, DesiredNumberScheduled: %d, NumberReady: %d",
+			daemonsetName, ds.Status.DesiredNumberScheduled, ds.Status.NumberReady)
+		return false, ds.Status.DesiredNumberScheduled, nil
+	}
+	return true, ds.Status.DesiredNumberScheduled, nil
 }
 
-func isResourceSlicesPublished(config *dependency.Config, namespace string) (bool, error) {
-	// Get a list of all nodes
-	// nodes, err := getReadyNodesCount(config)
-	// if err != nil {
-	// 	return false, fmt.Errorf("failed to list nodes: %v", err)
-	// }
-
-	driverPluginPods, err := getDriverPluginPods(config, namespace, draDaemonsetName)
-	if err != nil {
-		return false, fmt.Errorf("failed to list driverPluginPods: %v", err)
-	}
-
-	workerCount := driverPluginPods
-
+func isResourceSlicesPublished(config *dependency.Config, expected int) (bool, error) {
 	resourceSlices, err := config.ClusterFramework.GetClientSets().GetClient().ResourceV1().ResourceSlices().List(context.Background(), metav1.ListOptions{})
 	if err != nil {
 		return false, fmt.Errorf("failed to list resourceslices: %v", err)
 	}
-	if len(resourceSlices.Items) != workerCount {
-		klog.V(2).Infof("waiting for resourceslices to be available, "+
-			"DesiredResourceSliceCount: %d, NumberResourceSlicesAvailable: %d", workerCount, len(resourceSlices.Items))
+	if len(resourceSlices.Items) < expected {
+		klog.V(2).Infof("waiting for resourceslices to be available, expected: %d, available: %d",
+			expected, len(resourceSlices.Items))
 		return false, nil
 	}
+	klog.V(2).Infof("resourceslices ready, expected: %d, available: %d", expected, len(resourceSlices.Items))
 	return true, nil
-}
-
-func getDriverPluginPods(config *dependency.Config, namespace string, namePrefix string) (int, error) {
-	pods, err := config.ClusterFramework.GetClientSets().GetClient().CoreV1().Pods(namespace).List(context.Background(), metav1.ListOptions{})
-	if err != nil {
-		return 0, fmt.Errorf("failed to list pods in namespace %s: %w", namespace, err)
-	}
-
-	runningPods := 0
-	for _, pod := range pods.Items {
-		if !strings.HasPrefix(pod.Name, namePrefix) {
-			continue
-		}
-
-		if pod.Status.Phase == corev1.PodRunning {
-			runningPods++
-		}
-	}
-
-	return runningPods, nil
 }
 
 func getWorkerCount(config *dependency.Config) interface{} {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
/kind flake

#### What this PR does / why we need it:

DRATestDriver readiness could pass while no driver DaemonSet pods or ResourceSlices existed yet (`DesiredNumberScheduled == NumberReady == 0`, and `0` ResourceSlices matching `0` running plugin pods). FastFill then starts before the DRA driver is usable, which shows up as scheduler "cannot allocate all claims" retries and inflated `create_to_schedule` / FastFillPodStartup p99.

This change waits until `WorkerNodeCount` driver pods are Desired/Ready and at least that many ResourceSlices are published, and uses one typed `getWorkerCount` helper for both manifest templating and readiness checks.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # https://github.com/kubernetes/kubernetes/issues/141046

#### Special notes for your reviewer:

Observed on aws-dra-500Nodes-with-workload FastFillPodStartup p99 spikes where scheduler logs repeatedly report "500 cannot allocate all claims" before binding succeeds.