### PR TITLE
test(clusterloader2): add unit tests for pkg/errors

### DIFF
--- a/clusterloader2/pkg/errors/error_list_test.go
+++ b/clusterloader2/pkg/errors/error_list_test.go
@@ -1,0 +1,176 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package errors
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestNewErrorList(t *testing.T) {
+	errOne := errors.New("first error")
+	errTwo := errors.New("second error")
+	tests := []struct {
+		name      string
+		errors    []error
+		wantEmpty bool
+		want      string
+	}{
+		{
+			name:      "empty",
+			wantEmpty: true,
+			want:      "[]",
+		},
+		{
+			name:      "with errors",
+			errors:    []error{errOne, errTwo},
+			wantEmpty: false,
+			want:      "[first error\nsecond error]",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			list := NewErrorList(tt.errors...)
+			if got := list.IsEmpty(); got != tt.wantEmpty {
+				t.Errorf("IsEmpty() = %t, want %t", got, tt.wantEmpty)
+			}
+			if got := list.String(); got != tt.want {
+				t.Errorf("String() = %q, want %q", got, tt.want)
+			}
+			if got := list.Error(); got != tt.want {
+				t.Errorf("Error() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestErrorListAppend(t *testing.T) {
+	tests := []struct {
+		name string
+		errs []error
+		want string
+	}{
+		{
+			name: "single error",
+			errs: []error{errors.New("first error")},
+			want: "[first error]",
+		},
+		{
+			name: "multiple errors",
+			errs: []error{errors.New("first error"), errors.New("second error")},
+			want: "[first error\nsecond error]",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			list := NewErrorList()
+			list.Append(tt.errs...)
+
+			if list.IsEmpty() {
+				t.Error("IsEmpty() = true, want false")
+			}
+			if got := list.String(); got != tt.want {
+				t.Errorf("String() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestErrorListConcat(t *testing.T) {
+	errOne := errors.New("first error")
+	errTwo := errors.New("second error")
+	tests := []struct {
+		name  string
+		base  []error
+		other *ErrorList
+		want  string
+	}{
+		{
+			name:  "nil list",
+			base:  []error{errOne},
+			other: nil,
+			want:  "[first error]",
+		},
+		{
+			name:  "empty list",
+			base:  []error{errOne},
+			other: NewErrorList(),
+			want:  "[first error]",
+		},
+		{
+			name:  "non-empty list",
+			base:  []error{errOne},
+			other: NewErrorList(errTwo),
+			want:  "[first error\nsecond error]",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			list := NewErrorList(tt.base...)
+			list.Concat(tt.other)
+
+			if got := list.String(); got != tt.want {
+				t.Errorf("String() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestErrorListHas(t *testing.T) {
+	directErr := errors.New("direct error")
+	wrappedErr := errors.New("wrapped error")
+	list := NewErrorList(directErr, fmt.Errorf("context: %w", wrappedErr))
+
+	tests := []struct {
+		name   string
+		target error
+		want   bool
+	}{
+		{
+			name:   "direct match",
+			target: directErr,
+			want:   true,
+		},
+		{
+			name:   "wrapped match",
+			target: wrappedErr,
+			want:   true,
+		},
+		{
+			name:   "different error",
+			target: errors.New("different error"),
+			want:   false,
+		},
+		{
+			name:   "same message but different error",
+			target: errors.New("direct error"),
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := list.Has(tt.target); got != tt.want {
+				t.Errorf("Has(%v) = %t, want %t", tt.target, got, tt.want)
+			}
+		})
+	}
+}

--- a/clusterloader2/pkg/errors/fatal_error_test.go
+++ b/clusterloader2/pkg/errors/fatal_error_test.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package errors
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestNewErrCritical(t *testing.T) {
+	originalErr := errors.New("original error")
+	wrappedErr := fmt.Errorf("wrapped error: %w", originalErr)
+	got := NewErrCritical(wrappedErr)
+
+	if !errors.Is(got, ErrCritical) {
+		t.Errorf("errors.Is(%v, ErrCritical) = false, want true", got)
+	}
+	if !errors.Is(got, wrappedErr) {
+		t.Errorf("errors.Is(%v, wrappedErr) = false, want true", got)
+	}
+	if !errors.Is(got, originalErr) {
+		t.Errorf("errors.Is(%v, originalErr) = false, want true", got)
+	}
+	for _, want := range []string{ErrCritical.Error(), wrappedErr.Error()} {
+		if !strings.Contains(got.Error(), want) {
+			t.Errorf("Error() = %q, want it to contain %q", got.Error(), want)
+		}
+	}
+}

--- a/clusterloader2/pkg/errors/metric_violation_error_test.go
+++ b/clusterloader2/pkg/errors/metric_violation_error_test.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package errors
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestNewMetricViolationError(t *testing.T) {
+	tests := []struct {
+		name   string
+		metric string
+		reason string
+		want   string
+	}{
+		{
+			name:   "metric violation",
+			metric: "pod startup latency",
+			reason: "threshold exceeded",
+			want:   "pod startup latency: threshold exceeded",
+		},
+		{
+			name:   "empty values",
+			metric: "",
+			reason: "",
+			want:   ": ",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NewMetricViolationError(tt.metric, tt.reason).Error(); got != tt.want {
+				t.Errorf("Error() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsMetricViolationError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "metric violation error",
+			err:  NewMetricViolationError("metric", "reason"),
+			want: true,
+		},
+		{
+			name: "standard error",
+			err:  errors.New("standard error"),
+			want: false,
+		},
+		{
+			name: "critical error",
+			err:  NewErrCritical(errors.New("critical error")),
+			want: false,
+		},
+		{
+			name: "nil error",
+			err:  nil,
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsMetricViolationError(tt.err); got != tt.want {
+				t.Errorf("IsMetricViolationError(%v) = %t, want %t", tt.err, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What this PR does

Adds unit test coverage for `clusterloader2/pkg/errors`, which had zero test files. Part of the broader effort tracked in #572 ("clusterloader2 should be covered with unit tests").

Covers all three source files in the package:
- `error_list.go` — `ErrorList`: `IsEmpty`, `Append`, `Concat` (including nil-argument case), `Has` (including `errors.Is`-wrapped error matching), `String`, `Error`
- `fatal_error.go` — `NewErrCritical`, verifying `errors.Is` unwraps to both `ErrCritical` and the original wrapped error
- `metric_violation_error.go` — `NewMetricViolationError` / `IsMetricViolationError`

Package coverage: 100%.

## Relation to #3872

This does not overlap with #3872, which adds a single test (`TestConvertSampleToHistogram`) for `pkg/measurement/util/histogram.go`. This PR targets a different, currently-untested package (`pkg/errors`) chosen specifically to avoid duplicating that work.

## Testing

```
go build ./...
go test ./pkg/errors/... -v -cover
gofmt -l pkg/errors/*_test.go
go vet ./pkg/errors/...
```

All pass, no other files modified.