### PR TITLE
Raise etcd backend quota for write-throughput kind cluster

### DIFF
--- a/clusterloader2/testing/write-throughput/kind.yaml
+++ b/clusterloader2/testing/write-throughput/kind.yaml
@@ -18,3 +18,4 @@ nodes:
       local:
         extraArgs:
           listen-metrics-urls: "http://0.0.0.0:2382"
+          quota-backend-bytes: "8589934592"


### PR DESCRIPTION
etcd's 2GiB default is too small for this benchmark, the 15m run hits NOSPACE around minute 7.