### PR TITLE
perflens: re-base run timestamps so runs share one axis

### DIFF
--- a/perflens/README.md
+++ b/perflens/README.md
@@ -29,9 +29,19 @@ so the x-axis reads as elapsed time since run start instead of wall clock. Midni
 deliberate: Grafana has no duration axis mode, so an axis labelled `00:00`, `00:30`,
 `01:00` reads as elapsed time for free.
 
-The offset is computed once per run, from the earliest `minTime` across its Prometheus
-snapshot blocks, and every block of the run shifts by the same amount. Only the origin
-moves, values and durations are untouched.
+The origin, `t=0`, is **ClusterLoader2's first step**, read from the run's
+`build-log.txt`. That is the same event in every run, which is what makes two runs
+comparable. The start of the Prometheus data is not: it is when scraping began, which
+trails cluster bring-up by a run dependent amount, so anchoring on it would offset two
+overlaid runs by the difference in their bring-up times. Runs whose CL2 log was not
+collected fall back to the start of scraped data, and `perflens ingest` prints which
+anchor it used.
+
+Samples scraped before the test started therefore land *before* the origin, outside the
+default dashboard window. Widen the range to the left to see bring-up.
+
+The offset is computed once per run and every block of the run shifts by the same amount.
+Only the origin moves, values and durations are untouched.
 
 Consequences:
 
@@ -45,7 +55,7 @@ Consequences:
 - The SLO block used to be stamped at ingest time, far from the metrics block of the same
   run. It now carries the run's offset and holds constant across the run's window.
 
-Recover the original wall clock start from `perflens_run_start_timestamp_seconds`:
+Recover the anchor's original wall clock time from `perflens_run_start_timestamp_seconds`:
 
 ```bash
 curl -s -G localhost:9090/api/v1/query \

--- a/perflens/README.md
+++ b/perflens/README.md
@@ -19,3 +19,39 @@
 3. **View the SLO Verification Landing Page**:
    - Open Grafana: [http://localhost:3000/d/perflens-slo-landing](http://localhost:3000/d/perflens-slo-landing)
    - Open Thanos Query: [http://localhost:9090](http://localhost:9090)
+
+---
+
+## Normalized time
+
+Ingest re-bases every sample of a run onto a common anchor of **2000-01-01T00:00:00Z**,
+so the x-axis reads as elapsed time since run start instead of wall clock. Midnight is
+deliberate: Grafana has no duration axis mode, so an axis labelled `00:00`, `00:30`,
+`01:00` reads as elapsed time for free.
+
+The offset is computed once per run, from the earliest `minTime` across its Prometheus
+snapshot blocks, and every block of the run shifts by the same amount. Only the origin
+moves, values and durations are untouched.
+
+Consequences:
+
+- `$run` is a comparison dimension, not a time selector. One time range works for every
+  run, and the variable is multi-select so picking two runs overlays them.
+- Dashboard time ranges are absolute and anchored to the constant, `2000-01-01T00:00:00Z`
+  to `2000-01-01T02:00:00Z`. Never make them relative, `now-2h` points at today. Four
+  measured runs span 88 to 111 minutes, so 2h fits them with room to spare. A longer run is
+  truncated at the right edge with nothing to say data is missing, so widen the range by
+  hand if a run overruns.
+- The SLO block used to be stamped at ingest time, far from the metrics block of the same
+  run. It now carries the run's offset and holds constant across the run's window.
+
+Recover the original wall clock start from `perflens_run_start_timestamp_seconds`:
+
+```bash
+curl -s -G localhost:9090/api/v1/query \
+  --data-urlencode 'query=perflens_run_start_timestamp_seconds' \
+  --data-urlencode 'time=2000-01-01T01:00:00Z'
+```
+
+Normalization is on by default because the shipped dashboards assume the anchor window.
+Pass `-normalize-time=false` to keep original wall clock timestamps.

--- a/perflens/bin/perflens
+++ b/perflens/bin/perflens
@@ -167,6 +167,12 @@ cmd_download() {
       gcloud storage cp -n "${gcs_path}" "${local_file}"
   done
 
+  # ClusterLoader2 logs its step markers to the job level build-log.txt, which is
+  # a sibling of artifacts/ rather than a member of it. Ingest anchors the run's
+  # timeline on the first step, so fetch it when the job published one.
+  gcloud storage cp -n "${PREFIX%/artifacts}/build-log.txt" "${DEST_DIR}/build-log.txt" 2>/dev/null \
+    || echo "    Note: no build-log.txt, ingest will anchor on the start of scraped data"
+
   ABS_RUN_DIR="$(cd "${DEST_DIR}" && pwd)"
   echo "==> Download complete for Build ID ${BUILD_ID}."
   echo "    Saved to: ${ABS_RUN_DIR}"

--- a/perflens/cmd/ingest/main.go
+++ b/perflens/cmd/ingest/main.go
@@ -26,22 +26,24 @@ import (
 
 func main() {
 	opts := parseFlags()
-	if err := ingest.Run(opts.buildID, opts.mode, opts.artifactsDir); err != nil {
+	if err := ingest.Run(opts.buildID, opts.mode, opts.artifactsDir, opts.normalizeTime); err != nil {
 		fmt.Fprintf(os.Stderr, "Ingestion error: %v\n", err)
 		os.Exit(1)
 	}
 }
 
 type options struct {
-	buildID      string
-	mode         string
-	artifactsDir string
+	buildID       string
+	mode          string
+	artifactsDir  string
+	normalizeTime bool
 }
 
 func parseFlags() options {
 	buildID := flag.String("build-id", "", "Prow Build ID, run identifier, or run directory path")
 	mode := flag.String("mode", "all", "Ingestion mode: slo-metrics, prometheus-metrics, or all")
 	artifactsDir := flag.String("artifacts-dir", "", "Root _artifacts directory")
+	normalizeTime := flag.Bool("normalize-time", true, "Re-base sample timestamps so every run starts at the common anchor "+ingest.AnchorTime.Format("2006-01-02T15:04:05Z")+". Disable to keep original wall clock timestamps")
 	flag.Parse()
 
 	if *buildID == "" || *artifactsDir == "" {
@@ -49,8 +51,9 @@ func parseFlags() options {
 		os.Exit(1)
 	}
 	return options{
-		buildID:      *buildID,
-		mode:         *mode,
-		artifactsDir: *artifactsDir,
+		buildID:       *buildID,
+		mode:          *mode,
+		artifactsDir:  *artifactsDir,
+		normalizeTime: *normalizeTime,
 	}
 }

--- a/perflens/config/grafana/dashboards/apiserver_metrics.json
+++ b/perflens/config/grafana/dashboards/apiserver_metrics.json
@@ -801,7 +801,7 @@
         "hide": 0,
         "includeAll": false,
         "label": "Scale Run",
-        "multi": false,
+        "multi": true,
         "name": "run",
         "options": [],
         "query": "label_values(run)",
@@ -879,8 +879,8 @@
     ]
   },
   "time": {
-    "from": "2026-07-03T00:00:00Z",
-    "to": "2026-07-22T23:59:59Z"
+    "from": "2000-01-01T00:00:00Z",
+    "to": "2000-01-01T02:00:00Z"
   },
   "timepicker": {
     "refresh_intervals": [

--- a/perflens/config/grafana/dashboards/control_plane.json
+++ b/perflens/config/grafana/dashboards/control_plane.json
@@ -1,0 +1,886 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "collapsed": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "panels": [],
+      "title": "Process resources",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Resident set size per control-plane process. This is the number to quote for memory. Container working-set memory excludes inactive page cache and badly understates mmap-heavy processes such as etcd. Series are labelled by the Service port name: apiserver, etcd-2382, kube-scheduler, kube-controller-manager. etcd-events is never scraped, so it is absent here.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "min": 0,
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 1
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "process_resident_memory_bytes{run=~\"^$run\",job=\"master\",endpoint!=\"node-exporter\"}",
+          "legendFormat": "${cmp}{{endpoint}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Process RSS",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Cores consumed per control-plane process. Series are labelled by the Service port name: apiserver, etcd-2382, kube-scheduler, kube-controller-manager. etcd-events is never scraped, so it is absent here.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "min": 0,
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 1
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "rate(process_cpu_seconds_total{run=~\"^$run\",job=\"master\",endpoint!=\"node-exporter\"}[1m])",
+          "legendFormat": "${cmp}{{endpoint}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Process CPU",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Goroutine count per control-plane process. Series are labelled by the Service port name: apiserver, etcd-2382, kube-scheduler, kube-controller-manager. etcd-events is never scraped, so it is absent here.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "min": 0,
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 1
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "go_goroutines{run=~\"^$run\",job=\"master\",endpoint!=\"node-exporter\"}",
+          "legendFormat": "${cmp}{{endpoint}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Goroutines",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 9
+      },
+      "id": 5,
+      "panels": [],
+      "title": "Go runtime, kube-apiserver",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Mean number of goroutines waiting on a Go mutex at any instant. This is the only Go lock metric that exists. It does not attribute to a specific lock, and it also counts runtime-internal locks.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "min": 0,
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 10
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "rate(go_sync_mutex_wait_total_seconds_total{job=\"master\",endpoint=\"apiserver\",run=~\"^$run\"}[1m])",
+          "legendFormat": "${cmp}mutex wait",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Goroutines blocked on a mutex",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Mean time a runnable goroutine waits for a P. Use the mean, not a quantile: the exported histogram has few buckets and a low top finite edge, so a p99 taken from it pins to that edge regardless of the real tail.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "min": 0,
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 10
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "rate(go_sched_latencies_seconds_sum{job=\"master\",endpoint=\"apiserver\",run=~\"^$run\"}[1m]) / rate(go_sched_latencies_seconds_count{job=\"master\",endpoint=\"apiserver\",run=~\"^$run\"}[1m])",
+          "legendFormat": "${cmp}sched latency mean",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Goroutine scheduling latency, mean",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Work queued against work executing, against GOMAXPROCS. The third state, waiting, is 98 to 100 percent of goroutines in a healthy apiserver, so total goroutine count moves for reasons unrelated to load.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "min": 0,
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 10
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "go_sched_goroutines_runnable_goroutines{job=\"master\",endpoint=\"apiserver\",run=~\"^$run\"}",
+          "legendFormat": "${cmp}runnable",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "go_sched_goroutines_running_goroutines{job=\"master\",endpoint=\"apiserver\",run=~\"^$run\"}",
+          "legendFormat": "${cmp}running",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Runnable and running goroutines",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Ps with work assigned, summing to GOMAXPROCS. This is NOT CPU consumed. Compare against the Process CPU panel: the gap between the two is time Ps hold work they are not running.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "min": 0,
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 18
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "rate(go_cpu_classes_user_cpu_seconds_total{job=\"master\",endpoint=\"apiserver\",run=~\"^$run\"}[1m])",
+          "legendFormat": "${cmp}user",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "rate(go_cpu_classes_gc_total_cpu_seconds_total{job=\"master\",endpoint=\"apiserver\",run=~\"^$run\"}[1m])",
+          "legendFormat": "${cmp}gc",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "rate(go_cpu_classes_gc_mark_assist_cpu_seconds_total{job=\"master\",endpoint=\"apiserver\",run=~\"^$run\"}[1m])",
+          "legendFormat": "${cmp}gc mark assist",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Go CPU classes",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Live heap after the last GC cycle. Moves with GC timing, so read it alongside allocation rate rather than alone.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "min": 0,
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 18
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "go_gc_heap_live_bytes{job=\"master\",endpoint=\"apiserver\",run=~\"^$run\"}",
+          "legendFormat": "${cmp}live heap",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Live heap",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Bytes allocated per second. A better regression signal than heap size, which GC timing smears.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "min": 0,
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 18
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "rate(go_gc_heap_allocs_bytes_total{job=\"master\",endpoint=\"apiserver\",run=~\"^$run\"}[1m])",
+          "legendFormat": "${cmp}alloc rate",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Allocation rate",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 26
+      },
+      "id": 23,
+      "panels": [],
+      "title": "etcd disk and admission",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Write-path disk latency. etcd shares the control-plane host with the apiserver, so a host-level effect shows up here and in the apiserver panels, and neither is then evidence about the other. Series are labelled by the Service port name: apiserver, etcd-2382, kube-scheduler, kube-controller-manager. etcd-events is never scraped, so it is absent here.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "min": 0,
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 27
+      },
+      "id": 24,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by (endpoint, le) (rate(etcd_disk_wal_fsync_duration_seconds_bucket{run=~\"^$run\"}[1m])))",
+          "legendFormat": "${cmp}{{endpoint}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "etcd WAL fsync p99",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Backend commit latency. Series are labelled by the Service port name: apiserver, etcd-2382, kube-scheduler, kube-controller-manager. etcd-events is never scraped, so it is absent here.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "min": 0,
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 27
+      },
+      "id": 25,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by (endpoint, le) (rate(etcd_disk_backend_commit_duration_seconds_bucket{run=~\"^$run\"}[1m])))",
+          "legendFormat": "${cmp}{{endpoint}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "etcd backend commit p99",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Concurrency actually executing, by request kind.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "min": 0,
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 27
+      },
+      "id": 26,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (request_kind) (apiserver_current_inflight_requests{run=~\"^$run\"})",
+          "legendFormat": "${cmp}{{request_kind}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Inflight requests",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": [
+    "perflens",
+    "control-plane"
+  ],
+  "templating": {
+    "list": [
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "definition": "label_values(run)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Scale Run",
+        "multi": true,
+        "name": "run",
+        "options": [],
+        "query": "label_values(run)",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": "off",
+          "value": ""
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Compare runs",
+        "multi": false,
+        "name": "cmp",
+        "options": [
+          {
+            "selected": true,
+            "text": "off",
+            "value": ""
+          },
+          {
+            "selected": false,
+            "text": "on",
+            "value": "{{run}} "
+          }
+        ],
+        "query": "off : ,on : {{run}} ",
+        "skipUrlSync": false,
+        "type": "custom"
+      }
+    ]
+  },
+  "time": {
+    "from": "2000-01-01T00:00:00Z",
+    "to": "2000-01-01T02:00:00Z"
+  },
+  "timepicker": {},
+  "timezone": "utc",
+  "title": "Control Plane",
+  "uid": "perflens-control-plane",
+  "version": 1
+}

--- a/perflens/config/grafana/dashboards/node_exporter.json
+++ b/perflens/config/grafana/dashboards/node_exporter.json
@@ -15421,7 +15421,7 @@
         "hide": 0,
         "includeAll": false,
         "label": "Scale Run",
-        "multi": false,
+        "multi": true,
         "name": "run",
         "options": [],
         "query": {
@@ -15458,8 +15458,8 @@
     ]
   },
   "time": {
-    "from": "now-7d",
-    "to": "now"
+    "from": "2000-01-01T00:00:00Z",
+    "to": "2000-01-01T02:00:00Z"
   },
   "timepicker": {},
   "timezone": "browser",

--- a/perflens/config/grafana/dashboards/slo_landing_page.json
+++ b/perflens/config/grafana/dashboards/slo_landing_page.json
@@ -30,7 +30,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "last_over_time(k8s_slo_status{run=~\"$run\", slo=~\"$slo\", resource=~\"$resource\", verb=~\"$verb\"}[100y])",
+          "expr": "last_over_time(k8s_slo_status{run=~\"$run\", slo=~\"$slo\", resource=~\"$resource\", verb=~\"$verb\"}[$__range])",
           "format": "table",
           "instant": true,
           "range": false,
@@ -130,7 +130,7 @@
         "hide": 0,
         "includeAll": false,
         "label": "Scale Run",
-        "multi": false,
+        "multi": true,
         "name": "run",
         "options": [],
         "query": {
@@ -242,8 +242,8 @@
     ]
   },
   "time": {
-    "from": "now-100y",
-    "to": "now"
+    "from": "2000-01-01T00:00:00Z",
+    "to": "2000-01-01T02:00:00Z"
   },
   "timepicker": {
     "hidden": true

--- a/perflens/config/grafana/dashboards/write_throughput.json
+++ b/perflens/config/grafana/dashboards/write_throughput.json
@@ -1433,7 +1433,7 @@
         "hide": 0,
         "includeAll": false,
         "label": "Scale Run",
-        "multi": false,
+        "multi": true,
         "name": "run",
         "options": [],
         "query": "label_values(run)",
@@ -1471,8 +1471,8 @@
     ]
   },
   "time": {
-    "from": "2026-08-05T19:20:55.755Z",
-    "to": "2026-08-05T19:28:50.514Z"
+    "from": "2000-01-01T00:00:00Z",
+    "to": "2000-01-01T02:00:00Z"
   },
   "timepicker": {
     "refresh_intervals": [

--- a/perflens/docker/docker-compose.yml
+++ b/perflens/docker/docker-compose.yml
@@ -9,6 +9,10 @@ services:
     environment:
       - GF_AUTH_ANONYMOUS_ENABLED=true
       - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+      - GF_NEWS_NEWS_FEED_ENABLED=false
+      - GF_ANALYTICS_REPORTING_ENABLED=false
+      - GF_ANALYTICS_CHECK_FOR_UPDATES=false
+      - GF_ANALYTICS_CHECK_FOR_PLUGIN_UPDATES=false
     volumes:
       - ../config/grafana/provisioning:/etc/grafana/provisioning
       - ../config/grafana/dashboards:/var/lib/grafana/dashboards

--- a/perflens/go.mod
+++ b/perflens/go.mod
@@ -3,6 +3,7 @@ module k8s.io/perf-tests/perflens
 go 1.26.4
 
 require (
+	github.com/oklog/ulid/v2 v2.1.1
 	github.com/prometheus/prometheus v0.309.1
 	github.com/thanos-io/thanos v0.42.2
 )
@@ -56,7 +57,6 @@ require (
 	github.com/minio/sha256-simd v1.0.1 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f // indirect
-	github.com/oklog/ulid/v2 v2.1.1 // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect

--- a/perflens/pkg/ingest/block.go
+++ b/perflens/pkg/ingest/block.go
@@ -1,0 +1,196 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ingest
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+
+	"github.com/oklog/ulid/v2"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/tsdb"
+	"github.com/thanos-io/thanos/pkg/block/metadata"
+)
+
+const twoHoursMS = int64(2 * 60 * 60 * 1000)
+
+// runSpanStepMS is the cadence used for values that hold for a whole run, such as
+// SLO verdicts and the run start marker. It has to stay well under Prometheus'
+// 5 minute staleness lookback, otherwise an instant query landing between two
+// samples reads the series as absent.
+const runSpanStepMS = int64(60 * 1000)
+
+// appendRunSpan writes value as a constant series across [startMS, endMS], so the
+// series is readable from any instant inside the run rather than only at its edges.
+func appendRunSpan(app storage.Appender, lbls labels.Labels, startMS, endMS int64, value float64) error {
+	var ref storage.SeriesRef
+	for ts := startMS; ts < endMS; ts += runSpanStepMS {
+		var err error
+		if ref, err = app.Append(ref, lbls, ts, value); err != nil {
+			return err
+		}
+	}
+	_, err := app.Append(ref, lbls, endMS, value)
+	return err
+}
+
+// blockSizeForSpan returns a head chunk range wide enough to hold [minMS, maxMS].
+// The TSDB head rejects any sample older than maxTime minus half the chunk range,
+// so a range narrower than twice the span would silently drop the beginning of
+// every series appended after the first one.
+func blockSizeForSpan(minMS, maxMS int64) int64 {
+	span := maxMS - minMS
+	if span < 0 {
+		span = 0
+	}
+	size := 2*span + 2
+	if size < twoHoursMS {
+		size = twoHoursMS
+	}
+	return size
+}
+
+// Thanos block sources, one per ingester. They double as the key for replacing a
+// run's previous blocks, so re-running a single mode never drops another mode's work.
+const (
+	sourceSnapshot = "perflens-snapshot-ingest"
+	sourceSLO      = "perflens-ingest"
+	sourceLogs     = "perflens-log-ingest"
+	sourceTimebase = "perflens-timebase"
+)
+
+// removeRunBlocks deletes the blocks in tsdbDir that this run already has from the
+// given source, so a re-ingest replaces the run rather than stacking a second copy
+// of it on the same axis. Blocks always get a fresh ULID rather than reusing the
+// source one, because Thanos Store caches a block's index header by ULID and would
+// keep serving the previous content otherwise.
+func removeRunBlocks(tsdbDir string, runName string, source string) (int, error) {
+	entries, err := os.ReadDir(tsdbDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, nil
+		}
+		return 0, err
+	}
+
+	removed := 0
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		blockDir := filepath.Join(tsdbDir, entry.Name())
+		meta, err := metadata.ReadFromDir(blockDir)
+		if err != nil || meta.Thanos.Labels["run"] != runName || string(meta.Thanos.Source) != source {
+			continue
+		}
+		if err := os.RemoveAll(blockDir); err != nil {
+			return removed, fmt.Errorf("removing stale block %s: %w", entry.Name(), err)
+		}
+		removed++
+	}
+	return removed, nil
+}
+
+// writeThanosBlock builds a TSDB block via fill, stamps it with the run's Thanos
+// external label and installs it in tsdbDir. Writing happens in a staging
+// directory outside tsdbDir so Thanos Store never observes a half-built block in
+// the bucket.
+func writeThanosBlock(ctx context.Context, tsdbDir string, runName string, source string, blockSizeMS int64, fill func(bw *tsdb.BlockWriter) error) (ulid.ULID, error) {
+	tsdbDirAbs, err := filepath.Abs(tsdbDir)
+	if err != nil {
+		return ulid.ULID{}, err
+	}
+	if err := os.MkdirAll(tsdbDirAbs, 0755); err != nil {
+		return ulid.ULID{}, err
+	}
+
+	stagingRoot := filepath.Join(filepath.Dir(tsdbDirAbs), ".perflens-staging")
+	if err := os.MkdirAll(stagingRoot, 0755); err != nil {
+		return ulid.ULID{}, err
+	}
+	staging, err := os.MkdirTemp(stagingRoot, "block-")
+	if err != nil {
+		return ulid.ULID{}, err
+	}
+	defer os.RemoveAll(staging)
+
+	blockULID, err := writeTSDBBlock(ctx, staging, blockSizeMS, fill)
+	if err != nil {
+		return ulid.ULID{}, err
+	}
+
+	blockDir := filepath.Join(staging, blockULID.String())
+	if err := stampBlockMeta(blockDir, runName, source); err != nil {
+		return ulid.ULID{}, err
+	}
+
+	target := filepath.Join(tsdbDirAbs, blockULID.String())
+	if err := os.RemoveAll(target); err != nil {
+		return ulid.ULID{}, err
+	}
+	if err := os.Rename(blockDir, target); err != nil {
+		return ulid.ULID{}, fmt.Errorf("installing block %s: %w", blockULID, err)
+	}
+	return blockULID, nil
+}
+
+func writeTSDBBlock(ctx context.Context, destDir string, blockSizeMS int64, fill func(bw *tsdb.BlockWriter) error) (ulid.ULID, error) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	bw, err := tsdb.NewBlockWriter(logger, destDir, blockSizeMS)
+	if err != nil {
+		return ulid.ULID{}, fmt.Errorf("creating TSDB BlockWriter: %w", err)
+	}
+	defer bw.Close()
+
+	if err := fill(bw); err != nil {
+		return ulid.ULID{}, err
+	}
+
+	blockULID, err := bw.Flush(ctx)
+	if err != nil {
+		return ulid.ULID{}, fmt.Errorf("writing TSDB block: %w", err)
+	}
+	if blockULID == (ulid.ULID{}) {
+		return ulid.ULID{}, fmt.Errorf("no block written, appender produced no series")
+	}
+	return blockULID, nil
+}
+
+// stampBlockMeta injects the run's Thanos external label into a freshly written block.
+func stampBlockMeta(blockDir string, runName string, source string) error {
+	meta, err := metadata.ReadFromDir(blockDir)
+	if err != nil {
+		return fmt.Errorf("reading block meta in %s: %w", blockDir, err)
+	}
+
+	meta.Thanos = metadata.Thanos{
+		Labels: map[string]string{
+			"run": runName,
+		},
+		Source: metadata.SourceType(source),
+	}
+
+	if err := meta.WriteToDir(nopLogger{}, blockDir); err != nil {
+		return fmt.Errorf("writing block meta in %s: %w", blockDir, err)
+	}
+	return nil
+}

--- a/perflens/pkg/ingest/cl2steps.go
+++ b/perflens/pkg/ingest/cl2steps.go
@@ -1,0 +1,147 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ingest
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// cl2StepStartRe matches the step marker ClusterLoader2 logs at klog -v=2, from
+// clusterloader2/pkg/test/simple_test_executor.go:
+//
+//	I0726 16:23:51.123456      12 simple_test_executor.go:162] Step "foo" started
+//
+// klog omits the year, so only MMDD and the time of day are captured.
+var cl2StepStartRe = regexp.MustCompile(`[IWEF](\d{2})(\d{2})\s+(\d{2}:\d{2}:\d{2})(?:\.\d+)?\s.*Step\s+"`)
+
+// maxCL2LogScanBytes bounds a single log line. Prow build logs interleave every
+// component's output, and a stray binary blob would otherwise abort the scan
+// with ErrTooLong before the first step marker is reached.
+const maxCL2LogScanBytes = 1 << 20
+
+// cl2TestStart returns the wall clock time of ClusterLoader2's first step, in
+// Unix millis. That is when the test proper begins, which is later, and by a
+// run dependent amount, than when Prometheus started scraping. Anchoring on it
+// is what makes two runs line up at the same event rather than at whatever
+// their bring-up happened to cost.
+//
+// hintMS is any timestamp known to fall inside the run, used to recover the
+// year that klog leaves out.
+func cl2TestStart(runDir string, hintMS int64) (int64, bool) {
+	var best int64
+	found := false
+
+	for _, path := range findCL2LogFiles(runDir) {
+		ms, ok := firstStepStart(path, hintMS)
+		if !ok {
+			continue
+		}
+		if !found || ms < best {
+			best = ms
+			found = true
+		}
+	}
+	return best, found
+}
+
+// findCL2LogFiles lists the files that may carry ClusterLoader2's own output.
+// On Prow the framework logs to the job level build-log.txt, which sits beside
+// artifacts/ rather than inside it, so both locations are searched.
+func findCL2LogFiles(runDir string) []string {
+	var files []string
+
+	for _, name := range []string{
+		filepath.Join(runDir, "build-log.txt"),
+		filepath.Join(runDir, "artifacts", "build-log.txt"),
+	} {
+		if info, err := os.Stat(name); err == nil && !info.IsDir() {
+			files = append(files, name)
+		}
+	}
+
+	_ = filepath.Walk(filepath.Join(runDir, "artifacts"), func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() {
+			return nil
+		}
+		name := strings.ToLower(info.Name())
+		if strings.HasPrefix(name, "clusterloader") && strings.Contains(name, ".log") {
+			files = append(files, path)
+		}
+		return nil
+	})
+
+	return files
+}
+
+// firstStepStart scans one log file for the earliest step marker.
+func firstStepStart(path string, hintMS int64) (int64, bool) {
+	f, err := os.Open(path)
+	if err != nil {
+		return 0, false
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), maxCL2LogScanBytes)
+	for scanner.Scan() {
+		m := cl2StepStartRe.FindStringSubmatch(scanner.Text())
+		if m == nil {
+			continue
+		}
+		if ms, ok := klogTimeToMillis(m[1], m[2], m[3], hintMS); ok {
+			return ms, true
+		}
+	}
+	return 0, false
+}
+
+// klogTimeToMillis resolves a klog MMDD plus time of day to Unix millis. klog
+// prints no year, so the candidate nearest hintMS wins. Trying the neighbouring
+// years too is what keeps a run that straddles New Year from landing 12 months
+// away from its own metrics.
+func klogTimeToMillis(mm, dd, hhmmss string, hintMS int64) (int64, bool) {
+	hint := time.UnixMilli(hintMS).UTC()
+
+	var best int64
+	found := false
+	for _, year := range []int{hint.Year() - 1, hint.Year(), hint.Year() + 1} {
+		stamp := time.Date(year, 1, 1, 0, 0, 0, 0, time.UTC).Format("2006") +
+			"-" + mm + "-" + dd + "T" + hhmmss + "Z"
+		t, err := time.Parse(time.RFC3339, stamp)
+		if err != nil {
+			continue
+		}
+		ms := t.UnixMilli()
+		if !found || absInt64(ms-hintMS) < absInt64(best-hintMS) {
+			best = ms
+			found = true
+		}
+	}
+	return best, found
+}
+
+func absInt64(v int64) int64 {
+	if v < 0 {
+		return -v
+	}
+	return v
+}

--- a/perflens/pkg/ingest/cl2steps_test.go
+++ b/perflens/pkg/ingest/cl2steps_test.go
@@ -1,0 +1,197 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ingest
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func ms(t *testing.T, rfc3339 string) int64 {
+	t.Helper()
+	parsed, err := time.Parse(time.RFC3339, rfc3339)
+	if err != nil {
+		t.Fatalf("bad timestamp %q: %v", rfc3339, err)
+	}
+	return parsed.UnixMilli()
+}
+
+// buildLog is a trimmed excerpt of a Prow build-log.txt: some non-CL2 noise,
+// then the step markers clusterloader2 emits at -v=2.
+const buildLog = `I0726 16:20:11.100000       1 clusterloader.go:230] Building cluster framework
+I0726 16:20:12.000000       1 imagepreload.go:96] Preloading images
+I0726 16:23:51.123456      12 simple_test_executor.go:162] Step "Starting measurement for 'load'" started
+I0726 16:23:51.987000      12 simple_test_executor.go:183] Step "Starting measurement for 'load'" ended
+I0726 16:44:36.000000      12 simple_test_executor.go:162] Step "Collecting measurements" started
+`
+
+func writeRun(t *testing.T, files map[string]string) string {
+	t.Helper()
+	dir := t.TempDir()
+	for rel, body := range files {
+		full := filepath.Join(dir, rel)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return dir
+}
+
+func TestCL2TestStartFindsFirstStep(t *testing.T) {
+	hint := ms(t, "2026-07-26T16:15:00Z")
+
+	for _, tc := range []struct {
+		name  string
+		files map[string]string
+	}{
+		{"job level build log", map[string]string{"build-log.txt": buildLog}},
+		{"under artifacts", map[string]string{"artifacts/build-log.txt": buildLog}},
+		{"named clusterloader log", map[string]string{"artifacts/clusterloader2.log": buildLog}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := cl2TestStart(writeRun(t, tc.files), hint)
+			if !ok {
+				t.Fatal("expected to find a step marker")
+			}
+			if want := ms(t, "2026-07-26T16:23:51Z"); got != want {
+				t.Errorf("got %d (%s), want %d (%s)",
+					got, time.UnixMilli(got).UTC(), want, time.UnixMilli(want).UTC())
+			}
+		})
+	}
+}
+
+// The earliest marker wins even when it is not in the first file walked.
+func TestCL2TestStartTakesEarliestAcrossFiles(t *testing.T) {
+	late := `I0726 17:00:00.000000 12 simple_test_executor.go:162] Step "later" started` + "\n"
+	dir := writeRun(t, map[string]string{
+		"build-log.txt":                late,
+		"artifacts/clusterloader2.log": buildLog,
+	})
+
+	got, ok := cl2TestStart(dir, ms(t, "2026-07-26T16:15:00Z"))
+	if !ok {
+		t.Fatal("expected to find a step marker")
+	}
+	if want := ms(t, "2026-07-26T16:23:51Z"); got != want {
+		t.Errorf("got %s, want %s", time.UnixMilli(got).UTC(), time.UnixMilli(want).UTC())
+	}
+}
+
+func TestCL2TestStartAbsentWithoutMarkers(t *testing.T) {
+	dir := writeRun(t, map[string]string{
+		"build-log.txt": "I0726 16:20:11.100000 1 clusterloader.go:230] no steps here\n",
+	})
+	if _, ok := cl2TestStart(dir, ms(t, "2026-07-26T16:15:00Z")); ok {
+		t.Error("expected no step marker to be found")
+	}
+}
+
+func TestCL2TestStartOnEmptyRunDir(t *testing.T) {
+	if _, ok := cl2TestStart(t.TempDir(), ms(t, "2026-07-26T16:15:00Z")); ok {
+		t.Error("expected no step marker in an empty run dir")
+	}
+}
+
+// klog omits the year, so a run that straddles New Year must resolve against
+// the neighbouring year rather than the hint's own.
+func TestKlogTimeToMillisPicksNearestYear(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		mm, dd, hms string
+		hint, want  string
+	}{
+		{"same year", "07", "26", "16:23:51", "2026-07-26T16:15:00Z", "2026-07-26T16:23:51Z"},
+		{"log in december, hint in january", "12", "31", "23:50:00", "2027-01-01T00:10:00Z", "2026-12-31T23:50:00Z"},
+		{"log in january, hint in december", "01", "01", "00:10:00", "2026-12-31T23:50:00Z", "2027-01-01T00:10:00Z"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := klogTimeToMillis(tc.mm, tc.dd, tc.hms, ms(t, tc.hint))
+			if !ok {
+				t.Fatal("expected a resolved timestamp")
+			}
+			if want := ms(t, tc.want); got != want {
+				t.Errorf("got %s, want %s", time.UnixMilli(got).UTC(), time.UnixMilli(want).UTC())
+			}
+		})
+	}
+}
+
+// A leap day only parses against the leap year, so the nearest-year search must
+// skip the candidates that fail to parse rather than give up on the line.
+func TestKlogTimeToMillisLeapDay(t *testing.T) {
+	got, ok := klogTimeToMillis("02", "29", "12:00:00", ms(t, "2028-03-01T00:00:00Z"))
+	if !ok {
+		t.Fatal("expected a resolved timestamp")
+	}
+	if want := ms(t, "2028-02-29T12:00:00Z"); got != want {
+		t.Errorf("got %s, want %s", time.UnixMilli(got).UTC(), time.UnixMilli(want).UTC())
+	}
+}
+
+// The anchor is the CL2 first step when the log is there, and falls back to the
+// start of scraped data when it is not. Either way the offset must map the
+// anchor exactly onto AnchorTime.
+func TestRunAnchorPrefersCL2StepOverDataStart(t *testing.T) {
+	dataStart := ms(t, "2026-07-26T16:15:00Z")
+
+	withLog := writeRun(t, map[string]string{"build-log.txt": buildLog})
+	got, src := runAnchor(withLog, dataStart)
+	if want := ms(t, "2026-07-26T16:23:51Z"); got != want {
+		t.Errorf("anchor: got %s, want %s", time.UnixMilli(got).UTC(), time.UnixMilli(want).UTC())
+	}
+	if src != "clusterloader2 first step" {
+		t.Errorf("source: got %q", src)
+	}
+
+	got, src = runAnchor(t.TempDir(), dataStart)
+	if got != dataStart {
+		t.Errorf("fallback anchor: got %s, want %s", time.UnixMilli(got).UTC(), time.UnixMilli(dataStart).UTC())
+	}
+	if src != "start of scraped data" {
+		t.Errorf("fallback source: got %q", src)
+	}
+}
+
+// Samples scraped before the test starts must land before the origin, and the
+// anchor itself must land exactly on it.
+func TestTimebaseShiftPutsAnchorOnOrigin(t *testing.T) {
+	tb := &Timebase{
+		Enabled:  true,
+		Known:    true,
+		StartMS:  ms(t, "2026-07-26T16:15:00Z"),
+		EndMS:    ms(t, "2026-07-26T17:44:36Z"),
+		AnchorMS: ms(t, "2026-07-26T16:23:51Z"),
+	}
+	tb.OffsetMS = AnchorTimeMillis - tb.AnchorMS
+
+	if got := tb.Shift(tb.AnchorMS); got != AnchorTimeMillis {
+		t.Errorf("anchor shifted to %s, want %s",
+			time.UnixMilli(got).UTC(), AnchorTime.Format(time.RFC3339))
+	}
+	if got := tb.NormalizedStart(); got >= AnchorTimeMillis {
+		t.Errorf("pre-test data shifted to %s, want it before the origin", time.UnixMilli(got).UTC())
+	}
+	if got, want := tb.NormalizedEnd()-tb.NormalizedStart(), tb.EndMS-tb.StartMS; got != want {
+		t.Errorf("duration changed under shift: got %d, want %d", got, want)
+	}
+}

--- a/perflens/pkg/ingest/log_ingester.go
+++ b/perflens/pkg/ingest/log_ingester.go
@@ -20,7 +20,6 @@ import (
 	"bufio"
 	"context"
 	"fmt"
-	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -32,7 +31,6 @@ import (
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/tsdb"
-	"github.com/thanos-io/thanos/pkg/block/metadata"
 )
 
 var defaultLatencyBuckets = []float64{0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0}
@@ -46,7 +44,7 @@ func NewLogIngester() *LogIngester {
 }
 
 // Ingest parses apiserver trace logs in runDir and generates OpenMetrics & Thanos TSDB block.
-func (l *LogIngester) Ingest(ctx context.Context, runDir string, runName string, tsdbDir string, omDir string) error {
+func (l *LogIngester) Ingest(ctx context.Context, runDir string, runName string, tsdbDir string, omDir string, tb *Timebase) error {
 	logFiles, err := findAPIServerLogFiles(runDir)
 	if err != nil || len(logFiles) == 0 {
 		return fmt.Errorf("no kube-apiserver log files found in %s", runDir)
@@ -64,7 +62,7 @@ func (l *LogIngester) Ingest(ctx context.Context, runDir string, runName string,
 		return fmt.Errorf("processing logs and writing OpenMetrics: %w", err)
 	}
 
-	if err := createThanosTSDBBlockFromOpenMetrics(ctx, tsdbDir, runName, omFile); err != nil {
+	if err := createThanosTSDBBlockFromOpenMetrics(ctx, tsdbDir, runName, omFile, tb); err != nil {
 		return fmt.Errorf("creating Thanos TSDB block for logs: %w", err)
 	}
 
@@ -538,32 +536,79 @@ func convertToEpoch(dateStr, tsStr string) int64 {
 	return t.Unix()
 }
 
-func createThanosTSDBBlockFromOpenMetrics(ctx context.Context, tsdbDir string, runName string, openmetricsFilePath string) error {
+// createThanosTSDBBlockFromOpenMetrics writes the parsed log traces into a TSDB
+// block, shifting sample timestamps by the run's offset so the log block stays
+// aligned with the run's snapshot and SLO blocks.
+func createThanosTSDBBlockFromOpenMetrics(ctx context.Context, tsdbDir string, runName string, openmetricsFilePath string, tb *Timebase) error {
+	minMS, maxMS, err := openMetricsTimeRange(openmetricsFilePath, runName, tb)
+	if err != nil {
+		return err
+	}
+
+	samplesCount := 0
+	if _, err := removeRunBlocks(tsdbDir, runName, sourceLogs); err != nil {
+		return err
+	}
+
+	blockULID, err := writeThanosBlock(ctx, tsdbDir, runName, sourceLogs,
+		blockSizeForSpan(minMS, maxMS),
+		func(bw *tsdb.BlockWriter) error {
+			app := bw.Appender(ctx)
+			err := scanOpenMetricsSamples(openmetricsFilePath, runName, tb, func(lblsMap map[string]string, value float64, tsMS int64) error {
+				if _, err := app.Append(0, labels.FromMap(lblsMap), tsMS, value); err != nil {
+					return fmt.Errorf("appending sample %s to TSDB: %w", lblsMap["__name__"], err)
+				}
+				samplesCount++
+				return nil
+			})
+			if err != nil {
+				return err
+			}
+			return app.Commit()
+		})
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Native Thanos TSDB block for log traces created successfully: ULID %s in %s (%d samples)\n", blockULID, tsdbDir, samplesCount)
+	return nil
+}
+
+// openMetricsTimeRange is a first pass over the generated file, needed because
+// the TSDB head only accepts samples once its chunk range is known to cover them.
+func openMetricsTimeRange(openmetricsFilePath string, runName string, tb *Timebase) (int64, int64, error) {
+	var minMS, maxMS int64
+	found := false
+
+	err := scanOpenMetricsSamples(openmetricsFilePath, runName, tb, func(_ map[string]string, _ float64, tsMS int64) error {
+		if !found || tsMS < minMS {
+			minMS = tsMS
+		}
+		if !found || tsMS > maxMS {
+			maxMS = tsMS
+		}
+		found = true
+		return nil
+	})
+	if err != nil {
+		return 0, 0, err
+	}
+	if !found {
+		return 0, 0, fmt.Errorf("no valid samples parsed from %s", openmetricsFilePath)
+	}
+	return minMS, maxMS, nil
+}
+
+func scanOpenMetricsSamples(openmetricsFilePath string, runName string, tb *Timebase, visit func(lblsMap map[string]string, value float64, tsMS int64) error) error {
 	file, err := os.Open(openmetricsFilePath)
 	if err != nil {
 		return fmt.Errorf("opening openmetrics file %s: %w", openmetricsFilePath, err)
 	}
 	defer file.Close()
 
-	tsdbDirAbs, err := filepath.Abs(tsdbDir)
-	if err != nil {
-		return err
-	}
-
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	bw, err := tsdb.NewBlockWriter(logger, tsdbDirAbs, 2*60*60*1000)
-	if err != nil {
-		return fmt.Errorf("creating TSDB BlockWriter: %w", err)
-	}
-	defer bw.Close()
-
-	app := bw.Appender(ctx)
-
 	scanner := bufio.NewScanner(file)
 	buf := make([]byte, 1024*1024)
 	scanner.Buffer(buf, 16*1024*1024)
-
-	samplesCount := 0
 
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
@@ -577,40 +622,11 @@ func createThanosTSDBBlockFromOpenMetrics(ctx context.Context, tsdbDir string, r
 		}
 		lblsMap["__name__"] = name
 
-		if _, err := app.Append(0, labels.FromMap(lblsMap), tsMS, valFloat); err != nil {
-			return fmt.Errorf("appending sample %s to TSDB: %w", name, err)
+		if err := visit(lblsMap, valFloat, tb.Shift(tsMS)); err != nil {
+			return err
 		}
-		samplesCount++
 	}
-
-	if samplesCount == 0 {
-		return fmt.Errorf("no valid samples parsed from %s", openmetricsFilePath)
-	}
-
-	if err := app.Commit(); err != nil {
-		return fmt.Errorf("committing TSDB appender: %w", err)
-	}
-
-	blockULID, err := bw.Flush(ctx)
-	if err != nil {
-		return fmt.Errorf("writing TSDB block: %w", err)
-	}
-
-	blockDir := filepath.Join(tsdbDirAbs, blockULID.String())
-	thanosMeta := metadata.Thanos{
-		Labels: map[string]string{
-			"run": runName,
-		},
-		Source: metadata.SourceType("perflens-log-ingest"),
-	}
-
-	nopLog := nopLogger{}
-	if _, err := metadata.InjectThanos(nopLog, blockDir, thanosMeta, nil); err != nil {
-		return fmt.Errorf("injecting Thanos metadata into block %s: %w", blockULID.String(), err)
-	}
-
-	fmt.Printf("Native Thanos TSDB block for log traces created successfully: ULID %s in %s (%d samples)\n", blockULID.String(), tsdbDirAbs, samplesCount)
-	return nil
+	return scanner.Err()
 }
 
 func parseOpenMetricsSampleLine(line string, runName string) (string, map[string]string, float64, int64, error) {

--- a/perflens/pkg/ingest/perflens.go
+++ b/perflens/pkg/ingest/perflens.go
@@ -25,7 +25,7 @@ import (
 )
 
 // Run executes the metric ingestion pipeline for a given build ID, mode, and artifacts root directory.
-func Run(buildID string, mode string, artifactsDir string) error {
+func Run(buildID string, mode string, artifactsDir string, normalizeTime bool) error {
 	rawBuildID := strings.TrimPrefix(buildID, "run-")
 	runName := "run-" + rawBuildID
 
@@ -41,9 +41,21 @@ func Run(buildID string, mode string, artifactsDir string) error {
 	ctx := context.Background()
 	modeLower := strings.ToLower(mode)
 
+	// One Timebase for the whole run. Every ingester shifts by this same offset,
+	// otherwise the run's blocks would desync against each other.
+	timebase := NewTimebase(runDir, runName, normalizeTime)
+	fmt.Println(timebase.Describe())
+	if normalizeTime && !timebase.Known {
+		fmt.Fprintf(os.Stderr, "Warning: could not determine the wall clock window of %s, ingesting without normalization\n", runName)
+	}
+
+	if err := writeRunTimebaseBlock(ctx, tsdbDir, timebase); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning/Info: %v\n", err)
+	}
+
 	if modeLower == "slo" || modeLower == "all" {
 		sloIngester := NewSLOIngester()
-		if err := sloIngester.Ingest(ctx, runDir, runName, tsdbDir, omDir); err != nil {
+		if err := sloIngester.Ingest(ctx, runDir, runName, tsdbDir, omDir, timebase); err != nil {
 			fmt.Fprintf(os.Stderr, "Error ingesting SLO metrics for build %s: %v\n", buildID, err)
 			if modeLower != "all" {
 				return err
@@ -53,14 +65,14 @@ func Run(buildID string, mode string, artifactsDir string) error {
 
 	if modeLower == "prometheus-metrics" || modeLower == "prometheus" || modeLower == "all" {
 		promIngester := NewPrometheusIngester()
-		if err := promIngester.Ingest(ctx, runDir, runName, tsdbDir); err != nil {
+		if err := promIngester.Ingest(ctx, runDir, runName, tsdbDir, timebase); err != nil {
 			fmt.Fprintf(os.Stderr, "Warning/Info: Prometheus snapshot ingestion for build %s: %v\n", buildID, err)
 		}
 	}
 
 	if modeLower == "log-metrics" || modeLower == "logs" || modeLower == "all" {
 		logIngester := NewLogIngester()
-		if err := logIngester.Ingest(ctx, runDir, runName, tsdbDir, omDir); err != nil {
+		if err := logIngester.Ingest(ctx, runDir, runName, tsdbDir, omDir, timebase); err != nil {
 			fmt.Fprintf(os.Stderr, "Warning/Info: Log trace ingestion for build %s: %v\n", buildID, err)
 		}
 	}

--- a/perflens/pkg/ingest/prometheus_ingester.go
+++ b/perflens/pkg/ingest/prometheus_ingester.go
@@ -19,11 +19,22 @@ package ingest
 import (
 	"context"
 	"fmt"
-	"os"
+	"io"
+	"log/slog"
 	"path/filepath"
+	"time"
 
-	"github.com/thanos-io/thanos/pkg/block/metadata"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/tsdb"
+	"github.com/prometheus/prometheus/tsdb/chunkenc"
 )
+
+// commitEverySamples bounds how much an in-flight appender transaction holds in
+// memory while a large snapshot block is rewritten. Commits only happen on a
+// series boundary, so this is a floor rather than an exact batch size. Tests
+// lower it to exercise the multi-transaction path.
+var commitEverySamples = 2_000_000
 
 // PrometheusIngester processes downloaded Prometheus TSDB snapshot blocks and injects Thanos metadata.
 type PrometheusIngester struct{}
@@ -33,58 +44,130 @@ func NewPrometheusIngester() *PrometheusIngester {
 	return &PrometheusIngester{}
 }
 
-// Ingest ingests local Prometheus snapshot TSDB blocks into tsdbDir.
-func (p *PrometheusIngester) Ingest(ctx context.Context, runDir string, runName string, tsdbDir string) error {
-	localSnapshotDir := filepath.Join(runDir, "artifacts", "prometheus", "snapshots")
-
-	if _, err := os.Stat(localSnapshotDir); os.IsNotExist(err) {
-		return fmt.Errorf("no Prometheus snapshot TSDB blocks found at canonical path %s", localSnapshotDir)
+// Ingest ingests local Prometheus snapshot TSDB blocks into tsdbDir, re-basing
+// every sample onto the run's Timebase.
+func (p *PrometheusIngester) Ingest(ctx context.Context, runDir string, runName string, tsdbDir string, tb *Timebase) error {
+	blockDirs := findSnapshotBlockDirs(runDir)
+	if len(blockDirs) == 0 {
+		return fmt.Errorf("no Prometheus snapshot TSDB blocks found under %s",
+			filepath.Join(runDir, "artifacts", "prometheus", "snapshots"))
 	}
 
-	foundBlocks := 0
-	err := filepath.Walk(localSnapshotDir, func(path string, info os.FileInfo, err error) error {
-		if err != nil || !info.IsDir() {
-			return nil
+	// Sweep once for the whole run, not per block, because a run can produce
+	// several snapshot blocks that all belong to the same ingest.
+	if removed, err := removeRunBlocks(tsdbDir, runName, sourceSnapshot); err != nil {
+		return err
+	} else if removed > 0 {
+		fmt.Printf("Replacing %d previously ingested snapshot block(s) of %s\n", removed, runName)
+	}
+
+	ingested := 0
+	for _, blockDir := range blockDirs {
+		if err := p.ingestBlock(ctx, blockDir, runName, tsdbDir, tb); err != nil {
+			fmt.Printf("Warning: Failed ingesting snapshot block %s: %v\n", filepath.Base(blockDir), err)
+			continue
 		}
-		metaPath := filepath.Join(path, "meta.json")
-		indexPath := filepath.Join(path, "index")
-		if _, e1 := os.Stat(metaPath); e1 == nil {
-			if _, e2 := os.Stat(indexPath); e2 == nil {
-				blockULID := filepath.Base(path)
-				targetDir := filepath.Join(tsdbDir, blockULID)
-
-				if err := copyDir(path, targetDir); err != nil {
-					return nil
-				}
-				if err := p.injectThanosRunLabel(targetDir, runName); err != nil {
-					fmt.Printf("Warning: Failed injecting Thanos metadata into %s: %v\n", blockULID, err)
-				}
-				foundBlocks++
-			}
-		}
-		return nil
-	})
-	if err != nil {
-		return fmt.Errorf("error reading TSDB snapshot blocks in %s: %w", localSnapshotDir, err)
+		ingested++
 	}
 
-	if foundBlocks == 0 {
-		return fmt.Errorf("no valid Prometheus snapshot TSDB blocks found in %s", localSnapshotDir)
+	if ingested == 0 {
+		return fmt.Errorf("no valid Prometheus snapshot TSDB blocks ingested from %s", runDir)
 	}
 
-	fmt.Printf("Successfully ingested %d local Prometheus snapshot TSDB blocks for %s\n", foundBlocks, runName)
+	fmt.Printf("Successfully ingested %d local Prometheus snapshot TSDB blocks for %s\n", ingested, runName)
 	return nil
 }
 
-func (p *PrometheusIngester) injectThanosRunLabel(blockDir string, runName string) error {
-	thanosMeta := metadata.Thanos{
-		Labels: map[string]string{
-			"run": runName,
-		},
-		Source: metadata.SourceType("perflens-snapshot-ingest"),
+// ingestBlock rewrites one snapshot block into tsdbDir with shifted timestamps.
+func (p *PrometheusIngester) ingestBlock(ctx context.Context, srcDir string, runName string, tsdbDir string, tb *Timebase) error {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	blk, err := tsdb.OpenBlock(logger, srcDir, chunkenc.NewPool(), nil)
+	if err != nil {
+		return fmt.Errorf("opening block %s: %w", srcDir, err)
+	}
+	defer blk.Close()
+
+	meta := blk.Meta()
+	fmt.Printf("Rewriting snapshot block %s (%d series, %d samples, %s to %s)...\n",
+		meta.ULID, meta.Stats.NumSeries, meta.Stats.NumSamples,
+		time.UnixMilli(meta.MinTime).UTC().Format(time.RFC3339),
+		time.UnixMilli(meta.MaxTime).UTC().Format(time.RFC3339))
+
+	blockSize := blockSizeForSpan(tb.Shift(meta.MinTime), tb.Shift(meta.MaxTime))
+	written, err := writeThanosBlock(ctx, tsdbDir, runName, sourceSnapshot, blockSize,
+		func(bw *tsdb.BlockWriter) error {
+			return copyShiftedSamples(ctx, blk, bw, tb)
+		})
+	if err != nil {
+		return err
 	}
 
-	oldLogger := nopLogger{}
-	_, err := metadata.InjectThanos(oldLogger, blockDir, thanosMeta, nil)
-	return err
+	fmt.Printf("  wrote block %s starting at %s\n", written,
+		time.UnixMilli(tb.Shift(meta.MinTime)).UTC().Format(time.RFC3339))
+	return nil
+}
+
+// copyShiftedSamples streams every sample of src into bw with its timestamp
+// shifted by the run's offset.
+func copyShiftedSamples(ctx context.Context, src *tsdb.Block, bw *tsdb.BlockWriter, tb *Timebase) error {
+	meta := src.Meta()
+	q, err := tsdb.NewBlockQuerier(src, meta.MinTime, meta.MaxTime)
+	if err != nil {
+		return fmt.Errorf("querying block %s: %w", meta.ULID, err)
+	}
+	defer q.Close()
+
+	named := labels.MustNewMatcher(labels.MatchRegexp, labels.MetricName, ".+")
+	series := q.Select(ctx, false, nil, named)
+
+	app := bw.Appender(ctx)
+	pending := 0
+	var it chunkenc.Iterator
+
+	for series.Next() {
+		s := series.At()
+		lbls := s.Labels()
+		var ref storage.SeriesRef
+
+		it = s.Iterator(it)
+		for valType := it.Next(); valType != chunkenc.ValNone; valType = it.Next() {
+			var appendErr error
+			switch valType {
+			case chunkenc.ValFloat:
+				ts, v := it.At()
+				ref, appendErr = app.Append(ref, lbls, tb.Shift(ts), v)
+			case chunkenc.ValHistogram:
+				ts, h := it.AtHistogram(nil)
+				ref, appendErr = app.AppendHistogram(ref, lbls, tb.Shift(ts), h, nil)
+			case chunkenc.ValFloatHistogram:
+				ts, fh := it.AtFloatHistogram(nil)
+				ref, appendErr = app.AppendHistogram(ref, lbls, tb.Shift(ts), nil, fh)
+			default:
+				continue
+			}
+			if appendErr != nil {
+				return fmt.Errorf("appending sample for %s: %w", lbls.String(), appendErr)
+			}
+			pending++
+		}
+		if err := it.Err(); err != nil {
+			return fmt.Errorf("iterating samples of %s: %w", lbls.String(), err)
+		}
+
+		if pending >= commitEverySamples {
+			if err := app.Commit(); err != nil {
+				return fmt.Errorf("committing TSDB appender: %w", err)
+			}
+			app = bw.Appender(ctx)
+			pending = 0
+		}
+	}
+	if err := series.Err(); err != nil {
+		return fmt.Errorf("reading series of block %s: %w", meta.ULID, err)
+	}
+
+	if err := app.Commit(); err != nil {
+		return fmt.Errorf("committing TSDB appender: %w", err)
+	}
+	return nil
 }

--- a/perflens/pkg/ingest/slo_ingester.go
+++ b/perflens/pkg/ingest/slo_ingester.go
@@ -20,8 +20,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
-	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -29,7 +27,6 @@ import (
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/tsdb"
-	"github.com/thanos-io/thanos/pkg/block/metadata"
 )
 
 // SLOIngester processes ClusterLoader2 summary JSON files and ingests SLO metrics into Thanos TSDB.
@@ -41,17 +38,17 @@ func NewSLOIngester() *SLOIngester {
 }
 
 // Ingest implements the ingestion entrypoint for SLO metrics.
-func (i *SLOIngester) Ingest(ctx context.Context, runDir string, runName string, tsdbDir string, omDir string) error {
+func (i *SLOIngester) Ingest(ctx context.Context, runDir string, runName string, tsdbDir string, omDir string, tb *Timebase) error {
 	entries, err := i.ingestBuildMetrics(runDir)
 	if err != nil {
 		return fmt.Errorf("ingesting SLO metrics from %s: %w", runDir, err)
 	}
 
-	if _, err := i.generateOpenMetricsFile(runName, entries, omDir); err != nil {
+	if _, err := i.generateOpenMetricsFile(runName, entries, omDir, tb); err != nil {
 		return fmt.Errorf("generating OpenMetrics file: %w", err)
 	}
 
-	if err := i.createThanosTSDBBlock(ctx, tsdbDir, runName, entries); err != nil {
+	if err := i.createThanosTSDBBlock(ctx, tsdbDir, runName, entries, tb); err != nil {
 		return fmt.Errorf("creating Thanos TSDB block: %w", err)
 	}
 
@@ -151,13 +148,18 @@ func (i *SLOIngester) ingestBuildMetrics(runDir string) ([]SLOEntry, error) {
 	return allEntries, nil
 }
 
-func (i *SLOIngester) generateOpenMetricsFile(runName string, entries []SLOEntry, omDir string) (string, error) {
+func (i *SLOIngester) generateOpenMetricsFile(runName string, entries []SLOEntry, omDir string, tb *Timebase) (string, error) {
 	if err := os.MkdirAll(omDir, 0755); err != nil {
 		return "", err
 	}
 	omFile := filepath.Join(omDir, fmt.Sprintf("openmetrics_%s.txt", runName))
 
+	// The text artifact is the wall clock view, so it keeps the run's real start
+	// time even when the TSDB block is normalized.
 	timestampSec := time.Now().UTC().Unix()
+	if tb != nil && tb.Known {
+		timestampSec = tb.StartMS / 1000
+	}
 	var builder strings.Builder
 	builder.WriteString("# HELP k8s_slo_status Status of K8s SLO evaluation (1 = PASS, 0 = FAIL)\n")
 	builder.WriteString("# TYPE k8s_slo_status gauge\n")
@@ -190,82 +192,67 @@ func (i *SLOIngester) generateOpenMetricsFile(runName string, entries []SLOEntry
 	return omFile, nil
 }
 
-func (i *SLOIngester) createThanosTSDBBlock(ctx context.Context, tsdbDir string, runName string, entries []SLOEntry) error {
-	if err := os.MkdirAll(tsdbDir, 0755); err != nil {
-		return err
-	}
-
-	tsdbDirAbs, err := filepath.Abs(tsdbDir)
-	if err != nil {
-		return err
-	}
+// createThanosTSDBBlock writes the run's SLO verdicts as a constant line spanning
+// the run's normalized window. An SLO entry summarizes the whole run, so it holds
+// over the run's own window rather than being stamped at ingest time. That also
+// lands the SLO block on the same axis as the run's snapshot and log blocks.
+func (i *SLOIngester) createThanosTSDBBlock(ctx context.Context, tsdbDir string, runName string, entries []SLOEntry, tb *Timebase) error {
+	startMS := tb.NormalizedStart()
+	endMS := tb.NormalizedEnd()
 
 	fmt.Println("Writing TSDB block and injecting Thanos metadata via github.com/thanos-io/thanos Go package...")
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	bw, err := tsdb.NewBlockWriter(logger, tsdbDirAbs, 2*60*60*1000)
-	if err != nil {
-		return fmt.Errorf("creating TSDB BlockWriter: %w", err)
+	if _, err := removeRunBlocks(tsdbDir, runName, sourceSLO); err != nil {
+		return err
 	}
-	defer bw.Close()
 
-	app := bw.Appender(ctx)
-	timestampMS := time.Now().UTC().UnixMilli()
+	blockULID, err := writeThanosBlock(ctx, tsdbDir, runName, sourceSLO,
+		blockSizeForSpan(startMS, endMS),
+		func(bw *tsdb.BlockWriter) error {
+			app := bw.Appender(ctx)
 
-	for _, e := range entries {
-		lblsStatus := labels.FromMap(map[string]string{
-			"__name__": "k8s_slo_status",
-			"run":      runName,
-			"slo":      e.SLO,
-			"resource": e.Resource,
-			"verb":     e.Verb,
-			"target":   e.Target,
-			"actual":   e.Actual,
+			appendAt := func(lbls labels.Labels, value float64) error {
+				return appendRunSpan(app, lbls, startMS, endMS, value)
+			}
+
+			for _, e := range entries {
+				lblsStatus := labels.FromMap(map[string]string{
+					"__name__": "k8s_slo_status",
+					"run":      runName,
+					"slo":      e.SLO,
+					"resource": e.Resource,
+					"verb":     e.Verb,
+					"target":   e.Target,
+					"actual":   e.Actual,
+				})
+				if err := appendAt(lblsStatus, float64(e.Status)); err != nil {
+					return fmt.Errorf("appending status sample to TSDB: %w", err)
+				}
+
+				lblsBase := map[string]string{
+					"run":      runName,
+					"slo":      e.SLO,
+					"resource": e.Resource,
+					"verb":     e.Verb,
+				}
+
+				lblsMeas := labels.FromMap(mergeMap(lblsBase, map[string]string{"__name__": "k8s_slo_measurement"}))
+				if err := appendAt(lblsMeas, e.ActualVal); err != nil {
+					return fmt.Errorf("appending measurement sample to TSDB: %w", err)
+				}
+
+				lblsTarget := labels.FromMap(mergeMap(lblsBase, map[string]string{"__name__": "k8s_slo_target"}))
+				if err := appendAt(lblsTarget, e.TargetVal); err != nil {
+					return fmt.Errorf("appending target sample to TSDB: %w", err)
+				}
+			}
+
+			return app.Commit()
 		})
-		if _, err := app.Append(0, lblsStatus, timestampMS, float64(e.Status)); err != nil {
-			return fmt.Errorf("appending status sample to TSDB: %w", err)
-		}
-
-		lblsBase := map[string]string{
-			"run":      runName,
-			"slo":      e.SLO,
-			"resource": e.Resource,
-			"verb":     e.Verb,
-		}
-
-		lblsMeas := labels.FromMap(mergeMap(lblsBase, map[string]string{"__name__": "k8s_slo_measurement"}))
-		if _, err := app.Append(0, lblsMeas, timestampMS, e.ActualVal); err != nil {
-			return fmt.Errorf("appending measurement sample to TSDB: %w", err)
-		}
-
-		lblsTarget := labels.FromMap(mergeMap(lblsBase, map[string]string{"__name__": "k8s_slo_target"}))
-		if _, err := app.Append(0, lblsTarget, timestampMS, e.TargetVal); err != nil {
-			return fmt.Errorf("appending target sample to TSDB: %w", err)
-		}
-	}
-
-	if err := app.Commit(); err != nil {
-		return fmt.Errorf("committing TSDB appender: %w", err)
-	}
-
-	blockULID, err := bw.Flush(ctx)
 	if err != nil {
-		return fmt.Errorf("writing TSDB block: %w", err)
+		return err
 	}
 
-	blockDir := filepath.Join(tsdbDirAbs, blockULID.String())
-	thanosMeta := metadata.Thanos{
-		Labels: map[string]string{
-			"run": runName,
-		},
-		Source: metadata.SourceType("perflens-ingest"),
-	}
-
-	oldLogger := nopLogger{}
-	if _, err := metadata.InjectThanos(oldLogger, blockDir, thanosMeta, nil); err != nil {
-		return fmt.Errorf("injecting Thanos metadata into block %s: %w", blockULID.String(), err)
-	}
-
-	fmt.Printf("Native Thanos TSDB block created & injected successfully: ULID %s in %s\n", blockULID.String(), tsdbDirAbs)
+	fmt.Printf("Native Thanos TSDB block created & injected successfully: ULID %s in %s\n", blockULID, tsdbDir)
 	return nil
 }
 

--- a/perflens/pkg/ingest/timebase.go
+++ b/perflens/pkg/ingest/timebase.go
@@ -1,0 +1,257 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ingest
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"time"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/tsdb"
+)
+
+// AnchorTime is the common origin that every ingested run is re-based to. Scale
+// runs are bounded experiments that happen days or weeks apart, so ingest shifts
+// each run onto this instant and dashboards read elapsed time since run start.
+// A round year is used rather than epoch 0 because Grafana renders 1970 badly.
+var AnchorTime = time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC)
+
+// AnchorTimeMillis is AnchorTime as a Unix millisecond timestamp.
+const AnchorTimeMillis int64 = 946684800000
+
+// RunStartMetric carries a run's original wall clock start time, so absolute
+// time stays recoverable after normalization.
+const RunStartMetric = "perflens_run_start_timestamp_seconds"
+
+// cl2ArtifactTimeRe matches the RFC3339 stamp CL2 puts in its summary filenames,
+// for example APIResponsivenessPrometheus_load_2026-08-05T19:44:02Z.json.
+var cl2ArtifactTimeRe = regexp.MustCompile(`(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z)`)
+
+// Timebase is a run's mapping from original wall clock to normalized time. One
+// Timebase is computed per run and shared by every ingester, so the snapshot,
+// SLO and log blocks of a run all shift by the same amount and stay aligned
+// with each other.
+type Timebase struct {
+	RunName string
+	// Enabled reports whether timestamps are re-based. When false Shift is the
+	// identity and samples keep their original wall clock.
+	Enabled bool
+	// Known reports whether the run's wall clock window could be determined.
+	Known bool
+	// StartMS and EndMS are the run's original wall clock window in Unix millis.
+	StartMS int64
+	EndMS   int64
+	// OffsetMS is added to every sample timestamp of this run.
+	OffsetMS int64
+}
+
+// NewTimebase determines a run's wall clock window and the offset that maps it
+// onto AnchorTime.
+func NewTimebase(runDir string, runName string, normalize bool) *Timebase {
+	tb := &Timebase{RunName: runName}
+
+	start, end, ok := runWallClockWindow(runDir)
+	if !ok {
+		return tb
+	}
+	tb.Known = true
+	tb.StartMS = start
+	tb.EndMS = end
+
+	if normalize {
+		tb.Enabled = true
+		tb.OffsetMS = AnchorTimeMillis - start
+	}
+	return tb
+}
+
+// Shift maps an original sample timestamp in Unix millis onto the normalized axis.
+func (t *Timebase) Shift(ms int64) int64 {
+	if t == nil || !t.Enabled {
+		return ms
+	}
+	return ms + t.OffsetMS
+}
+
+// NormalizedStart is the timestamp a run's samples begin at after shifting.
+func (t *Timebase) NormalizedStart() int64 {
+	if t == nil || !t.Known {
+		return time.Now().UTC().UnixMilli()
+	}
+	return t.Shift(t.StartMS)
+}
+
+// NormalizedEnd is the timestamp a run's samples end at after shifting.
+func (t *Timebase) NormalizedEnd() int64 {
+	if t == nil || !t.Known {
+		return time.Now().UTC().UnixMilli()
+	}
+	return t.Shift(t.EndMS)
+}
+
+// Describe renders the mapping for the ingest log.
+func (t *Timebase) Describe() string {
+	if t == nil || !t.Enabled {
+		return "time normalization off, samples keep their original wall clock"
+	}
+	start := time.UnixMilli(t.StartMS).UTC()
+	return fmt.Sprintf("re-basing %s from %s to %s (offset %s, duration %s)",
+		t.RunName,
+		start.Format(time.RFC3339),
+		AnchorTime.Format(time.RFC3339),
+		time.Duration(t.OffsetMS)*time.Millisecond,
+		time.Duration(t.EndMS-t.StartMS)*time.Millisecond,
+	)
+}
+
+// runWallClockWindow finds the run's original time window. The Prometheus
+// snapshot is authoritative because it brackets the whole run. CL2 summary
+// filenames are a fallback for runs ingested without a snapshot.
+func runWallClockWindow(runDir string) (start int64, end int64, ok bool) {
+	if start, end, ok = snapshotWindow(runDir); ok {
+		return start, end, true
+	}
+	return artifactFilenameWindow(runDir)
+}
+
+// snapshotWindow returns the min minTime and max maxTime over every TSDB block
+// in the run's Prometheus snapshot. Taking the extremes over all blocks, rather
+// than per block, is what keeps a multi-block run internally aligned.
+func snapshotWindow(runDir string) (int64, int64, bool) {
+	var start, end int64
+	found := false
+
+	for _, blockDir := range findSnapshotBlockDirs(runDir) {
+		body, err := os.ReadFile(filepath.Join(blockDir, "meta.json"))
+		if err != nil {
+			continue
+		}
+		var meta struct {
+			MinTime int64 `json:"minTime"`
+			MaxTime int64 `json:"maxTime"`
+		}
+		if err := json.Unmarshal(body, &meta); err != nil || meta.MaxTime <= meta.MinTime {
+			continue
+		}
+		if !found || meta.MinTime < start {
+			start = meta.MinTime
+		}
+		if !found || meta.MaxTime > end {
+			end = meta.MaxTime
+		}
+		found = true
+	}
+	return start, end, found
+}
+
+// findSnapshotBlockDirs lists the TSDB block directories of a run's extracted
+// Prometheus snapshot.
+func findSnapshotBlockDirs(runDir string) []string {
+	root := filepath.Join(runDir, "artifacts", "prometheus", "snapshots")
+	if _, err := os.Stat(root); err != nil {
+		return nil
+	}
+
+	var dirs []string
+	_ = filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil || !info.IsDir() {
+			return nil
+		}
+		if _, err := os.Stat(filepath.Join(path, "meta.json")); err != nil {
+			return nil
+		}
+		if _, err := os.Stat(filepath.Join(path, "index")); err != nil {
+			return nil
+		}
+		dirs = append(dirs, path)
+		return nil
+	})
+	return dirs
+}
+
+func artifactFilenameWindow(runDir string) (int64, int64, bool) {
+	var start, end int64
+	found := false
+
+	_ = filepath.Walk(filepath.Join(runDir, "artifacts"), func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() {
+			return nil
+		}
+		match := cl2ArtifactTimeRe.FindString(info.Name())
+		if match == "" {
+			return nil
+		}
+		ts, err := time.Parse(time.RFC3339, match)
+		if err != nil {
+			return nil
+		}
+		ms := ts.UTC().UnixMilli()
+		if !found || ms < start {
+			start = ms
+		}
+		if !found || ms > end {
+			end = ms
+		}
+		found = true
+		return nil
+	})
+	return start, end, found
+}
+
+// writeRunTimebaseBlock emits RunStartMetric for the run, spanning the run's
+// normalized window so the original start time is readable from any point in
+// the dashboard time range.
+func writeRunTimebaseBlock(ctx context.Context, tsdbDir string, tb *Timebase) error {
+	if tb == nil || !tb.Known {
+		return fmt.Errorf("run window unknown, skipping %s", RunStartMetric)
+	}
+
+	startMS := tb.NormalizedStart()
+	endMS := tb.NormalizedEnd()
+	value := float64(tb.StartMS) / 1000.0
+
+	lbls := labels.FromMap(map[string]string{
+		"__name__": RunStartMetric,
+		"run":      tb.RunName,
+	})
+
+	if _, err := removeRunBlocks(tsdbDir, tb.RunName, sourceTimebase); err != nil {
+		return err
+	}
+
+	blockULID, err := writeThanosBlock(ctx, tsdbDir, tb.RunName, sourceTimebase,
+		blockSizeForSpan(startMS, endMS),
+		func(bw *tsdb.BlockWriter) error {
+			app := bw.Appender(ctx)
+			if err := appendRunSpan(app, lbls, startMS, endMS, value); err != nil {
+				return err
+			}
+			return app.Commit()
+		})
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Wrote %s block %s for %s (original start %s)\n",
+		RunStartMetric, blockULID, tb.RunName, time.UnixMilli(tb.StartMS).UTC().Format(time.RFC3339))
+	return nil
+}

--- a/perflens/pkg/ingest/timebase.go
+++ b/perflens/pkg/ingest/timebase.go
@@ -38,8 +38,10 @@ var AnchorTime = time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC)
 // AnchorTimeMillis is AnchorTime as a Unix millisecond timestamp.
 const AnchorTimeMillis int64 = 946684800000
 
-// RunStartMetric carries a run's original wall clock start time, so absolute
-// time stays recoverable after normalization.
+// RunStartMetric carries the original wall clock time that a run's normalized
+// origin maps back to, so absolute time stays recoverable after normalization.
+// It reports the anchor, not the first sample, so it always answers "what real
+// instant is t=0 on this axis".
 const RunStartMetric = "perflens_run_start_timestamp_seconds"
 
 // cl2ArtifactTimeRe matches the RFC3339 stamp CL2 puts in its summary filenames,
@@ -58,14 +60,22 @@ type Timebase struct {
 	// Known reports whether the run's wall clock window could be determined.
 	Known bool
 	// StartMS and EndMS are the run's original wall clock window in Unix millis.
+	// This is the extent of the data, which begins before the test does.
 	StartMS int64
 	EndMS   int64
+	// AnchorMS is the original wall clock instant that maps onto AnchorTime, in
+	// other words what t=0 means on the normalized axis. It is the start of the
+	// test rather than the start of the data, so samples scraped during bring-up
+	// land before the origin.
+	AnchorMS int64
+	// AnchorSource names where AnchorMS came from, for the ingest log.
+	AnchorSource string
 	// OffsetMS is added to every sample timestamp of this run.
 	OffsetMS int64
 }
 
-// NewTimebase determines a run's wall clock window and the offset that maps it
-// onto AnchorTime.
+// NewTimebase determines a run's wall clock window and the offset that maps its
+// anchor onto AnchorTime.
 func NewTimebase(runDir string, runName string, normalize bool) *Timebase {
 	tb := &Timebase{RunName: runName}
 
@@ -76,12 +86,27 @@ func NewTimebase(runDir string, runName string, normalize bool) *Timebase {
 	tb.Known = true
 	tb.StartMS = start
 	tb.EndMS = end
+	tb.AnchorMS, tb.AnchorSource = runAnchor(runDir, start)
 
 	if normalize {
 		tb.Enabled = true
-		tb.OffsetMS = AnchorTimeMillis - start
+		tb.OffsetMS = AnchorTimeMillis - tb.AnchorMS
 	}
 	return tb
+}
+
+// runAnchor picks the instant that becomes t=0 for a run.
+//
+// ClusterLoader2's first step is the right anchor because it is the same event
+// in every run. The data window start is not: it is when Prometheus began
+// scraping, which trails cluster bring-up by a run dependent amount, so
+// anchoring on it offsets two overlaid runs by the difference in their bring-up
+// times. It stays as the fallback for runs whose CL2 log was not collected.
+func runAnchor(runDir string, windowStartMS int64) (int64, string) {
+	if ms, ok := cl2TestStart(runDir, windowStartMS); ok {
+		return ms, "clusterloader2 first step"
+	}
+	return windowStartMS, "start of scraped data"
 }
 
 // Shift maps an original sample timestamp in Unix millis onto the normalized axis.
@@ -113,13 +138,14 @@ func (t *Timebase) Describe() string {
 	if t == nil || !t.Enabled {
 		return "time normalization off, samples keep their original wall clock"
 	}
-	start := time.UnixMilli(t.StartMS).UTC()
-	return fmt.Sprintf("re-basing %s from %s to %s (offset %s, duration %s)",
+	return fmt.Sprintf("re-basing %s: anchor %s (%s) to %s, offset %s, data spans %s from %s before the anchor",
 		t.RunName,
-		start.Format(time.RFC3339),
+		time.UnixMilli(t.AnchorMS).UTC().Format(time.RFC3339),
+		t.AnchorSource,
 		AnchorTime.Format(time.RFC3339),
 		time.Duration(t.OffsetMS)*time.Millisecond,
 		time.Duration(t.EndMS-t.StartMS)*time.Millisecond,
+		time.Duration(t.AnchorMS-t.StartMS)*time.Millisecond,
 	)
 }
 
@@ -218,8 +244,8 @@ func artifactFilenameWindow(runDir string) (int64, int64, bool) {
 }
 
 // writeRunTimebaseBlock emits RunStartMetric for the run, spanning the run's
-// normalized window so the original start time is readable from any point in
-// the dashboard time range.
+// normalized window so the anchor's original wall clock time is readable from
+// any point in the dashboard time range.
 func writeRunTimebaseBlock(ctx context.Context, tsdbDir string, tb *Timebase) error {
 	if tb == nil || !tb.Known {
 		return fmt.Errorf("run window unknown, skipping %s", RunStartMetric)
@@ -227,7 +253,7 @@ func writeRunTimebaseBlock(ctx context.Context, tsdbDir string, tb *Timebase) er
 
 	startMS := tb.NormalizedStart()
 	endMS := tb.NormalizedEnd()
-	value := float64(tb.StartMS) / 1000.0
+	value := float64(tb.AnchorMS) / 1000.0
 
 	lbls := labels.FromMap(map[string]string{
 		"__name__": RunStartMetric,
@@ -251,7 +277,8 @@ func writeRunTimebaseBlock(ctx context.Context, tsdbDir string, tb *Timebase) er
 		return err
 	}
 
-	fmt.Printf("Wrote %s block %s for %s (original start %s)\n",
-		RunStartMetric, blockULID, tb.RunName, time.UnixMilli(tb.StartMS).UTC().Format(time.RFC3339))
+	fmt.Printf("Wrote %s block %s for %s (anchor %s, %s)\n",
+		RunStartMetric, blockULID, tb.RunName,
+		time.UnixMilli(tb.AnchorMS).UTC().Format(time.RFC3339), tb.AnchorSource)
 	return nil
 }

--- a/perflens/pkg/ingest/utils.go
+++ b/perflens/pkg/ingest/utils.go
@@ -16,53 +16,10 @@ limitations under the License.
 
 package ingest
 
-import (
-	"io"
-	"os"
-	"path/filepath"
-)
-
 type nopLogger struct{}
 
 func (nopLogger) Log(keyvals ...interface{}) error {
 	return nil
-}
-
-func copyDir(src, dst string) error {
-	if src == dst {
-		return nil
-	}
-	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-		rel, err := filepath.Rel(src, path)
-		if err != nil {
-			return err
-		}
-		targetPath := filepath.Join(dst, rel)
-		if info.IsDir() {
-			return os.MkdirAll(targetPath, info.Mode())
-		}
-		return copyFile(path, targetPath)
-	})
-}
-
-func copyFile(src, dst string) error {
-	in, err := os.Open(src)
-	if err != nil {
-		return err
-	}
-	defer in.Close()
-
-	out, err := os.Create(dst)
-	if err != nil {
-		return err
-	}
-	defer out.Close()
-
-	_, err = io.Copy(out, in)
-	return err
 }
 
 func mergeMap(m1, m2 map[string]string) map[string]string {


### PR DESCRIPTION
- Ingest re-bases each run's samples to a common anchor, so one time range works for every run and selecting two runs overlays them instead of showing two spikes days apart. perflens_run_start_timestamp_seconds keeps the original start.
- Adds a Control Plane dashboard: process resources, Go runtime, etcd disk.
- Turns off the Grafana news feed and analytics calls.

Basically allows us to loosely compare two runs in the same dashboard and we don't need to hunt for the time as we align every run to start at 2000/1/1 0:00 UTC. 

<img width="1059" height="463" alt="image" src="https://github.com/user-attachments/assets/db828975-db79-4707-a153-f7268a5ab7d4" />

<img width="1052" height="459" alt="image" src="https://github.com/user-attachments/assets/b4c2d31f-d5dc-45d7-b40c-61d23b1a9db7" />
