### PR TITLE
Extend WaitForPods measurement

### DIFF
--- a/clusterloader2/pkg/measurement/common/wait_for_pods.go
+++ b/clusterloader2/pkg/measurement/common/wait_for_pods.go
@@ -67,6 +67,11 @@ func (w *waitForRunningPodsMeasurement) Execute(config *measurement.Config) ([]m
 		return nil, err
 	}
 
+	tolerationTimeout, err := util.GetDurationOrDefault(config.Params, "tolerationTimeout", 0)
+	if err != nil {
+		return nil, err
+	}
+
 	isFatal, err := util.GetBoolOrDefault(config.Params, "isFatal", defaultIsFatal)
 	if err != nil {
 		return nil, err
@@ -78,6 +83,7 @@ func (w *waitForRunningPodsMeasurement) Execute(config *measurement.Config) ([]m
 		DesiredPodCount:     func() int { return desiredPodCount },
 		CallerName:          w.String(),
 		WaitForPodsInterval: refreshInterval,
+		TolerationTimeout:   tolerationTimeout,
 	}
 	podStore, err := measurementutil.NewPodStore(config.ClusterFramework.GetClientSets().GetClient(), selector)
 	if err != nil {

--- a/clusterloader2/pkg/measurement/util/wait_for_pods.go
+++ b/clusterloader2/pkg/measurement/util/wait_for_pods.go
@@ -41,6 +41,7 @@ type WaitForPodOptions struct {
 	CountErrorMargin    int
 	CallerName          string
 	WaitForPodsInterval time.Duration
+	TolerationTimeout   time.Duration
 
 	// IsPodUpdated can be used to detect which pods have been already updated.
 	// nil value means all pods are updated.
@@ -70,6 +71,16 @@ func WaitForPods(ctx context.Context, ps PodLister, options *WaitForPodOptions) 
 	var oldPodsStatus PodsStartupStatus
 	var lastIsPodUpdatedError error
 
+	var tolerationCh <-chan time.Time
+	if options.TolerationTimeout > 0 {
+		timer := time.NewTimer(options.TolerationTimeout)
+		defer timer.Stop()
+		tolerationCh = timer.C
+	}
+
+	var tolerationExpired bool
+	var tolerationExpiredAt time.Time
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -87,6 +98,25 @@ func WaitForPods(ctx context.Context, ps PodLister, options *WaitForPodOptions) 
 					desiredPodCount, ps.String(), oldPodsStatus.String())
 			}
 			return pods.NotRunningAndReady(), ctx.Err()
+
+		case <-tolerationCh:
+			desiredPodCount := options.DesiredPodCount()
+			pods, err := ps.List()
+			if err != nil {
+				return nil, fmt.Errorf("failed to list pods: %w", err)
+			}
+			podsStatus := ComputePodsStartupStatus(pods, desiredPodCount, options.IsPodUpdated)
+			if podsStatus.LastIsPodUpdatedError != nil {
+				lastIsPodUpdatedError = podsStatus.LastIsPodUpdatedError
+			}
+			klog.V(2).Infof("%s: %s: toleration timeout expired, pods status: %s", options.CallerName, ps.String(), podsStatus.String())
+			if isPodsStatusAcceptable(pods, podsStatus, desiredPodCount, options.CountErrorMargin) {
+				return nil, nil
+			}
+			tolerationExpired = true
+			tolerationExpiredAt = time.Now()
+			oldPods = pods
+			oldPodsStatus = podsStatus
 
 		case <-time.After(options.WaitForPodsInterval):
 			desiredPodCount := options.DesiredPodCount()
@@ -121,18 +151,30 @@ func WaitForPods(ctx context.Context, ps PodLister, options *WaitForPodOptions) 
 			if podsStatus.String() != oldPodsStatus.String() {
 				klog.V(2).Infof("%s: %s: %s", options.CallerName, ps.String(), podsStatus.String())
 			}
-			// We allow inactive pods (e.g. eviction happened).
-			// We wait until there is a desired number of pods running and all other pods are inactive.
-			if len(pods) == (podsStatus.Running+podsStatus.Inactive) && podsStatus.Running == podsStatus.RunningUpdated && podsStatus.RunningUpdated == desiredPodCount {
-				return nil, nil
-			}
-			// When using preemptibles on large scale, number of ready nodes is not stable and reaching DesiredPodCount could take a very long time.
-			// Overall number of pods (especially Inactive pods) should not grow unchecked.
-			if options.CountErrorMargin > 0 && podsStatus.RunningUpdated >= desiredPodCount-options.CountErrorMargin && len(pods)-podsStatus.Inactive <= desiredPodCount && podsStatus.Inactive <= options.CountErrorMargin {
+			if isPodsStatusAcceptable(pods, podsStatus, desiredPodCount, options.CountErrorMargin) {
+				if tolerationExpired {
+					delay := time.Since(tolerationExpiredAt)
+					return nil, fmt.Errorf("desired number of %d pods in %s reached after tolerationTimeout (%v), delay after tolerationTimeout was %v",
+						desiredPodCount, ps.String(), options.TolerationTimeout, delay)
+				}
 				return nil, nil
 			}
 			oldPods = pods
 			oldPodsStatus = podsStatus
 		}
 	}
+}
+
+func isPodsStatusAcceptable(pods []*v1.Pod, podsStatus PodsStartupStatus, desiredPodCount int, countErrorMargin int) bool {
+	// We allow inactive pods (e.g. eviction happened).
+	// We wait until there is a desired number of pods running and all other pods are inactive.
+	if len(pods) == (podsStatus.Running+podsStatus.Inactive) && podsStatus.Running == podsStatus.RunningUpdated && podsStatus.RunningUpdated == desiredPodCount {
+		return true
+	}
+	// When using preemptibles on large scale, number of ready nodes is not stable and reaching DesiredPodCount could take a very long time.
+	// Overall number of pods (especially Inactive pods) should not grow unchecked.
+	if countErrorMargin > 0 && podsStatus.RunningUpdated >= desiredPodCount-countErrorMargin && len(pods)-podsStatus.Inactive <= desiredPodCount && podsStatus.Inactive <= countErrorMargin {
+		return true
+	}
+	return false
 }

--- a/clusterloader2/pkg/measurement/util/wait_for_pods_test.go
+++ b/clusterloader2/pkg/measurement/util/wait_for_pods_test.go
@@ -1,0 +1,161 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type fakePodLister struct {
+	lock sync.Mutex
+	pods []*corev1.Pod
+}
+
+func (f *fakePodLister) List() ([]*corev1.Pod, error) {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+	return f.pods, nil
+}
+
+func (f *fakePodLister) setPods(pods []*corev1.Pod) {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+	f.pods = pods
+}
+
+func (f *fakePodLister) String() string {
+	return "fakePodStore"
+}
+
+func runningAndReadyPodWithLabels(name string, labels map[string]string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   name,
+			Labels: labels,
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			Conditions: []corev1.PodCondition{
+				{
+					Type:   corev1.PodReady,
+					Status: corev1.ConditionTrue,
+				},
+			},
+		},
+	}
+}
+
+func TestWaitForPods_WithinTolerationTimeout(t *testing.T) {
+	lister := &fakePodLister{
+		pods: []*corev1.Pod{
+			runningAndReadyPodWithLabels("pod-1", map[string]string{"app": "test"}),
+		},
+	}
+
+	options := &WaitForPodOptions{
+		DesiredPodCount:     func() int { return 1 },
+		CallerName:          "Test",
+		WaitForPodsInterval: 10 * time.Millisecond,
+		TolerationTimeout:   200 * time.Millisecond,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	status, err := WaitForPods(ctx, lister, options)
+	if err != nil {
+		t.Fatalf("expected nil error when pods are ready before tolerationTimeout, got: %v", err)
+	}
+	if status != nil {
+		t.Fatalf("expected nil status when pods are ready before tolerationTimeout, got: %v", status)
+	}
+}
+
+func TestWaitForPods_AfterTolerationTimeoutBeforeContextDeadline(t *testing.T) {
+	lister := &fakePodLister{
+		pods: []*corev1.Pod{},
+	}
+
+	options := &WaitForPodOptions{
+		DesiredPodCount:     func() int { return 1 },
+		CallerName:          "Test",
+		WaitForPodsInterval: 20 * time.Millisecond,
+		TolerationTimeout:   100 * time.Millisecond,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	// Add ready pod AFTER tolerationTimeout elapses (at ~200ms)
+	time.AfterFunc(200*time.Millisecond, func() {
+		lister.setPods([]*corev1.Pod{
+			runningAndReadyPodWithLabels("pod-1", map[string]string{"app": "test"}),
+		})
+	})
+
+	status, err := WaitForPods(ctx, lister, options)
+	if err == nil {
+		t.Fatalf("expected error when pods become ready after tolerationTimeout, got nil")
+	}
+	if status != nil {
+		t.Fatalf("expected nil status when pods successfully become ready after tolerationTimeout, got: %v", status)
+	}
+
+	errMsg := err.Error()
+	if !strings.Contains(errMsg, "reached after tolerationTimeout") {
+		t.Errorf("expected error message to contain 'reached after tolerationTimeout', got: %v", errMsg)
+	}
+	if !strings.Contains(errMsg, "delay after tolerationTimeout") {
+		t.Errorf("expected error message to contain 'delay after tolerationTimeout', got: %v", errMsg)
+	}
+}
+
+func TestWaitForPods_TimeoutAfterContextDeadline(t *testing.T) {
+	lister := &fakePodLister{
+		pods: []*corev1.Pod{},
+	}
+
+	options := &WaitForPodOptions{
+		DesiredPodCount:     func() int { return 1 },
+		CallerName:          "Test",
+		WaitForPodsInterval: 20 * time.Millisecond,
+		TolerationTimeout:   100 * time.Millisecond,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	status, err := WaitForPods(ctx, lister, options)
+	if err == nil {
+		t.Fatalf("expected timeout error when pods never become ready, got nil")
+	}
+
+	errMsg := err.Error()
+	if !strings.Contains(errMsg, "while waiting for 1 pods to be running") {
+		t.Errorf("expected standard timeout error message, got: %v", errMsg)
+	}
+	if status == nil {
+		t.Fatalf("expected non-nil status on timeout, got nil")
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR extends the existing WaitForPods measurement with ability to specify the **tolerationTimeout**.
This property allows CL2 to still capture the data on pods between tolerationTimeout and timeout, observing the pod state, but failing the test as toleartionTimeout was exceeded.

When not specified, the measurement falls back to its usual behaviour.

