### PR TITLE
request-benchmark: add --content-type flag to informer mode

### DIFF
--- a/util-images/request-benchmark/Makefile
+++ b/util-images/request-benchmark/Makefile
@@ -1,6 +1,6 @@
 PROJECT ?= k8s-staging-perf-tests
 IMG = gcr.io/$(PROJECT)/perf-tests-util/request-benchmark
-TAG = v0.0.13
+TAG = v0.0.14
 
 all: build push
 

--- a/util-images/request-benchmark/mode_informer.go
+++ b/util-images/request-benchmark/mode_informer.go
@@ -51,6 +51,7 @@ func runInformer(args []string) error {
 	disableCompression := fs.Bool("disableCompression", false, "whether to disable gzip compression for API requests")
 	apiVersion := fs.String("api-version", "v1", "apiVersion of the target resource (e.g. v1, apps/v1).")
 	resource := fs.String("resource", "secrets", "resource name of the target resource (e.g. pods, deployments).")
+	contentType := fs.String("content-type", "proto", "Content type for informer requests. Valid values: [json, proto]")
 
 	if err := fs.Parse(args); err != nil {
 		return err
@@ -72,8 +73,19 @@ func runInformer(args []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to build config: %w", err)
 	}
-	config.AcceptContentTypes = "application/vnd.kubernetes.protobuf,application/json"
-	config.ContentType = "application/vnd.kubernetes.protobuf"
+
+	// TODO: add cbor support
+	switch *contentType {
+	case "json":
+		config.AcceptContentTypes = "application/json"
+		config.ContentType = "application/json"
+	case "proto":
+		config.AcceptContentTypes = "application/vnd.kubernetes.protobuf"
+		config.ContentType = "application/vnd.kubernetes.protobuf"
+	default:
+		return fmt.Errorf("only json,proto values are supported for --content-type")
+	}
+
 	config.DisableCompression = *disableCompression
 	klog.Infof("The following Kubernetes client config will be used\n%v", config.String())
 


### PR DESCRIPTION
the first step toward migrating benchmark-list from http to informer mode (the base variant of the benchmark-list uses json).

tested manually on my local cluster.