### PR TITLE
DNSPropagation: use watch to know when pods are ready

### DIFF
--- a/clusterloader2/pkg/measurement/common/probes/probes.go
+++ b/clusterloader2/pkg/measurement/common/probes/probes.go
@@ -80,7 +80,7 @@ var (
 	dnsPropagationConfig = proberConfig{
 		Name:             "DnsPropagation",
 		MetricVersion:    "v1",
-		Query:            "probes_dns_propagation_seconds",
+		Query:            "max_over_time(probes_dns_propagation_seconds[%v])",
 		Manifests:        "dnsPropagation/*.yaml",
 		ProbeLabelValues: []string{"dns-propagation-prober"},
 		ProberType:       "propagation",

--- a/util-images/probes/go.mod
+++ b/util-images/probes/go.mod
@@ -4,6 +4,7 @@ go 1.26.4
 
 require (
 	github.com/prometheus/client_golang v1.23.2
+	k8s.io/api v0.36.3
 	k8s.io/apimachinery v0.36.3
 	k8s.io/client-go v0.36.3
 	k8s.io/klog v1.0.0
@@ -27,6 +28,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect
@@ -43,7 +45,6 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/api v0.36.3 // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a // indirect
 	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2 // indirect

--- a/util-images/probes/pkg/dnspropagation/probe.go
+++ b/util-images/probes/pkg/dnspropagation/probe.go
@@ -18,7 +18,6 @@ package dnspropagation
 
 import (
 	"context"
-	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -32,9 +31,12 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog"
 )
 
@@ -52,8 +54,8 @@ var (
 )
 
 var (
-	errorLogger   *slog.Logger
-	latencyLogger *slog.Logger
+	errorLogger   = slog.New(slog.NewJSONHandler(io.Discard, nil))
+	latencyLogger = slog.New(slog.NewJSONHandler(io.Discard, nil))
 )
 
 type DNSPodPropagationResult struct {
@@ -93,6 +95,9 @@ func Run() {
 	if err != nil {
 		klog.Fatalf("Can not build inClusterConfig, error:%v", err)
 	}
+	kubeConfig.QPS = 100.0
+	kubeConfig.Burst = 200
+
 	// creates the inCluster kube client
 	clientset, err := kubernetes.NewForConfig(kubeConfig)
 
@@ -111,50 +116,134 @@ func Run() {
 // runProbe runs the DNS propagation probe.
 func runProbe(client kubernetes.Interface) {
 	klog.V(1).Infof("DNS propagation probe started")
+
+	indices := selectSample(*podCount, *sampleCount)
+	targetPods := make(map[string]struct{}, len(indices))
+	for _, idx := range indices {
+		targetPods[fmt.Sprintf("%s-%d", *statefulSet, idx)] = struct{}{}
+	}
+
+	var mu sync.Mutex
 	var wg sync.WaitGroup
 	ch := make(chan DNSPodPropagationResult, *sampleCount)
-	indices := selectSample(*podCount, *sampleCount)
+
 	durations := make([]float64, 0, *sampleCount)
-	for _, idx := range indices {
-		podName := fmt.Sprintf("%s-%d", *statefulSet, idx)
-		url := fmt.Sprintf("%s.%s.%s.%s.%s.%s", podName, *service, *namespace, "svc", *clusterDomain, *suffix)
-		wg.Add(1)
-		go func(client kubernetes.Interface, url, podName string, namespace string, interval time.Duration) {
-			defer wg.Done()
-			result := runSinglePod(client, url, podName, namespace, interval)
-			ch <- DNSPodPropagationResult{
-				podName:  podName,
-				duration: result,
-			}
-		}(client, url, podName, *namespace, *interval)
-	}
-	klog.V(2).Infof("Waiting for all sample pods processes to finish")
+	collectorDone := make(chan struct{})
 	go func() {
-		wg.Wait()
-		close(ch)
+		for propagationResult := range ch {
+			labels := prometheus.Labels{
+				"namespace": *namespace,
+				"service":   *service,
+				"podName":   propagationResult.podName,
+			}
+			DNSPropagationSeconds.With(labels).Set(propagationResult.duration.Seconds())
+			DNSPropagationCount.With(labels).Inc()
+			durations = append(durations, propagationResult.duration.Seconds())
+		}
+		close(collectorDone)
 	}()
 
-	for propagationResult := range ch {
-		labels := prometheus.Labels{
-			"namespace": *namespace,
-			"service":   *service,
-			"podName":   propagationResult.podName,
-		}
-		DNSPropagationSeconds.With(labels).Set(propagationResult.duration.Seconds())
-		DNSPropagationCount.With(labels).Inc()
-		durations = append(durations, propagationResult.duration.Seconds())
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	factory := informers.NewSharedInformerFactoryWithOptions(
+		client,
+		0,
+		informers.WithNamespace(*namespace),
+	)
+	podInformer := factory.Core().V1().Pods().Informer()
+
+	if err := podInformer.SetTransform(transformPod); err != nil {
+		klog.Fatalf("Failed to set pod transform: %v", err)
 	}
+
+	handlePod := func(obj interface{}) {
+		pod, ok := obj.(*v1.Pod)
+		if !ok {
+			return
+		}
+
+		mu.Lock()
+		if _, exists := targetPods[pod.Name]; !exists {
+			mu.Unlock()
+			return
+		}
+
+		readyTime, isReady := getPodReadyTransitionTime(pod)
+		if !isReady {
+			mu.Unlock()
+			return
+		}
+
+		delete(targetPods, pod.Name)
+		remaining := len(targetPods)
+		mu.Unlock()
+
+		url := fmt.Sprintf("%s.%s.%s.%s.%s.%s", pod.Name, *service, *namespace, "svc", *clusterDomain, *suffix)
+
+		wg.Add(1)
+		go func(url, podName string, readyTime time.Time) {
+			defer wg.Done()
+
+			duration := probeDNSUntilResolved(url, readyTime, *interval)
+			ch <- DNSPodPropagationResult{
+				podName:  podName,
+				duration: duration,
+			}
+		}(url, pod.Name, readyTime)
+
+		if remaining == 0 {
+			cancel()
+		}
+	}
+
+	if _, err := podInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: handlePod,
+		UpdateFunc: func(oldObj, newObj interface{}) {
+			handlePod(newObj)
+		},
+	}); err != nil {
+		klog.Fatalf("Failed to add event handler: %v", err)
+	}
+
+	factory.Start(ctx.Done())
+	factory.WaitForCacheSync(ctx.Done())
+
+	<-ctx.Done()
+
+	klog.V(2).Infof("Waiting for all sample pods processes to finish")
+	wg.Wait()
+	close(ch)
+	<-collectorDone
 	klog.V(2).Infof("Finished calculating DNS propagation for all sample pods")
 
 	if len(durations) == 0 {
 		klog.Warningf("DNS propagation probe has zero observations")
 		return
 	}
+
 	sum := 0.0
 	for _, duration := range durations {
 		sum += duration
 	}
 	klog.V(1).Infof("DNS propagation probe finished, total of %v observations, average duration, %v s", len(durations), sum/float64(len(durations)))
+}
+
+// transformPod strips spec and unneeded metadata to minimize memory usage under scale testing.
+func transformPod(obj interface{}) (interface{}, error) {
+	pod, ok := obj.(*v1.Pod)
+	if !ok {
+		return obj, nil
+	}
+	return &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      pod.Name,
+			Namespace: pod.Namespace,
+		},
+		Status: v1.PodStatus{
+			Conditions: pod.Status.Conditions,
+		},
+	}, nil
 }
 
 // selectSample returns a slice of indices of length sampleCount, randomly selected from the range [0, podCount).
@@ -168,49 +257,21 @@ func selectSample(podCount int, sampleCount int) []int {
 	return indices
 }
 
-// runSinglePod runs a single DNS propagation test for the given pod.
-// It returns the duration between the time the DNS lookup succeeds and the time the pod was created.
-func runSinglePod(client kubernetes.Interface, url string, podName string, namespace string, interval time.Duration) time.Duration {
+func probeDNSUntilResolved(url string, readyTimestamp time.Time, interval time.Duration) time.Duration {
 	klog.V(4).Infof("Starting dns propagation calculation for pod %s ...", url)
 	tick := time.NewTicker(interval)
 	defer tick.Stop()
-	var lookupErrorLogged = false
+
 	for {
 		select {
 		case <-tick.C:
-			klog.V(4).Infof("DNS lookup %s", url)
-			if err := lookup(url); err != nil {
-				var dnsErr *net.DNSError
-				if errors.As(err, &dnsErr) && dnsErr.IsNotFound {
-					klog.Warningf("DNS lookup error: %v", err)
-					continue
-				}
-				if !lookupErrorLogged {
-					lookupErrorLogged = true
-					errTimestamp := time.Now()
-					klog.Errorf("DNS lookup error for url %s at %v: %v", url, errTimestamp.Format(time.RFC3339), err)
-					errorLogger.Error("DNS propagation probe failed",
-						"hostname", url,
-						"error", err.Error(),
-					)
-					labels := prometheus.Labels{
-						"namespace": namespace,
-						"service":   *service,
-						"podName":   podName,
-					}
-					DNSLookupErrors.With(labels).Inc()
-				}
+			if err := lookupFunc(url); err != nil {
 				continue
 			}
+
 			endTime := time.Now()
-			klog.V(2).Infof("DNS lookup finished for pod %s, finding pod running time...", url)
-			timestamp, err := fetchPodRunningTime(client, podName, namespace)
-			if err != nil {
-				klog.Fatalf("K8s error: %v", err)
-				continue
-			}
-			duration := endTime.Sub(timestamp)
-			klog.V(2).Infof("Pod running time fetched for pod %s, timestamp= %v, DNS propagation duration= %v s", url, timestamp, duration)
+			duration := endTime.Sub(readyTimestamp)
+			klog.V(2).Infof("DNS lookup succeeded for pod %s, timestamp= %v, DNS propagation duration= %v s", url, readyTimestamp, duration)
 			latencyLogger.Info("DNS propagation latency recorded",
 				"hostname", url,
 				"timestamp", time.Now(),
@@ -220,47 +281,19 @@ func runSinglePod(client kubernetes.Interface, url string, podName string, names
 	}
 }
 
+var lookupFunc = lookup
+
 // lookup performs a DNS lookup for the given URL.
-// It returns nil if the lookup succeeds, or an error otherwise.
 func lookup(url string) error {
 	_, err := net.LookupIP(url)
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
 }
 
-// fetchPodRunningTime fetches the running time of the given pod.
-// It retries 3 times with 1 second intervals between retries.
-// It returns the running time of the pod, or an error if the pod is not found or if the running time cannot be fetched.
-func fetchPodRunningTime(client kubernetes.Interface, podName string, namespace string) (time.Time, error) {
-	trials := 0
-	for trials < 3 {
-		readyTimestamp, err := getPodRunningTimeFromClient(client, podName, namespace)
-		if err == nil {
-			return readyTimestamp, nil
-		}
-		klog.Warningf("Failed at obtaining pod running time for pod %s, reason: %v", podName, err)
-		trials++
-		time.Sleep(1 * time.Second)
-	}
-	return getPodRunningTimeFromClient(client, podName, namespace)
-}
-
-// getPodRunningTimeFromClient fetches the running time of the given pod.
-// It returns the running time of the pod, or an error if the pod is not found or if the running time cannot be fetched.
-func getPodRunningTimeFromClient(client kubernetes.Interface, podName string, namespace string) (time.Time, error) {
-	options := metav1.GetOptions{ResourceVersion: "0"}
-	pod, err := client.CoreV1().Pods(namespace).Get(context.TODO(), podName, options)
-	if err != nil {
-		return time.Now(), err
-	}
-
+func getPodReadyTransitionTime(pod *v1.Pod) (time.Time, bool) {
 	for _, condition := range pod.Status.Conditions {
-		if condition.Type == "Ready" && condition.Status == "True" {
-			readyTimestamp := condition.LastTransitionTime.Time
-			return readyTimestamp, nil
+		if condition.Type == v1.PodReady && condition.Status == v1.ConditionTrue {
+			return condition.LastTransitionTime.Time, true
 		}
 	}
-	return time.Now(), errors.New("Ready status wasn't found")
+	return time.Time{}, false
 }

--- a/util-images/probes/pkg/dnspropagation/probe_test.go
+++ b/util-images/probes/pkg/dnspropagation/probe_test.go
@@ -1,0 +1,275 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dnspropagation
+
+import (
+	"errors"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+func TestGetPodReadyTransitionTime(t *testing.T) {
+	now := metav1.Now()
+
+	testCases := []struct {
+		name       string
+		pod        *v1.Pod
+		wantTime   time.Time
+		wantIsRead bool
+	}{
+		{
+			name: "pod with no conditions",
+			pod: &v1.Pod{
+				Status: v1.PodStatus{},
+			},
+			wantTime:   time.Time{},
+			wantIsRead: false,
+		},
+		{
+			name: "pod with PodReady = False",
+			pod: &v1.Pod{
+				Status: v1.PodStatus{
+					Conditions: []v1.PodCondition{
+						{
+							Type:               v1.PodReady,
+							Status:             v1.ConditionFalse,
+							LastTransitionTime: now,
+						},
+					},
+				},
+			},
+			wantTime:   time.Time{},
+			wantIsRead: false,
+		},
+		{
+			name: "pod with unrelated condition = True",
+			pod: &v1.Pod{
+				Status: v1.PodStatus{
+					Conditions: []v1.PodCondition{
+						{
+							Type:               v1.PodScheduled,
+							Status:             v1.ConditionTrue,
+							LastTransitionTime: now,
+						},
+					},
+				},
+			},
+			wantTime:   time.Time{},
+			wantIsRead: false,
+		},
+		{
+			name: "pod with PodReady = True",
+			pod: &v1.Pod{
+				Status: v1.PodStatus{
+					Conditions: []v1.PodCondition{
+						{
+							Type:               v1.PodReady,
+							Status:             v1.ConditionTrue,
+							LastTransitionTime: now,
+						},
+					},
+				},
+			},
+			wantTime:   now.Time,
+			wantIsRead: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotTime, gotIsReady := getPodReadyTransitionTime(tc.pod)
+			if gotIsReady != tc.wantIsRead {
+				t.Errorf("getPodReadyTransitionTime() gotIsReady = %v, want %v", gotIsReady, tc.wantIsRead)
+			}
+			if !gotTime.Equal(tc.wantTime) {
+				t.Errorf("getPodReadyTransitionTime() gotTime = %v, want %v", gotTime, tc.wantTime)
+			}
+		})
+	}
+}
+
+func TestSelectSample(t *testing.T) {
+	podTotal := 50
+	sampleTotal := 10
+
+	samples := selectSample(podTotal, sampleTotal)
+	if len(samples) != sampleTotal {
+		t.Fatalf("selectSample() returned %d samples, want %d", len(samples), sampleTotal)
+	}
+
+	seen := make(map[int]bool)
+	for _, idx := range samples {
+		if idx < 0 || idx >= podTotal {
+			t.Errorf("sample index %d out of bounds [0, %d)", idx, podTotal)
+		}
+		if seen[idx] {
+			t.Errorf("duplicate sample index %d selected", idx)
+		}
+		seen[idx] = true
+	}
+}
+
+func TestProbeDNSUntilResolved(t *testing.T) {
+	readyTime := time.Now().Add(-500 * time.Millisecond)
+	var attempts atomic.Int32
+
+	oldLookup := lookupFunc
+	defer func() { lookupFunc = oldLookup }()
+
+	lookupFunc = func(url string) error {
+		if attempts.Add(1) < 3 {
+			return errors.New("NXDOMAIN")
+		}
+		return nil
+	}
+
+	duration := probeDNSUntilResolved("test-pod.test-svc.default.svc.cluster.local", readyTime, 10*time.Millisecond)
+	if duration <= 0 {
+		t.Errorf("probeDNSUntilResolved() returned non-positive duration: %v", duration)
+	}
+
+	if attempts.Load() < 3 {
+		t.Errorf("lookupFunc was called %d times, expected at least 3", attempts.Load())
+	}
+}
+
+func TestTransformPod(t *testing.T) {
+	now := metav1.Now()
+	fullPod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "test-pod-0",
+			Namespace:       "test-ns",
+			Annotations:     map[string]string{"heavy": "annotation"},
+			Labels:          map[string]string{"heavy": "label"},
+			ResourceVersion: "12345",
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name:  "container-1",
+					Image: "heavy-image:v1",
+				},
+			},
+		},
+		Status: v1.PodStatus{
+			Conditions: []v1.PodCondition{
+				{
+					Type:               v1.PodReady,
+					Status:             v1.ConditionTrue,
+					LastTransitionTime: now,
+				},
+			},
+		},
+	}
+
+	transformed, err := transformPod(fullPod)
+	if err != nil {
+		t.Fatalf("transformPod returned error: %v", err)
+	}
+
+	strippedPod, ok := transformed.(*v1.Pod)
+	if !ok {
+		t.Fatalf("transformPod did not return *v1.Pod")
+	}
+
+	if strippedPod.Name != "test-pod-0" || strippedPod.Namespace != "test-ns" {
+		t.Errorf("transformPod did not preserve Name and Namespace")
+	}
+
+	if len(strippedPod.Spec.Containers) != 0 {
+		t.Errorf("transformPod did not strip Spec.Containers")
+	}
+
+	if len(strippedPod.Annotations) != 0 {
+		t.Errorf("transformPod did not strip Annotations")
+	}
+
+	if len(strippedPod.Status.Conditions) != 1 || strippedPod.Status.Conditions[0].Type != v1.PodReady {
+		t.Errorf("transformPod did not preserve Status.Conditions")
+	}
+}
+
+func TestRunProbeWithInformer(t *testing.T) {
+	stsName := "test-sts"
+	svcName := "test-svc"
+	nsName := "test-ns"
+	count := 2
+	samples := 2
+
+	statefulSet = &stsName
+	service = &svcName
+	namespace = &nsName
+	podCount = &count
+	sampleCount = &samples
+	intervalVal := 10 * time.Millisecond
+	interval = &intervalVal
+
+	oldLookup := lookupFunc
+	defer func() { lookupFunc = oldLookup }()
+	lookupFunc = func(url string) error {
+		return nil
+	}
+
+	fakeWatcher := watch.NewFake()
+	client := fake.NewClientset()
+	client.PrependWatchReactor("pods", func(action k8stesting.Action) (handled bool, ret watch.Interface, err error) {
+		return true, fakeWatcher, nil
+	})
+
+	now := metav1.Now()
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		for i := 0; i < count; i++ {
+			pod := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("%s-%d", stsName, i),
+					Namespace: nsName,
+				},
+				Status: v1.PodStatus{
+					Conditions: []v1.PodCondition{
+						{
+							Type:               v1.PodReady,
+							Status:             v1.ConditionTrue,
+							LastTransitionTime: now,
+						},
+					},
+				},
+			}
+			fakeWatcher.Add(pod)
+		}
+	}()
+
+	done := make(chan struct{})
+	go func() {
+		runProbe(client)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("runProbe timed out waiting for informer events and DNS probes to complete")
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

Removes busy polling on pods, aggregates measurement over entire time window instead of last x minutes Prometheus window, increases QPS. Basically support for larger clusters where this currently does not work.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

