### PR TITLE
Add WaitForRunningPodsRestart measurement

### DIFF
--- a/clusterloader2/pkg/measurement/common/wait_for_running_pods_restart.go
+++ b/clusterloader2/pkg/measurement/common/wait_for_running_pods_restart.go
@@ -1,0 +1,461 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"strings"
+	"sync"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+	"k8s.io/perf-tests/clusterloader2/pkg/errors"
+	"k8s.io/perf-tests/clusterloader2/pkg/measurement"
+	measurementutil "k8s.io/perf-tests/clusterloader2/pkg/measurement/util"
+	"k8s.io/perf-tests/clusterloader2/pkg/util"
+)
+
+const (
+	waitForRunningPodsRestartMeasurementName = "WaitForRunningPodsRestart"
+)
+
+func init() {
+	names := []string{
+		waitForRunningPodsRestartMeasurementName,
+		"WaitForPodsRestart",
+		"WaitForRunningPodsResync",
+		"WaitForPodsResync",
+		"WaitForRunningPodsRecovery",
+		"WaitForPodsRecovery",
+	}
+	for _, name := range names {
+		if err := measurement.Register(name, createWaitForRunningPodsRestartMeasurementFactory(name)); err != nil {
+			klog.Fatalf("Cannot register %s: %v", name, err)
+		}
+	}
+}
+
+func createWaitForRunningPodsRestartMeasurementFactory(name string) func() measurement.Measurement {
+	return func() measurement.Measurement {
+		return &waitForRunningPodsRestartMeasurement{
+			callerName: name,
+		}
+	}
+}
+
+type waitForRunningPodsRestartMeasurement struct {
+	lock           sync.Mutex
+	isRunning      bool
+	totalPodsCount int
+	selector       *util.ObjectSelector
+	callerName     string
+}
+
+// Execute supports "start", "gather", and "stop" actions.
+// On "start", all pods matching the given selector are counted and saved.
+// On "gather", the measurement waits until all counted pods (within configurable % difference) are back up and Running.
+func (w *waitForRunningPodsRestartMeasurement) Execute(config *measurement.Config) ([]measurement.Summary, error) {
+	action, err := util.GetString(config.Params, "action")
+	if err != nil {
+		return nil, err
+	}
+
+	switch action {
+	case "start":
+		return nil, w.start(config)
+	case "gather":
+		return nil, w.gather(config)
+	case "stop":
+		w.Dispose()
+		return nil, nil
+	default:
+		return nil, fmt.Errorf("unknown action %v", action)
+	}
+}
+
+func (w *waitForRunningPodsRestartMeasurement) start(config *measurement.Config) error {
+	w.lock.Lock()
+	defer w.lock.Unlock()
+
+	selector := util.NewObjectSelector()
+	if err := selector.Parse(config.Params); err != nil {
+		return err
+	}
+
+	client := config.ClusterFramework.GetClientSets().GetClient()
+	listOptions := metav1.ListOptions{}
+	selector.ApplySelectors(&listOptions)
+	podList, err := client.CoreV1().Pods(selector.Namespace).List(context.TODO(), listOptions)
+	if err != nil {
+		return fmt.Errorf("failed to list pods: %w", err)
+	}
+
+	totalPodsCount := len(podList.Items)
+
+	w.totalPodsCount = totalPodsCount
+	w.selector = selector
+	w.isRunning = true
+
+	klog.V(2).Infof("%s: started, found %d total pods matching selector '%s'",
+		w, totalPodsCount, selector.String())
+	return nil
+}
+
+func (w *waitForRunningPodsRestartMeasurement) gather(config *measurement.Config) error {
+	w.lock.Lock()
+	if !w.isRunning {
+		w.lock.Unlock()
+		return fmt.Errorf("measurement %s has not been started", w)
+	}
+	totalPodsCount := w.totalPodsCount
+	selector := w.selector
+	w.lock.Unlock()
+
+	timeout, err := util.GetDurationOrDefault(config.Params, "timeout", defaultWaitForPodsTimeout)
+	if err != nil {
+		return err
+	}
+	refreshInterval, err := util.GetDurationOrDefault(config.Params, "refreshInterval", defaultWaitForPodsInterval)
+	if err != nil {
+		return err
+	}
+	tolerationTimeout, err := util.GetDurationOrDefault(config.Params, "tolerationTimeout", 0)
+	if err != nil {
+		return err
+	}
+	isFatal, err := util.GetBoolOrDefault(config.Params, "isFatal", defaultIsFatal)
+	if err != nil {
+		return err
+	}
+
+	minDesired, maxDesired, margin, err := calculateDesiredPodRange(config.Params, totalPodsCount)
+	if err != nil {
+		return err
+	}
+
+	klog.V(2).Infof("%s: waiting for %d-%d pods (initially %d, margin %d) with selector '%s' to be running",
+		w, minDesired, maxDesired, totalPodsCount, margin, selector.String())
+
+	ctx, cancel := context.WithTimeout(context.TODO(), timeout)
+	defer cancel()
+
+	podStore, err := measurementutil.NewPodStore(config.ClusterFramework.GetClientSets().GetClient(), selector)
+	if err != nil {
+		return err
+	}
+	defer podStore.Stop()
+
+	err = w.waitForPods(ctx, podStore, minDesired, maxDesired, totalPodsCount, refreshInterval, tolerationTimeout)
+	if err != nil && isFatal {
+		return errors.NewErrCritical(err)
+	}
+	return err
+}
+
+func (w *waitForRunningPodsRestartMeasurement) waitForPods(
+	ctx context.Context,
+	ps measurementutil.PodLister,
+	minDesired, maxDesired, initialCount int,
+	refreshInterval, tolerationTimeout time.Duration,
+) error {
+	var timeout time.Duration
+	if deadline, hasDeadline := ctx.Deadline(); hasDeadline {
+		timeout = time.Until(deadline)
+	}
+	klog.V(2).Infof("%s: %s: starting with timeout: %v, expecting %d-%d running pods (initially %d)",
+		w, ps.String(), timeout, minDesired, maxDesired, initialCount)
+
+	oldPods, err := ps.List()
+	if err != nil {
+		return fmt.Errorf("failed to list pods: %w", err)
+	}
+
+	oldPodsStatus := measurementutil.ComputePodsStartupStatus(oldPods, initialCount, nil)
+	var tolerationCh <-chan time.Time
+	if tolerationTimeout > 0 {
+		timer := time.NewTimer(tolerationTimeout)
+		defer timer.Stop()
+		tolerationCh = timer.C
+	}
+
+	var tolerationExpired bool
+	var tolerationExpiredAt time.Time
+
+	for {
+		select {
+		case <-ctx.Done():
+			latestPods, listErr := ps.List()
+			if listErr == nil {
+				oldPods = latestPods
+				oldPodsStatus = measurementutil.ComputePodsStartupStatus(oldPods, initialCount, nil)
+			}
+			if ctx.Err() == context.DeadlineExceeded {
+				notRunning := getNotRunningPods(oldPods)
+				klog.V(2).Infof("%s: %s: expected %d-%d pods, got %d pods (not running pods: %s)",
+					w, ps.String(), minDesired, maxDesired, len(oldPods), strings.Join(notRunning, ", "))
+				klog.V(2).Infof("%s: %s: pods still not in Running state: %s",
+					w, ps.String(), strings.Join(notRunning, ", "))
+				if minDesired == maxDesired {
+					return fmt.Errorf("got %w while waiting for %d pods to be running in %s - summary of pods : %s, not running pods: %s",
+						ctx.Err(), minDesired, ps.String(), oldPodsStatus.String(), strings.Join(notRunning, ", "))
+				}
+				return fmt.Errorf("got %w while waiting for %d-%d pods to be running in %s - summary of pods : %s, not running pods: %s",
+					ctx.Err(), minDesired, maxDesired, ps.String(), oldPodsStatus.String(), strings.Join(notRunning, ", "))
+			}
+			return ctx.Err()
+
+		case <-tolerationCh:
+			pods, err := ps.List()
+			if err != nil {
+				return fmt.Errorf("failed to list pods: %w", err)
+			}
+			podsStatus := measurementutil.ComputePodsStartupStatus(pods, initialCount, nil)
+			klog.V(2).Infof("%s: %s: toleration timeout expired, pods status: %s", w, ps.String(), podsStatus.String())
+			if isPodsStatusAcceptable(pods, podsStatus, minDesired, maxDesired) {
+				return nil
+			}
+			notRunning := getNotRunningPods(pods)
+			klog.V(2).Infof("%s: %s: toleration timeout expired, pods not in Running state: %s",
+				w, ps.String(), strings.Join(notRunning, ", "))
+			tolerationExpired = true
+			tolerationExpiredAt = time.Now()
+			oldPods = pods
+			oldPodsStatus = podsStatus
+
+		case <-time.After(refreshInterval):
+			pods, err := ps.List()
+			if err != nil {
+				return fmt.Errorf("failed to list pods: %w", err)
+			}
+			podsStatus := measurementutil.ComputePodsStartupStatus(pods, initialCount, nil)
+
+			diff := measurementutil.DiffPods(oldPods, pods)
+			deletedPods := diff.DeletedPods()
+			if len(oldPods) < minDesired && len(deletedPods) > 0 {
+				klog.Warningf("%s: %s: %d pods disappeared: %v", w, ps.String(), len(deletedPods), strings.Join(deletedPods, ", "))
+			}
+			addedPods := diff.AddedPods()
+			if len(oldPods) > maxDesired && len(addedPods) > 0 {
+				klog.Warningf("%s: %s: %d pods appeared: %v", w, ps.String(), len(addedPods), strings.Join(addedPods, ", "))
+			}
+			if podsStatus.String() != oldPodsStatus.String() {
+				klog.V(2).Infof("%s: %s: %s", w, ps.String(), podsStatus.String())
+			}
+			if isPodsStatusAcceptable(pods, podsStatus, minDesired, maxDesired) {
+				if tolerationExpired {
+					delay := time.Since(tolerationExpiredAt)
+					if minDesired == maxDesired {
+						return fmt.Errorf("desired number of %d pods in %s reached after tolerationTimeout (%v), delay after tolerationTimeout was %v",
+							minDesired, ps.String(), tolerationTimeout, delay)
+					}
+					return fmt.Errorf("desired number of %d-%d pods in %s reached after tolerationTimeout (%v), delay after tolerationTimeout was %v",
+						minDesired, maxDesired, ps.String(), tolerationTimeout, delay)
+				}
+				return nil
+			}
+			oldPods = pods
+			oldPodsStatus = podsStatus
+		}
+	}
+}
+
+func isPodsStatusAcceptable(pods []*corev1.Pod, podsStatus measurementutil.PodsStartupStatus, minDesired, maxDesired int) bool {
+	// We wait until all pods are running and ready, and the total running count is in [minDesired, maxDesired].
+	if len(pods) == podsStatus.Running &&
+		podsStatus.Running == podsStatus.RunningUpdated &&
+		podsStatus.RunningUpdated >= minDesired && podsStatus.RunningUpdated <= maxDesired {
+		return true
+	}
+	return false
+}
+
+func getNotRunningPods(pods []*corev1.Pod) []string {
+	var notRunning []string
+	for _, p := range pods {
+		if !isPodRunning(p) {
+			if p.Namespace != "" {
+				notRunning = append(notRunning, fmt.Sprintf("%s/%s", p.Namespace, p.Name))
+			} else {
+				notRunning = append(notRunning, p.Name)
+			}
+		}
+	}
+	return notRunning
+}
+
+func isPodRunning(p *corev1.Pod) bool {
+	if p.DeletionTimestamp != nil {
+		return false
+	}
+	if p.Status.Phase != corev1.PodRunning {
+		return false
+	}
+	for _, c := range p.Status.Conditions {
+		if c.Type == corev1.PodReady && c.Status == corev1.ConditionTrue {
+			return true
+		}
+	}
+	return false
+}
+
+func calculateDesiredPodRange(params map[string]interface{}, initialRunningCount int) (minDesired, maxDesired, margin int, err error) {
+	hasMin := false
+	hasMax := false
+	if minVal, err := util.GetInt(params, "minDesiredPodCount"); err == nil {
+		minDesired = minVal
+		hasMin = true
+	}
+	if maxVal, err := util.GetInt(params, "maxDesiredPodCount"); err == nil {
+		maxDesired = maxVal
+		hasMax = true
+	}
+	if hasMin && hasMax {
+		if minDesired > maxDesired {
+			return 0, 0, 0, fmt.Errorf("minDesiredPodCount (%d) cannot be greater than maxDesiredPodCount (%d)", minDesired, maxDesired)
+		}
+		margin = (maxDesired - minDesired) / 2
+		return minDesired, maxDesired, margin, nil
+	}
+
+	// Check countErrorMargin (absolute pod count margin)
+	countErrorMargin, err := util.GetIntOrDefault(params, "countErrorMargin", 0)
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	if countErrorMargin > 0 {
+		margin = countErrorMargin
+	}
+
+	// Check allowedDifferencePercentage / tolerancePercentage / tolerationPercentage / differencePercentage
+	percentage, err := util.GetFloat64OrDefault(params, "allowedDifferencePercentage", 0.0)
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	if percentage == 0.0 {
+		percentage, err = util.GetFloat64OrDefault(params, "tolerancePercentage", 0.0)
+		if err != nil {
+			return 0, 0, 0, err
+		}
+	}
+	if percentage == 0.0 {
+		percentage, err = util.GetFloat64OrDefault(params, "tolerationPercentage", 0.0)
+		if err != nil {
+			return 0, 0, 0, err
+		}
+	}
+	if percentage == 0.0 {
+		percentage, err = util.GetFloat64OrDefault(params, "differencePercentage", 0.0)
+		if err != nil {
+			return 0, 0, 0, err
+		}
+	}
+	if percentage > 0.0 {
+		percentMargin := int(math.Ceil(float64(initialRunningCount) * percentage / 100.0))
+		if percentMargin > margin {
+			margin = percentMargin
+		}
+	}
+
+	// Check allowedDifferenceRatio / tolerationRatio / toleranceRatio
+	ratio, err := util.GetFloat64OrDefault(params, "allowedDifferenceRatio", 0.0)
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	if ratio == 0.0 {
+		ratio, err = util.GetFloat64OrDefault(params, "tolerationRatio", 0.0)
+		if err != nil {
+			return 0, 0, 0, err
+		}
+	}
+	if ratio == 0.0 {
+		ratio, err = util.GetFloat64OrDefault(params, "toleranceRatio", 0.0)
+		if err != nil {
+			return 0, 0, 0, err
+		}
+	}
+	if ratio > 0.0 {
+		ratioMargin := int(math.Ceil(float64(initialRunningCount) * ratio))
+		if ratioMargin > margin {
+			margin = ratioMargin
+		}
+	}
+
+	// Check general tolerance / toleration float parameter
+	tolerance, err := util.GetFloat64OrDefault(params, "tolerance", 0.0)
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	if tolerance == 0.0 {
+		tolerance, err = util.GetFloat64OrDefault(params, "toleration", 0.0)
+		if err != nil {
+			return 0, 0, 0, err
+		}
+	}
+	if tolerance > 0.0 {
+		var tolMargin int
+		if tolerance <= 1.0 {
+			tolMargin = int(math.Ceil(float64(initialRunningCount) * tolerance))
+		} else {
+			tolMargin = int(math.Ceil(float64(initialRunningCount) * tolerance / 100.0))
+		}
+		if tolMargin > margin {
+			margin = tolMargin
+		}
+	}
+
+	computedMin := initialRunningCount - margin
+	if computedMin < 0 {
+		computedMin = 0
+	}
+	computedMax := initialRunningCount + margin
+
+	if hasMin {
+		minDesired = minDesired
+	} else {
+		minDesired = computedMin
+	}
+
+	if hasMax {
+		maxDesired = maxDesired
+	} else {
+		maxDesired = computedMax
+	}
+
+	if minDesired > maxDesired {
+		return 0, 0, 0, fmt.Errorf("minDesiredPodCount (%d) cannot be greater than maxDesiredPodCount (%d)", minDesired, maxDesired)
+	}
+
+	return minDesired, maxDesired, margin, nil
+}
+
+// Dispose cleans up after the measurement.
+func (w *waitForRunningPodsRestartMeasurement) Dispose() {
+	w.lock.Lock()
+	defer w.lock.Unlock()
+	w.isRunning = false
+	w.totalPodsCount = 0
+	w.selector = nil
+}
+
+// String returns a string representation of the measurement.
+func (w *waitForRunningPodsRestartMeasurement) String() string {
+	return w.callerName
+}

--- a/clusterloader2/pkg/measurement/common/wait_for_running_pods_restart_test.go
+++ b/clusterloader2/pkg/measurement/common/wait_for_running_pods_restart_test.go
@@ -1,0 +1,417 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/perf-tests/clusterloader2/pkg/framework"
+	"k8s.io/perf-tests/clusterloader2/pkg/measurement"
+	measurementutil "k8s.io/perf-tests/clusterloader2/pkg/measurement/util"
+)
+
+func TestCalculateDesiredPodRange(t *testing.T) {
+	testCases := []struct {
+		name                string
+		params              map[string]interface{}
+		initialRunningCount int
+		expectedMin         int
+		expectedMax         int
+		expectedMargin      int
+		expectErr           bool
+	}{
+		{
+			name:                "no difference specified (exact count)",
+			params:              map[string]interface{}{},
+			initialRunningCount: 100,
+			expectedMin:         100,
+			expectedMax:         100,
+			expectedMargin:      0,
+		},
+		{
+			name: "allowedDifferencePercentage 1%",
+			params: map[string]interface{}{
+				"allowedDifferencePercentage": 1.0,
+			},
+			initialRunningCount: 1000,
+			expectedMin:         990,
+			expectedMax:         1010,
+			expectedMargin:      10,
+		},
+		{
+			name: "tolerancePercentage 5%",
+			params: map[string]interface{}{
+				"tolerancePercentage": 5.0,
+			},
+			initialRunningCount: 200,
+			expectedMin:         190,
+			expectedMax:         210,
+			expectedMargin:      10,
+		},
+		{
+			name: "tolerationPercentage 2%",
+			params: map[string]interface{}{
+				"tolerationPercentage": 2.0,
+			},
+			initialRunningCount: 100,
+			expectedMin:         98,
+			expectedMax:         102,
+			expectedMargin:      2,
+		},
+		{
+			name: "allowedDifferenceRatio 0.01 (1%)",
+			params: map[string]interface{}{
+				"allowedDifferenceRatio": 0.01,
+			},
+			initialRunningCount: 100,
+			expectedMin:         99,
+			expectedMax:         101,
+			expectedMargin:      1,
+		},
+		{
+			name: "countErrorMargin 5",
+			params: map[string]interface{}{
+				"countErrorMargin": 5,
+			},
+			initialRunningCount: 50,
+			expectedMin:         45,
+			expectedMax:         55,
+			expectedMargin:      5,
+		},
+		{
+			name: "explicit minDesiredPodCount and maxDesiredPodCount",
+			params: map[string]interface{}{
+				"minDesiredPodCount": 80,
+				"maxDesiredPodCount": 120,
+			},
+			initialRunningCount: 100,
+			expectedMin:         80,
+			expectedMax:         120,
+			expectedMargin:      20,
+		},
+		{
+			name: "invalid range min > max",
+			params: map[string]interface{}{
+				"minDesiredPodCount": 120,
+				"maxDesiredPodCount": 80,
+			},
+			initialRunningCount: 100,
+			expectErr:           true,
+		},
+		{
+			name: "initial count 0 with percentage",
+			params: map[string]interface{}{
+				"allowedDifferencePercentage": 1.0,
+			},
+			initialRunningCount: 0,
+			expectedMin:         0,
+			expectedMax:         0,
+			expectedMargin:      0,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			minDesired, maxDesired, margin, err := calculateDesiredPodRange(tc.params, tc.initialRunningCount)
+			if tc.expectErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if minDesired != tc.expectedMin {
+				t.Errorf("minDesired = %d, want %d", minDesired, tc.expectedMin)
+			}
+			if maxDesired != tc.expectedMax {
+				t.Errorf("maxDesired = %d, want %d", maxDesired, tc.expectedMax)
+			}
+			if margin != tc.expectedMargin {
+				t.Errorf("margin = %d, want %d", margin, tc.expectedMargin)
+			}
+		})
+	}
+}
+
+func createTestRunningPod(name, namespace string, labels map[string]string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    labels,
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			Conditions: []corev1.PodCondition{
+				{
+					Type:   corev1.PodReady,
+					Status: corev1.ConditionTrue,
+				},
+			},
+		},
+	}
+}
+
+func createTestPendingPod(name, namespace string, labels map[string]string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    labels,
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodPending,
+		},
+	}
+}
+
+func createTestTerminatingPod(name, namespace string, labels map[string]string) *corev1.Pod {
+	now := metav1.Now()
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              name,
+			Namespace:         namespace,
+			Labels:            labels,
+			DeletionTimestamp: &now,
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			Conditions: []corev1.PodCondition{
+				{
+					Type:   corev1.PodReady,
+					Status: corev1.ConditionTrue,
+				},
+			},
+		},
+	}
+}
+
+type fakePodLister struct {
+	lock sync.Mutex
+	pods []*corev1.Pod
+}
+
+func (f *fakePodLister) List() ([]*corev1.Pod, error) {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+	return f.pods, nil
+}
+
+func (f *fakePodLister) setPods(pods []*corev1.Pod) {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+	f.pods = pods
+}
+
+func (f *fakePodLister) String() string {
+	return "fakePodStore"
+}
+
+func TestWaitForRunningPodsRestart_Lifecycle(t *testing.T) {
+	objects := []runtime.Object{
+		createTestRunningPod("pod-1", "test-ns", map[string]string{"app": "foo"}),
+		createTestRunningPod("pod-2", "test-ns", map[string]string{"app": "foo"}),
+		createTestPendingPod("pod-3", "test-ns", map[string]string{"app": "foo"}),
+		createTestTerminatingPod("pod-4", "test-ns", map[string]string{"app": "foo"}),
+		createTestRunningPod("pod-other", "test-ns", map[string]string{"app": "bar"}),
+	}
+
+	fakeClient := fake.NewSimpleClientset(objects...)
+	multiClientSet := framework.NewMultiClientSetFromClients(fakeClient)
+	clusterFramework := framework.NewFrameworkFromClients(multiClientSet, nil)
+
+	m := createWaitForRunningPodsRestartMeasurementFactory("WaitForRunningPodsRestart")()
+
+	// 1. Gather before start should error
+	_, err := m.Execute(&measurement.Config{
+		ClusterFramework: clusterFramework,
+		Params: map[string]interface{}{
+			"action": "gather",
+		},
+	})
+	if err == nil {
+		t.Fatalf("expected error when calling gather before start, got nil")
+	}
+
+	// 2. Start should count all pods matching selector
+	_, err = m.Execute(&measurement.Config{
+		ClusterFramework: clusterFramework,
+		Params: map[string]interface{}{
+			"action":        "start",
+			"namespace":     "test-ns",
+			"labelSelector": "app=foo",
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error on start: %v", err)
+	}
+
+	measInstance := m.(*waitForRunningPodsRestartMeasurement)
+	if measInstance.totalPodsCount != 4 {
+		t.Fatalf("expected 4 total pods counted on start, got %d", measInstance.totalPodsCount)
+	}
+
+	// 3. Stop should reset state
+	_, err = m.Execute(&measurement.Config{
+		ClusterFramework: clusterFramework,
+		Params: map[string]interface{}{
+			"action": "stop",
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error on stop: %v", err)
+	}
+	if measInstance.isRunning {
+		t.Fatalf("expected isRunning to be false after stop")
+	}
+
+	// 4. Unknown action should error
+	_, err = m.Execute(&measurement.Config{
+		ClusterFramework: clusterFramework,
+		Params: map[string]interface{}{
+			"action": "invalid",
+		},
+	})
+	if err == nil {
+		t.Fatalf("expected error for invalid action, got nil")
+	}
+}
+
+func TestWaitForRunningPodsRestart_WaitForPodsWithDifference(t *testing.T) {
+	// Initially 100 pods, ±2% difference -> [98, 102]
+	// If cluster has 99 running pods (less by 1%), it should succeed.
+	pods99 := make([]*corev1.Pod, 99)
+	for i := 0; i < 99; i++ {
+		pods99[i] = createTestRunningPod(string(rune('a'+i)), "test-ns", map[string]string{"app": "foo"})
+	}
+
+	lister := &fakePodLister{pods: pods99}
+	w := &waitForRunningPodsRestartMeasurement{
+		callerName: "TestWait",
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	err := w.waitForPods(ctx, lister, 98, 102, 100, 10*time.Millisecond, 0)
+	if err != nil {
+		t.Fatalf("expected success when running pods (99) is within range [98, 102], got: %v", err)
+	}
+}
+
+func TestIsPodsStatusAcceptable(t *testing.T) {
+	podRunning1 := createTestRunningPod("pod-1", "test-ns", nil)
+	podRunning2 := createTestRunningPod("pod-2", "test-ns", nil)
+	podPending := createTestPendingPod("pod-3", "test-ns", nil)
+	podTerminating := createTestTerminatingPod("pod-4", "test-ns", nil)
+
+	// Case 1: 2 pods running, within [1, 3] -> acceptable
+	status2 := measurementutil.ComputePodsStartupStatus([]*corev1.Pod{podRunning1, podRunning2}, 2, nil)
+	if !isPodsStatusAcceptable([]*corev1.Pod{podRunning1, podRunning2}, status2, 1, 3) {
+		t.Errorf("expected status to be acceptable when running pods is within range")
+	}
+
+	// Case 2: 1 pod running, 1 pod pending -> not acceptable
+	statusPending := measurementutil.ComputePodsStartupStatus([]*corev1.Pod{podRunning1, podPending}, 2, nil)
+	if isPodsStatusAcceptable([]*corev1.Pod{podRunning1, podPending}, statusPending, 1, 3) {
+		t.Errorf("expected status to NOT be acceptable when a pod is pending")
+	}
+
+	// Case 3: 0 pods running, min is 1 -> not acceptable
+	status0 := measurementutil.ComputePodsStartupStatus([]*corev1.Pod{}, 0, nil)
+	if isPodsStatusAcceptable([]*corev1.Pod{}, status0, 1, 3) {
+		t.Errorf("expected status to NOT be acceptable when running pods (0) < min (1)")
+	}
+
+	// Case 4: 1 pod running, 1 pod terminating -> not acceptable
+	statusTerminating := measurementutil.ComputePodsStartupStatus([]*corev1.Pod{podRunning1, podTerminating}, 2, nil)
+	if isPodsStatusAcceptable([]*corev1.Pod{podRunning1, podTerminating}, statusTerminating, 1, 3) {
+		t.Errorf("expected status to NOT be acceptable when a pod is terminating")
+	}
+}
+
+func TestGetNotRunningPods(t *testing.T) {
+	pods := []*corev1.Pod{
+		createTestRunningPod("pod-running", "default", nil),
+		createTestPendingPod("pod-pending", "kube-system", nil),
+		createTestTerminatingPod("pod-terminating", "custom-ns", nil),
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pod-not-ready",
+				Namespace: "test-ns",
+			},
+			Status: corev1.PodStatus{
+				Phase: corev1.PodRunning,
+				Conditions: []corev1.PodCondition{
+					{
+						Type:   corev1.PodReady,
+						Status: corev1.ConditionFalse,
+					},
+				},
+			},
+		},
+	}
+
+	notRunning := getNotRunningPods(pods)
+	expected := []string{
+		"kube-system/pod-pending",
+		"custom-ns/pod-terminating",
+		"test-ns/pod-not-ready",
+	}
+
+	if len(notRunning) != len(expected) {
+		t.Fatalf("expected %d not running pods, got %d: %v", len(expected), len(notRunning), notRunning)
+	}
+	for i, exp := range expected {
+		if notRunning[i] != exp {
+			t.Errorf("notRunning[%d] = %s, want %s", i, notRunning[i], exp)
+		}
+	}
+}
+
+func TestWaitForPods_TimeoutListsNotRunningPods(t *testing.T) {
+	pods := []*corev1.Pod{
+		createTestRunningPod("pod-1", "test-ns", nil),
+		createTestPendingPod("pod-2", "test-ns", nil),
+	}
+
+	lister := &fakePodLister{pods: pods}
+	w := &waitForRunningPodsRestartMeasurement{
+		callerName: "TestTimeout",
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	err := w.waitForPods(ctx, lister, 2, 2, 2, 10*time.Millisecond, 0)
+	if err == nil {
+		t.Fatalf("expected timeout error, got nil")
+	}
+	if !strings.Contains(err.Error(), "test-ns/pod-2") {
+		t.Errorf("expected error message to contain not running pod 'test-ns/pod-2', got: %v", err)
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

This measurement is here to track and verify pod recovery during cluster restart cycles. 
1. At the start stage, it measures how many pods are currently Created
2. At the gather stage, it waits until the same amount of pods (+/- tolerance) is Running.
3. On tolerationTimeout, it prints the pods which are currently not running
4. If it times out, the test is marked as failed.

It is built similarily to WaitForPods measurement.
