### PR TITLE
benchmark-list: add informer mode

### DIFF
--- a/clusterloader2/testing/list/clusterrole.yaml
+++ b/clusterloader2/testing/list/clusterrole.yaml
@@ -9,3 +9,4 @@ rules:
   - "*"
   verbs:
   - list
+  - watch

--- a/clusterloader2/testing/list/config.yaml
+++ b/clusterloader2/testing/list/config.yaml
@@ -8,6 +8,10 @@
 {{$listReplicas := DefaultParam .CL2_LIST_BENCHMARK_PODS 1}}
 {{$contentType := DefaultParam .CL2_LIST_BENCHMARK_CONTENT_TYPE "json"}}
 
+{{$mode := DefaultParam .CL2_LIST_BENCHMARK_MODE "http"}}
+{{$informerCount := DefaultParam .CL2_LIST_INFORMER_COUNT 1}}
+{{$enableWatchList := DefaultParam .CL2_LIST_ENABLE_WATCHLIST false}}
+
 name: list-benchmark
 namespace:
   number: 1
@@ -58,6 +62,19 @@ steps:
         bytes: {{$configMapBytes}}
         group: {{$configMapGroup}}
 
+{{if eq $mode "informer"}}
+- module:
+    path: modules/list-benchmark.yaml
+    params:
+      namePrefix: "list-configmaps-"
+      replicas: {{$listReplicas}}
+      contentType: {{$contentType}}
+      mode: {{$mode}}
+      resource: configmaps
+      apiVersion: v1
+      count: {{$informerCount}}
+      enableWatchList: {{$enableWatchList}}
+{{else}}
 - module:
     path: modules/list-benchmark.yaml
     params:
@@ -66,6 +83,7 @@ steps:
       uri: /api/v1/configmaps?resourceVersion=0
       namespaced: false
       contentType: {{$contentType}}
+{{end}}
 - module:
     path: /modules/measurements.yaml
     params:
@@ -114,6 +132,19 @@ steps:
       templateFillMap:
         group: {{$podGroup}}
 
+{{if eq $mode "informer"}}
+- module:
+    path: modules/list-benchmark.yaml
+    params:
+      namePrefix: "list-pods-"
+      replicas: {{$listReplicas}}
+      contentType: {{$contentType}}
+      mode: {{$mode}}
+      resource: pods
+      apiVersion: v1
+      count: {{$informerCount}}
+      enableWatchList: {{$enableWatchList}}
+{{else}}
 - module:
     path: modules/list-benchmark.yaml
     params:
@@ -122,6 +153,7 @@ steps:
       uri: /api/v1/pods?resourceVersion=0
       namespaced: false
       contentType: {{$contentType}}
+{{end}}
 - module:
     path: /modules/measurements.yaml
     params:

--- a/clusterloader2/testing/list/deployment.yaml
+++ b/clusterloader2/testing/list/deployment.yaml
@@ -1,7 +1,14 @@
 # The source of the image is at https://github.com/kubernetes/perf-tests/tree/master/util-images/request-benchmark
-{{$image := DefaultParam .CL2_BENCHMARK_IMAGE "gcr.io/k8s-staging-perf-tests/perf-tests-util/request-benchmark:v0.0.10"}}
 {{$cpu := DefaultParam .cpu "1250m"}}
+{{$mode := DefaultParam .Mode "http"}}
+{{$image := DefaultParam .CL2_BENCHMARK_IMAGE "gcr.io/k8s-staging-perf-tests/perf-tests-util/request-benchmark:v0.0.17"}}
+# http mode streams responses to io.Discard, so 32Mi is plenty. informer mode
+# caches the full result set (~1GB per informer for 10k x 100KB configmaps),
+# so it needs a much larger limit that scales with .Count.
 {{$memory := DefaultParam .memory "32Mi"}}
+{{if eq $mode "informer"}}
+{{$memory = DefaultParam .memory "4Gi"}}
+{{end}}
 
 apiVersion: apps/v1
 kind: Deployment
@@ -25,9 +32,19 @@ spec:
         image: {{$image}}
         imagePullPolicy: Always
         args:
+{{if eq $mode "informer"}}
+        - informer
+        - --resource={{.Resource}}
+        - --api-version={{.ApiVersion}}
+        - --count={{.Count}}
+        - --content-type={{.ContentType}}
+        - --enableWatchListFeature={{.EnableWatchList}}
+        - --namespace=
+{{else}}
         - --namespace={{.Namespace}}
         - --uri={{.Uri}}
         - --content-type={{.ContentType}}
+{{end}}
         resources:
           requests:
             cpu: {{$cpu}}

--- a/clusterloader2/testing/list/modules/list-benchmark.yaml
+++ b/clusterloader2/testing/list/modules/list-benchmark.yaml
@@ -2,6 +2,7 @@
 {{$replicas := DefaultParam .replicas 0}}
 {{$uri := DefaultParam .uri "/"}}
 {{$contentType := DefaultParam .contentType "json"}}
+{{$mode := DefaultParam .mode "http"}}
 
 steps:
 - name: Creating WaitForControlledPodsRunning measurement
@@ -27,9 +28,19 @@ steps:
     - basename: {{$namePrefix}}deploy
       objectTemplatePath: deployment.yaml
       templateFillMap:
+{{if eq $mode "informer"}}
+        Replicas: {{$replicas}}
+        ContentType: {{$contentType}}
+        Mode: {{$mode}}
+        Resource: {{DefaultParam .resource "configmaps"}}
+        ApiVersion: {{DefaultParam .apiVersion "v1"}}
+        Count: {{DefaultParam .count 1}}
+        EnableWatchList: {{DefaultParam .enableWatchList false}}
+{{else}}
         Replicas: {{$replicas}}
         Uri: {{$uri}}
         ContentType: {{$contentType}}
+{{end}}
 - name: Waiting for WaitForControlledPodsRunning gather
   measurements:
   - Identifier: WaitForListBenchmarkDeployment


### PR DESCRIPTION
i created the following eval for an agent to make sure the new mode works:

```
to confirm same resource, scope (cluster-wide), verb i ask it to use `apiserver_request_total` and `httplogs`

to confirm same encoding (`proto`) i asked it to checked the pod's (client-side) logs

to confirm the http mode (existing) has not been broken i asked it to rendered the templates
```

**next** i'd like to run a CI job and check the artifacts. 