### PR TITLE
fix missing User-Agent for request-benchmark http mode

### DIFF
--- a/util-images/request-benchmark/Makefile
+++ b/util-images/request-benchmark/Makefile
@@ -1,6 +1,6 @@
 PROJECT ?= k8s-staging-perf-tests
 IMG = gcr.io/$(PROJECT)/perf-tests-util/request-benchmark
-TAG = v0.0.14
+TAG = v0.0.15
 
 all: build push
 

--- a/util-images/request-benchmark/mode_http.go
+++ b/util-images/request-benchmark/mode_http.go
@@ -99,6 +99,9 @@ func runHTTP(args []string) error {
 		return err
 	}
 	config.QPS = float32(*qps)
+	if config.UserAgent == "" {
+		config.UserAgent = rest.DefaultKubernetesUserAgent()
+	}
 	client, err := rest.HTTPClientFor(config)
 	if err != nil {
 		return err


### PR DESCRIPTION
setting the userAgent helps when you want to trace the httplogs produced by the server

before: `Go-http-client/2.0`
after: `request-benchmark/v0.0.0 (darwin/arm64) kubernetes/$Format`