### PR TITLE
Fix metric collection for etcd benchmark

### DIFF
--- a/clusterloader2/testing/etcd/modules/cluster/cluster.yaml
+++ b/clusterloader2/testing/etcd/modules/cluster/cluster.yaml
@@ -6,9 +6,6 @@ apiVersion: operator.etcd.io/v1alpha1
 kind: EtcdCluster
 metadata:
   name: {{.Name}}
-  labels:
-    app: etcd
-    group: etcd-cluster
 spec:
   size: {{$replicas}}
   version: "{{$version}}"

--- a/clusterloader2/testing/etcd/modules/cluster/podmonitor.yaml
+++ b/clusterloader2/testing/etcd/modules/cluster/podmonitor.yaml
@@ -9,7 +9,6 @@ spec:
   selector:
     matchLabels:
       app: {{.ClusterName}}
-      group: etcd-cluster
   namespaceSelector:
     any: true
   podMetricsEndpoints:

--- a/clusterloader2/testing/etcd/modules/measurements.yaml
+++ b/clusterloader2/testing/etcd/modules/measurements.yaml
@@ -15,10 +15,13 @@ steps:
       queries:
       - name: TotalPutRequests
         query: sum(increase(grpc_server_handled_total{job="etcd-cluster-0",grpc_method="Put"}[%v]))
+        requireSamples: true
       - name: TotalWALFsyncs
         query: sum(increase(etcd_disk_wal_fsync_duration_seconds_count{job="etcd-cluster-0"}[%v]))
+        requireSamples: true
       - name: TotalBackendCommits
         query: sum(increase(etcd_disk_backend_commit_duration_seconds_count{job="etcd-cluster-0"}[%v]))
+        requireSamples: true
 
   - Identifier: EtcdWriteThroughput
     Method: GenericPrometheusQuery
@@ -30,8 +33,10 @@ steps:
       queries:
       - name: PutThroughput
         query: sum(rate(grpc_server_handled_total{job="etcd-cluster-0",grpc_method="Put"}[%v]))
+        requireSamples: true
       - name: BackendCommitRate
         query: sum(rate(etcd_disk_backend_commit_duration_seconds_count{job="etcd-cluster-0"}[%v]))
+        requireSamples: true
 
   - Identifier: EtcdWalFsyncDuration
     Method: GenericPrometheusQuery
@@ -43,10 +48,13 @@ steps:
       queries:
       - name: Perc99
         query: histogram_quantile(0.99, sum(rate(etcd_disk_wal_fsync_duration_seconds_bucket{job="etcd-cluster-0"}[%v])) by (le))
+        requireSamples: true
       - name: Perc90
         query: histogram_quantile(0.90, sum(rate(etcd_disk_wal_fsync_duration_seconds_bucket{job="etcd-cluster-0"}[%v])) by (le))
+        requireSamples: true
       - name: Perc50
         query: histogram_quantile(0.50, sum(rate(etcd_disk_wal_fsync_duration_seconds_bucket{job="etcd-cluster-0"}[%v])) by (le))
+        requireSamples: true
 
   - Identifier: EtcdBackendCommitDuration
     Method: GenericPrometheusQuery
@@ -58,8 +66,11 @@ steps:
       queries:
       - name: Perc99
         query: histogram_quantile(0.99, sum(rate(etcd_disk_backend_commit_duration_seconds_bucket{job="etcd-cluster-0"}[%v])) by (le))
+        requireSamples: true
       - name: Perc90
         query: histogram_quantile(0.90, sum(rate(etcd_disk_backend_commit_duration_seconds_bucket{job="etcd-cluster-0"}[%v])) by (le))
+        requireSamples: true
       - name: Perc50
         query: histogram_quantile(0.50, sum(rate(etcd_disk_backend_commit_duration_seconds_bucket{job="etcd-cluster-0"}[%v])) by (le))
+        requireSamples: true
 

--- a/clusterloader2/testing/etcd/modules/writer/deployment.yaml
+++ b/clusterloader2/testing/etcd/modules/writer/deployment.yaml
@@ -1,4 +1,4 @@
-{{$image := DefaultParam .CL2_BENCHMARK_IMAGE "gcr.io/k8s-staging-perf-tests/perf-tests-util/request-benchmark:v0.0.16"}}
+{{$image := DefaultParam .CL2_BENCHMARK_IMAGE "gcr.io/k8s-staging-perf-tests/perf-tests-util/request-benchmark:v0.0.17"}}
 {{$imagePullPolicy := DefaultParam .CL2_IMAGE_PULL_POLICY "IfNotPresent"}}
 {{$endpoints := DefaultParam .Endpoints "http://etcd-cluster-0:2379"}}
 {{$qps := DefaultParam .Qps 100}}


### PR DESCRIPTION
/kind bug

From first couple of runs https://testgrid.k8s.io/sig-scalability-benchmarks#gce-benchmark-etcd-write-throughput I found that the metrics are not collected because fumbled when rewriting query. Labels on EtcdCluster object doesn't mean label on pods.

/cc @p0lyn0mial @AwesomePatrol 