### PR TITLE
Don't resume watch from last revision, just the freshes and report errors from watch channel

### DIFF
--- a/clusterloader2/testing/write-throughput/modules/watch/deployment.yaml
+++ b/clusterloader2/testing/write-throughput/modules/watch/deployment.yaml
@@ -1,4 +1,4 @@
-{{$image := DefaultParam .CL2_BENCHMARK_IMAGE "gcr.io/k8s-staging-perf-tests/perf-tests-util/request-benchmark:latest"}}
+{{$image := DefaultParam .CL2_BENCHMARK_IMAGE "gcr.io/k8s-staging-perf-tests/perf-tests-util/request-benchmark:v0.0.18"}}
 {{$imagePullPolicy := DefaultParam .CL2_IMAGE_PULL_POLICY "IfNotPresent"}}
 {{$cpu := DefaultParam .cpu "200m"}}
 {{$memory := DefaultParam .memory "100Mi"}}

--- a/clusterloader2/testing/write-throughput/modules/writer/deployment.yaml
+++ b/clusterloader2/testing/write-throughput/modules/writer/deployment.yaml
@@ -1,4 +1,4 @@
-{{$image := DefaultParam .CL2_BENCHMARK_IMAGE "gcr.io/k8s-staging-perf-tests/perf-tests-util/request-benchmark:latest"}}
+{{$image := DefaultParam .CL2_BENCHMARK_IMAGE "gcr.io/k8s-staging-perf-tests/perf-tests-util/request-benchmark:v0.0.18"}}
 {{$imagePullPolicy := DefaultParam .CL2_IMAGE_PULL_POLICY "IfNotPresent"}}
 {{$cpu := DefaultParam .cpu "200m"}}
 {{$memory := DefaultParam .memory "100Mi"}}

--- a/util-images/request-benchmark/Makefile
+++ b/util-images/request-benchmark/Makefile
@@ -1,6 +1,6 @@
 PROJECT ?= k8s-staging-perf-tests
 IMG = gcr.io/$(PROJECT)/perf-tests-util/request-benchmark
-TAG = v0.0.17
+TAG = v0.0.18
 
 all: build push
 

--- a/util-images/request-benchmark/mode_watch.go
+++ b/util-images/request-benchmark/mode_watch.go
@@ -22,7 +22,9 @@ import (
 	"fmt"
 	"time"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog/v2"
@@ -91,8 +93,14 @@ func runWatch(args []string) error {
 			continue
 		}
 		for event := range w.ResultChan() {
-			if meta, ok := event.Object.(metav1.Object); ok {
-				opts.ResourceVersion = meta.GetResourceVersion()
+			switch event.Type {
+			case watch.Added, watch.Modified, watch.Deleted, watch.Bookmark:
+			case watch.Error:
+				err := apierrors.FromObject(event.Object)
+				klog.Errorf("Watch failed: %v. Retrying in 1s...", err)
+				time.Sleep(1 * time.Second)
+			default:
+				panic(fmt.Sprintf("unexpected watch event type %q: %#v", event.Type, event))
 			}
 		}
 		w.Stop()


### PR DESCRIPTION
/kind bug

When pushing write throughput I noticed that it gets behind enough in RV that it cannot establish watch anymore, but doesn't report error.

/cc @p0lyn0mial 