### PR TITLE
clusterloader2: paginate pod list in ContainerResourceGatherer to avoid apiserver request timeout on large clusters

### DIFF
--- a/clusterloader2/pkg/measurement/util/gatherers/container_resource_gatherer.go
+++ b/clusterloader2/pkg/measurement/util/gatherers/container_resource_gatherer.go
@@ -26,8 +26,10 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/pager"
 	"k8s.io/klog/v2"
 	"k8s.io/perf-tests/clusterloader2/pkg/measurement/util"
 	"k8s.io/perf-tests/clusterloader2/pkg/provider"
@@ -43,6 +45,12 @@ const (
 	// MasterAndNonDaemons - all containers on Master nodes and non-daemons on other nodes.
 	MasterAndNonDaemons NodesSet = 1
 )
+
+// gathererPodListPageSize bounds the size of each pod LIST page issued at
+// gatherer startup. On large clusters a single unpaginated pod list can be
+// hundreds of MB and exceed the apiserver --request-timeout while being
+// serialized, resetting the connection. Tunable if needed.
+const gathererPodListPageSize = 2000
 
 // ResourceUsageSummary represents summary of resource usage per container.
 type ResourceUsageSummary map[string][]util.SingleContainerSummary
@@ -103,13 +111,7 @@ func NewResourceUsageGatherer(c clientset.Interface, host string, port int, prov
 			provider:                    provider,
 		})
 	} else {
-		listOptions := metav1.ListOptions{ResourceVersion: "0"}
-		pods, err := c.CoreV1().Pods(namespace).List(context.TODO(), listOptions)
-		if err != nil {
-			return nil, fmt.Errorf("listing pods error: %v", err)
-		}
-
-		nodeList, err := c.CoreV1().Nodes().List(context.TODO(), listOptions)
+		nodeList, err := c.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{ResourceVersion: "0"})
 		if err != nil {
 			return nil, fmt.Errorf("listing nodes error: %v", err)
 		}
@@ -122,9 +124,18 @@ func NewResourceUsageGatherer(c clientset.Interface, host string, port int, prov
 		}
 
 		nodesToConsider := make(map[string]bool)
-		for _, pod := range pods.Items {
-			if (options.Nodes == MasterAndNonDaemons) && !masterNodes.Has(pod.Spec.NodeName) && isDaemonPod(&pod) {
-				continue
+		// List pods in pages rather than in a single call.
+		podListPager := pager.New(func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
+			return c.CoreV1().Pods(namespace).List(ctx, opts)
+		})
+		podListPager.PageSize = gathererPodListPageSize
+		if err := podListPager.EachListItem(context.TODO(), metav1.ListOptions{}, func(obj runtime.Object) error {
+			pod, ok := obj.(*corev1.Pod)
+			if !ok {
+				return fmt.Errorf("unexpected object type %T", obj)
+			}
+			if (options.Nodes == MasterAndNonDaemons) && !masterNodes.Has(pod.Spec.NodeName) && isDaemonPod(pod) {
+				return nil
 			}
 			for _, container := range pod.Status.InitContainerStatuses {
 				g.containerIDs = append(g.containerIDs, container.Name)
@@ -135,6 +146,9 @@ func NewResourceUsageGatherer(c clientset.Interface, host string, port int, prov
 			if options.Nodes == MasterAndNonDaemons {
 				nodesToConsider[pod.Spec.NodeName] = true
 			}
+			return nil
+		}); err != nil {
+			return nil, fmt.Errorf("listing pods error: %v", err)
 		}
 
 		for _, node := range nodeList.Items {


### PR DESCRIPTION
## What this fixes

On large clusters, `ResourceUsageSummary` fails at startup with:

```
action start failed for ResourceUsageSummary measurement: listing pods error:
stream error when reading response body, may be caused by closed connection.
Please retry. Original error: stream error: stream ID 3; INTERNAL_ERROR; received from peer
```

`NewResourceUsageGatherer` lists **all pods in one non-paginated call** (`ResourceVersion: "0"`, no `Limit`). On a 5000-node cluster the `kube-system` list alone (a DaemonSet pod per node — CNI, kube-proxy, etc.) is **~110 MB**. Serializing/writing that single response exceeds the apiserver's `--request-timeout` (default 60s); the handler times out mid-write and resets the HTTP/2 stream, surfaced to the client as `INTERNAL_ERROR`.

Apiserver-side trace from an affected run (LIST started `01:48:52`, killed at exactly 60s):

```
Trace "List" namespace:kube-system resource:pods protocol:HTTP/2.0 user-agent:clusterloader ... verb:LIST
  ---"Write call failed" size:110681138, err:http: Handler timeout 60051ms
  [1m0.269109688s] END
apiserver was unable to write a JSON response: http: Handler timeout
```

Note `size:110681138` (~110 MB) / total time `60269ms`. It is intermittent because the request sits right at the 60s boundary.

## Fix

List pods in pages via `client-go/tools/pager` so each response is bounded and completes well under the request timeout. A `resourceVersion=0` (watch-cache) read ignores `Limit`, so the pager performs a chunked consistent read instead; this is a one-time gatherer-init call, so the extra cost is negligible.

`--request-timeout` (not `--min-request-timeout`, which is watch-only) is the governing limit; a client-side retry doesn't help since a re-listed 110 MB response times out again — pagination is the correct fix. Only the pods list is paginated (the demonstrated culprit); the nodes list is left as-is and could be paginated as a follow-up.

## Testing

- `go build ./...` and `go vet` on the gatherers package.
- Ran the `load` config on a 5000-node cluster; `ResourceUsageSummary` start/gather now succeed (previously failed at startup intermittently).