### PR TITLE
Fix regexp escaping

### DIFF
--- a/verify/verify-flags-underscore.py
+++ b/verify/verify-flags-underscore.py
@@ -121,12 +121,12 @@ def get_flags(rootdir, files):
     excluded_flags = set(f.read().splitlines())
     f.close()
 
-    regexs = [ re.compile('Var[P]?\([^,]*, "([^"]*)"'),
-               re.compile('.String[P]?\("([^"]*)",[^,]+,[^)]+\)'),
-               re.compile('.Int[P]?\("([^"]*)",[^,]+,[^)]+\)'),
-               re.compile('.Bool[P]?\("([^"]*)",[^,]+,[^)]+\)'),
-               re.compile('.Duration[P]?\("([^"]*)",[^,]+,[^)]+\)'),
-               re.compile('.StringSlice[P]?\("([^"]*)",[^,]+,[^)]+\)') ]
+    regexs = [ re.compile(r'Var[P]?\([^,]*, "([^"]*)"'),
+               re.compile(r'\.String[P]?\("([^"]*)",[^,]+,[^)]+\)'),
+               re.compile(r'\.Int[P]?\("([^"]*)",[^,]+,[^)]+\)'),
+               re.compile(r'\.Bool[P]?\("([^"]*)",[^,]+,[^)]+\)'),
+               re.compile(r'\.Duration[P]?\("([^"]*)",[^,]+,[^)]+\)'),
+               re.compile(r'\.StringSlice[P]?\("([^"]*)",[^,]+,[^)]+\)') ]
 
     flags = set()
     new_excluded_flags = set()
@@ -166,7 +166,7 @@ def flags_to_re(flags):
         # turn all flag names into regexs which will find both types
         newre = dashRE.sub('[-_]', flag)
         # only match if there is not a leading or trailing alphanumeric character
-        flagREs.append("[^\w${]" + newre + "[^\w]")
+        flagREs.append(r"[^\w${]" + newre + r"[^\w]")
     # turn that list of regex strings into a single large RE
     flagRE = "|".join(flagREs)
     flagRE = re.compile(flagRE)


### PR DESCRIPTION
Noticed ./verify/verify-flags-underscopre.py failing on PRs with `/home/prow/go/src/k8s.io/perf-tests/verify/verify-flags-underscore.py:124: SyntaxWarning: "\(" is an invalid escape sequence. Such sequences will not work in the future. Did you mean "\\("? A raw string is also an option.`

From https://github.com/kubernetes/perf-tests/pull/4361 failure on https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/perf-tests/4361/pull-perf-tests-verify-all-python/2097950245005561856

/kind flake

/cc @p0lyn0mial 

